### PR TITLE
fix(notify): align attack_name strings so allowlist matching works

### DIFF
--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -213,6 +213,7 @@ def loopback_attack(ctx: Any) -> None:
             chain,
             empty_wordlist,
             loopback=True,
+            attack_name="Loopback",
         )
 
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1452,6 +1452,7 @@ def hcatQuickDictionary(
     loopback=False,
     use_potfile_path=True,
     potfile_path=None,
+    attack_name="Quick Crack",
 ):
     global hcatProcess
     cmd = [
@@ -1480,7 +1481,7 @@ def hcatQuickDictionary(
     )
     cmd = _add_debug_mode_for_rules(cmd)
     _debug_cmd(cmd)
-    _run_hcat_cmd(cmd, attack_name="Quick Dictionary", hash_file=hcatHashFile)
+    _run_hcat_cmd(cmd, attack_name=attack_name, hash_file=hcatHashFile)
 
 
 # Top Mask Attack
@@ -1642,7 +1643,7 @@ def hcatFingerprint(
 
 
 # Combinator Attack
-def hcatCombination(hcatHashType, hcatHashFile, wordlists=None):
+def hcatCombination(hcatHashType, hcatHashFile, wordlists=None, attack_name="Combinator"):
     global hcatCombinationCount
     global hcatProcess
 
@@ -1689,7 +1690,7 @@ def hcatCombination(hcatHashType, hcatHashFile, wordlists=None):
         _insert_optimized_flag(cmd)
     cmd.extend(shlex.split(hcatTuning))
     _append_potfile_arg(cmd)
-    _run_hcat_cmd(cmd, attack_name="Combination", hash_file=hcatHashFile)
+    _run_hcat_cmd(cmd, attack_name=attack_name, hash_file=hcatHashFile)
 
     hcatCombinationCount = lineCount(hcatHashFile + ".out") - hcatHashCracked
 
@@ -1783,7 +1784,7 @@ def hcatCombinatorX(hcatHashType, hcatHashFile, wordlists, separator=None):
 
 
 # NgramX Attack - n-gram candidates from corpus file piped to hashcat
-def hcatNgramX(hcatHashType, hcatHashFile, corpus, group_size=3):
+def hcatNgramX(hcatHashType, hcatHashFile, corpus, group_size=3, attack_name="N-gram"):
     global hcatNgramXCount
     global hcatProcess
 
@@ -1806,7 +1807,7 @@ def hcatNgramX(hcatHashType, hcatHashFile, corpus, group_size=3):
         assert generator_proc.stdout is not None
         _run_hcat_cmd(
             hashcat_cmd,
-            attack_name="NgramX",
+            attack_name=attack_name,
             hash_file=hcatHashFile,
             stdin=generator_proc.stdout,
             companion_procs=[generator_proc],
@@ -2624,7 +2625,7 @@ def hcatCombipow(hcatHashType, hcatHashFile, wordlist, use_space_sep=True):
 
 
 # PRINCE Attack
-def hcatPrince(hcatHashType, hcatHashFile):
+def hcatPrince(hcatHashType, hcatHashFile, attack_name="PRINCE"):
     global hcatProcess
     prince_rules_dir = os.path.join(hate_path, "princeprocessor", "rules")
     prince_rule = get_rule_path("prince_optimized.rule", fallback_dir=prince_rules_dir)
@@ -2664,7 +2665,7 @@ def hcatPrince(hcatHashType, hcatHashFile):
         prince_proc = subprocess.Popen(prince_cmd, stdin=base, stdout=subprocess.PIPE)
         _run_hcat_cmd(
             hashcat_cmd,
-            attack_name="PRINCE",
+            attack_name=attack_name,
             hash_file=hcatHashFile,
             stdin=prince_proc.stdout,
             companion_procs=[prince_proc],
@@ -2772,7 +2773,7 @@ def hcatPrinceLing(hcatHashType, hcatHashFile):
     original_base = hcatPrinceBaseList
     hcatPrinceBaseList = [cache_path]
     try:
-        hcatPrince(hcatHashType, hcatHashFile)
+        hcatPrince(hcatHashType, hcatHashFile, attack_name="PRINCE-LING")
     finally:
         hcatPrinceBaseList = original_base
 


### PR DESCRIPTION
Fixes #110 

The attack_name passed to _run_hcat_cmd (what _should_fire checks against the allowlist) did not match the string passed to prompt_notify_for_attack (what gets written to config.json).  Since _in_allowlist uses exact comparison, notifications silently no-opped for Quick Crack, Loopback, Combinator, N-gram, and PRINCE-LING.

Fix by adding an attack_name parameter (default = canonical prompt string) to hcatQuickDictionary, hcatCombination, hcatNgramX, and hcatPrince, then passing it through to _run_hcat_cmd.  loopback_attack passes attack_name="Loopback" and hcatPrinceLing passes attack_name="PRINCE-LING" to override their respective defaults.