### PR TITLE
Reformat levenshtein_print() to avoid Syntax Error

### DIFF
--- a/PACK/rulegen.py
+++ b/PACK/rulegen.py
@@ -227,15 +227,13 @@ class RuleGen:
 
     def levenshtein_print(self, matrix, word, password):
         """ Print word X password matrix """
-        print
-        "      %s" % "  ".join(list(word))
+        print "      %s" % "  ".join(list(word))
         for i, row in enumerate(matrix):
-            if i == 0: print
-            " ",
-            else:      print
-            password[i - 1],
-            print
-            " ".join("%2d" % col for col in row)
+            if i == 0:
+                print " ",
+            else:
+                print password[i - 1],
+            print " ".join("%2d" % col for col in row)
 
     def generate_levenshtein_rules(self, word, password):
         """ Generates levenshtein rules. Returns a list of lists of levenshtein rules. """


### PR DESCRIPTION
flake8 testing of https://github.com/trustedsec/hate_crack on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./PACK/rulegen.py:235:16: E999 SyntaxError: invalid syntax
            else:      print
               ^
1     E999 SyntaxError: invalid syntax
```