### PR TITLE
fix: narrow config search path to repo/package dir and ~/.hate_crack

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,8 @@ hate_crack
 The `make install` command creates a bash shim at `~/.local/bin/hate_crack` that runs from the repo directory, so config and assets are always found regardless of your current working directory.
 
 Config is also searched in:
-- Current working directory and parent directory
 - The repo root and package directory
-- `~/hate_crack`, `~/hate-crack`, or `~/.hate_crack`
+- `~/.hate_crack`
 
 **Note:** The `hcatPath` in `config.json` is for the hashcat binary location only (optional if hashcat is in PATH). Hate_crack assets (hashcat-utils, princeprocessor, pcfg_cracker, omen) are loaded from the repository directory and bundled automatically by `make install`.
 
@@ -235,7 +234,7 @@ Most users can use defaults without customization:
 
 **Configuration loading:**
 - Missing config keys are automatically backfilled from `config.json.example` on startup
-- Config is searched in multiple locations: repo root, current working directory, `~/.hate_crack`, `/opt/hate_crack`
+- Config is searched in: repo root, package directory, `~/.hate_crack`
 
 ### Error: merge with ref 'refs/heads/master' but no such ref was fetched
 

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -179,17 +179,11 @@ def _get_hate_path():
 
 
 def _candidate_roots():
-    cwd = os.getcwd()
     home = os.path.expanduser("~")
-    candidates = [
-        cwd,
-        os.path.abspath(os.path.join(cwd, os.pardir)),
-        "/opt/hate_crack",
-        "/usr/local/share/hate_crack",
+    return [
+        _get_hate_path(),
+        os.path.join(home, ".hate_crack"),
     ]
-    for candidate_name in ["hate_crack", "hate-crack", ".hate_crack"]:
-        candidates.append(os.path.join(home, candidate_name))
-    return candidates
 
 
 def _resolve_config_path():

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -166,19 +166,12 @@ def _has_hate_crack_assets(path):
 
 
 def _candidate_roots():
-    cwd = os.getcwd()
     home = os.path.expanduser("~")
-    candidates = [
-        cwd,
-        os.path.abspath(os.path.join(cwd, os.pardir)),
+    return [
         _repo_root,
         _package_path,
-        "/opt/hate_crack",
-        "/usr/local/share/hate_crack",
+        os.path.join(home, ".hate_crack"),
     ]
-    for candidate_name in ["hate_crack", "hate-crack", ".hate_crack"]:
-        candidates.append(os.path.join(home, candidate_name))
-    return candidates
 
 
 def _resolve_config_path():


### PR DESCRIPTION
## Summary
- `_candidate_roots()` in both `main.py` and `api.py` now only checks `_repo_root`/`_package_path` (or `_get_hate_path()` in api.py) and `~/.hate_crack`, dropping CWD, CWD's parent, `/opt/hate_crack`, `/usr/local/share/hate_crack`, and the `~/hate_crack`/`~/hate-crack` variants.
- Updated README.md references to match the new search order.

## Test plan
- [x] `HATE_CRACK_SKIP_INIT=1 uv run pytest -q` — 1058 passed, 24 skipped