### PR TITLE
fix: raise omenMaxCandidates fallback default to 100,000,000

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -31,7 +31,7 @@
   "ollamaMaxSampleLines": 500,
   "ollamaAutoResearch": true,
   "omenTrainingList": "rockyou.txt",
-  "omenMaxCandidates": 50000000,
+  "omenMaxCandidates": 100000000,
   "pcfgRuleset": "DEFAULT",
   "pcfgMaxCandidates": 50000000,
   "pcfgPrinceLingMaxCandidates": 10000000,

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -476,7 +476,7 @@ ollamaMaxSampleLines = int(config_parser.get("ollamaMaxSampleLines", 500))
 ollamaAutoResearch = bool(config_parser.get("ollamaAutoResearch", True))
 
 omenTrainingList = config_parser.get("omenTrainingList", "rockyou.txt")
-omenMaxCandidates = int(config_parser.get("omenMaxCandidates", 1000000))
+omenMaxCandidates = int(config_parser.get("omenMaxCandidates", 100000000))
 pcfgRuleset = config_parser.get("pcfgRuleset", "DEFAULT")
 pcfgMaxCandidates = int(config_parser.get("pcfgMaxCandidates", 50000000))
 pcfgPrinceLingMaxCandidates = int(


### PR DESCRIPTION
## Summary
- Fixes #145 — the in-code fallback default for `omenMaxCandidates` (used when the key is missing from `config.json`) was 1,000,000, letting OMEN finish in ~2s instead of doing meaningful work.
- Raised the fallback in `hate_crack/main.py` and the shipped `config.json.example` value from 50,000,000 to 100,000,000 per the issue's recommendation, so both stay consistent.

## Test plan
- [x] `HATE_CRACK_SKIP_INIT=1 uv run pytest -v -k omen` — 39 passed
- [x] `HATE_CRACK_SKIP_INIT=1 uv run pytest -q` — 1055 passed, 24 skipped, 1 unrelated pre-existing failure (missing `pcfg_cracker` submodule binary in fresh worktree, unrelated to this change)

Closes #145