### PR TITLE
fix: use sys.executable for PCFG/PRINCE-LING subprocesses

### DIFF
--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -744,8 +744,6 @@ if not SKIP_INIT:
                 "pcfg_cracker not found at " + os.path.join(hate_path, "pcfg_cracker")
             )
             print("PCFG attacks will not be available. Run 'make' to fetch submodules.")
-        elif not shutil.which("python3"):
-            print("python3 not on PATH. PCFG attacks will not be available.")
 
     except Exception as e:
         print(f"Module initialization error: {e}")
@@ -2768,7 +2766,7 @@ def hcatPCFG(hcatHashType, hcatHashFile):
         print(f"pcfg_guesser.py not found at {pcfg_guesser_script}")
         return
     pcfg_cmd = [
-        "python3",
+        sys.executable,
         pcfg_guesser_script,
         "--rule",
         pcfgRuleset,
@@ -2837,7 +2835,7 @@ def hcatPrinceLing(hcatHashType, hcatHashFile):
     if needs_regen:
         print(f"[*] Generating prince_ling wordlist -> {cache_path}")
         cmd = [
-            "python3",
+            sys.executable,
             prince_ling_script,
             "--rule",
             pcfgRuleset,

--- a/tests/test_main_pcfg.py
+++ b/tests/test_main_pcfg.py
@@ -1,5 +1,6 @@
 """Tests for PCFG attack subprocess construction in hate_crack.main."""
 import os
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -46,7 +47,7 @@ class TestHcatPCFG:
         # First Popen call is the pcfg_guesser producer
         producer_args, producer_kwargs = captured_calls[0]
         producer_cmd = producer_args[0]
-        assert "python3" in producer_cmd[0] or producer_cmd[0].endswith("python3")
+        assert producer_cmd[0] == sys.executable
         assert any("pcfg_guesser.py" in part for part in producer_cmd)
         assert "--rule" in producer_cmd
         assert producer_cmd[producer_cmd.index("--rule") + 1] == main_module.pcfgRuleset
@@ -176,3 +177,27 @@ class TestHcatPrinceLing:
             main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
 
         assert main_module.hcatPrinceBaseList == original
+
+    def test_uses_sys_executable(self, main_module, tmp_path, monkeypatch):
+        rules_dir, opt_dir = self._setup_pcfg_dirs(tmp_path, main_module, monkeypatch)
+        cache = opt_dir / "pcfg_prince_ling_DEFAULT.txt"
+        cache.write_text("stale")
+        old = (rules_dir.stat().st_mtime - 100)
+        os.utime(cache, (old, old))
+
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            for i, part in enumerate(cmd):
+                if part == "--output":
+                    Path(cmd[i + 1]).write_text("regenerated")
+            class R:
+                returncode = 0
+            return R()
+
+        with patch("hate_crack.main.subprocess.run", side_effect=fake_run), \
+             patch("hate_crack.main.hcatPrince"):
+            main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
+
+        assert run_calls[0][0] == sys.executable


### PR DESCRIPTION
## Summary
- hcatPCFG and hcatPrinceLing now launch pcfg_guesser.py/prince_ling.py via sys.executable instead of a bare "python3" resolved from PATH.
- Removed the now-redundant shutil.which("python3") presence check.

Fixes #149

## Test plan
- [x] HATE_CRACK_SKIP_INIT=1 uv run pytest -v