### PR TITLE
docs: note that worktrees need make submodules before running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,22 @@ uv sync --dev
 HATE_CRACK_SKIP_INIT=1 uv run pytest -v
 ```
 
+`git worktree add` does NOT populate submodules, so a fresh worktree has no
+`hashcat-utils/bin/*.bin` and hate_crack refuses to start (`expander not found`).
+Tests are unaffected because `HATE_CRACK_SKIP_INIT=1` bypasses the binary checks,
+but **running the tool** in a worktree needs the submodules built first:
+
+```bash
+# Initializes all submodules and builds the bundled binaries.
+# Do this instead of hand-building: the target also handles the Apple Silicon
+# princeprocessor rename (src/ppAppleArm64.bin -> princeprocessor/pp64.bin).
+make submodules
+```
+
+Note that `git worktree remove` refuses a worktree containing submodules
+(`working trees containing submodules cannot be moved or removed`) - use
+`git worktree remove --force <path>` once you have built them.
+
 ### Rules
 
 1. **Always create a worktree** before making any file changes: `git worktree add /tmp/hate_crack-<task> -b <branch>`


### PR DESCRIPTION
## Problem

`git worktree add` does not populate submodules. A fresh worktree therefore has no `hashcat-utils/bin/*.bin`, and hate_crack aborts at startup:

```
Error: expander not found at /private/tmp/hate_crack-<task>/hashcat-utils/bin/expander.bin.
```

The existing Worktree Policy in `CLAUDE.md` tells agents to run `uv sync --dev` and `pytest`, both of which succeed — the test suite sets `HATE_CRACK_SKIP_INIT=1`, which bypasses the binary checks entirely. So the gap only surfaces when someone actually *runs* the tool in a worktree.

## Change

Docs only (`CLAUDE.md`). Adds to the Worktree Policy setup section:

- `make submodules` as the required step before running the tool, with a note to prefer the make target over hand-building because it also handles the Apple Silicon princeprocessor rename (`src/ppAppleArm64.bin` -> `princeprocessor/pp64.bin`, which is what `hcatPrinceBin` expects).
- That `git worktree remove` refuses a worktree containing submodules and needs `--force`.

No code changes, so no CHANGELOG entry and no version bump. `docs:` prefix means auto-tag will not cut a release.