### PR TITLE
fix: match pcfgRuleset default casing to on-disk Rules/Default

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -32,7 +32,7 @@
   "ollamaAutoResearch": true,
   "omenTrainingList": "rockyou.txt",
   "omenMaxCandidates": 100000000,
-  "pcfgRuleset": "DEFAULT",
+  "pcfgRuleset": "Default",
   "pcfgMaxCandidates": 50000000,
   "pcfgPrinceLingMaxCandidates": 10000000,
   "check_for_updates": true,

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -463,7 +463,7 @@ ollamaAutoResearch = bool(config_parser.get("ollamaAutoResearch", True))
 
 omenTrainingList = config_parser.get("omenTrainingList", "rockyou.txt")
 omenMaxCandidates = int(config_parser.get("omenMaxCandidates", 100000000))
-pcfgRuleset = config_parser.get("pcfgRuleset", "DEFAULT")
+pcfgRuleset = config_parser.get("pcfgRuleset", "Default")
 pcfgMaxCandidates = int(config_parser.get("pcfgMaxCandidates", 50000000))
 pcfgPrinceLingMaxCandidates = int(
     config_parser.get("pcfgPrinceLingMaxCandidates", 10000000)

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2759,17 +2759,38 @@ def hcatPrince(hcatHashType, hcatHashFile, attack_name="PRINCE"):
             prince_proc.stdout.close()
 
 
+def _resolve_pcfg_ruleset_dir(pcfg_root, ruleset_name):
+    """Resolve ruleset_name against pcfg_root/Rules case-insensitively.
+
+    Older config.json files may have "DEFAULT" backfilled to disk from
+    before the default changed to "Default" (see #148) — match whatever
+    casing exists on disk rather than requiring an exact match.
+    """
+    exact = os.path.join(pcfg_root, "Rules", ruleset_name)
+    if os.path.isdir(exact):
+        return exact
+    rules_root = os.path.join(pcfg_root, "Rules")
+    if os.path.isdir(rules_root):
+        for entry in os.listdir(rules_root):
+            if entry.lower() == ruleset_name.lower():
+                return os.path.join(rules_root, entry)
+    return exact
+
+
 def hcatPCFG(hcatHashType, hcatHashFile):
     """Mode A: pipe pcfg_guesser.py output into hashcat in stdin mode."""
     pcfg_guesser_script = os.path.join(hate_path, "pcfg_cracker", "pcfg_guesser.py")
     if not os.path.isfile(pcfg_guesser_script):
         print(f"pcfg_guesser.py not found at {pcfg_guesser_script}")
         return
+    pcfg_root = os.path.join(hate_path, "pcfg_cracker")
+    resolved_ruleset_dir = _resolve_pcfg_ruleset_dir(pcfg_root, pcfgRuleset)
+    resolved_ruleset_name = os.path.basename(resolved_ruleset_dir)
     pcfg_cmd = [
         sys.executable,
         pcfg_guesser_script,
         "--rule",
-        pcfgRuleset,
+        resolved_ruleset_name,
         "--limit",
         str(pcfgMaxCandidates),
     ]
@@ -2807,7 +2828,7 @@ def hcatPrinceLing(hcatHashType, hcatHashFile):
     global hcatPrinceBaseList
     pcfg_root = os.path.join(hate_path, "pcfg_cracker")
     prince_ling_script = os.path.join(pcfg_root, "prince_ling.py")
-    ruleset_dir = os.path.join(pcfg_root, "Rules", pcfgRuleset)
+    ruleset_dir = _resolve_pcfg_ruleset_dir(pcfg_root, pcfgRuleset)
     if not os.path.isfile(prince_ling_script):
         print(f"prince_ling.py not found at {prince_ling_script}")
         return

--- a/tests/test_main_pcfg.py
+++ b/tests/test_main_pcfg.py
@@ -77,7 +77,7 @@ class TestHcatPrinceLing:
     def _setup_pcfg_dirs(self, tmp_path, main_module, monkeypatch):
         """Lay out fake pcfg_cracker/Rules/<ruleset>/ and optimized_wordlists/."""
         pcfg_root = tmp_path / "pcfg_cracker"
-        rules_dir = pcfg_root / "Rules" / "DEFAULT"
+        rules_dir = pcfg_root / "Rules" / "Default"
         rules_dir.mkdir(parents=True)
         (rules_dir / "config.txt").write_text("dummy")
         # prince_ling script must "exist" for the function to proceed
@@ -91,7 +91,7 @@ class TestHcatPrinceLing:
 
     def test_regenerates_when_cache_stale(self, main_module, tmp_path, monkeypatch):
         rules_dir, opt_dir = self._setup_pcfg_dirs(tmp_path, main_module, monkeypatch)
-        cache = opt_dir / "pcfg_prince_ling_DEFAULT.txt"
+        cache = opt_dir / "pcfg_prince_ling_Default.txt"
         # Cache exists but is older than ruleset
         cache.write_text("stale")
         old = (rules_dir.stat().st_mtime - 100)
@@ -118,7 +118,7 @@ class TestHcatPrinceLing:
         cmd = run_calls[0]
         assert any("prince_ling.py" in p for p in cmd)
         assert "--rule" in cmd
-        assert cmd[cmd.index("--rule") + 1] == "DEFAULT"
+        assert cmd[cmd.index("--rule") + 1] == "Default"
         # Uses --size, NOT --limit
         assert "--size" in cmd
         assert "--limit" not in cmd
@@ -127,7 +127,7 @@ class TestHcatPrinceLing:
 
     def test_skips_regen_when_cache_fresh(self, main_module, tmp_path, monkeypatch):
         rules_dir, opt_dir = self._setup_pcfg_dirs(tmp_path, main_module, monkeypatch)
-        cache = opt_dir / "pcfg_prince_ling_DEFAULT.txt"
+        cache = opt_dir / "pcfg_prince_ling_Default.txt"
         cache.write_text("fresh")
         # Cache is newer than ruleset
         future = rules_dir.stat().st_mtime + 1000
@@ -156,12 +156,12 @@ class TestHcatPrinceLing:
             main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
 
         # No real cache file created; tmp file cleaned up
-        assert not (opt_dir / "pcfg_prince_ling_DEFAULT.txt").exists()
-        assert not (opt_dir / "pcfg_prince_ling_DEFAULT.txt.tmp").exists()
+        assert not (opt_dir / "pcfg_prince_ling_Default.txt").exists()
+        assert not (opt_dir / "pcfg_prince_ling_Default.txt.tmp").exists()
 
     def test_restores_hcatPrinceBaseList_on_exception(self, main_module, tmp_path, monkeypatch):
         rules_dir, opt_dir = self._setup_pcfg_dirs(tmp_path, main_module, monkeypatch)
-        cache = opt_dir / "pcfg_prince_ling_DEFAULT.txt"
+        cache = opt_dir / "pcfg_prince_ling_Default.txt"
         cache.write_text("fresh")
         future = rules_dir.stat().st_mtime + 1000
         os.utime(cache, (future, future))
@@ -180,7 +180,7 @@ class TestHcatPrinceLing:
 
     def test_uses_sys_executable(self, main_module, tmp_path, monkeypatch):
         rules_dir, opt_dir = self._setup_pcfg_dirs(tmp_path, main_module, monkeypatch)
-        cache = opt_dir / "pcfg_prince_ling_DEFAULT.txt"
+        cache = opt_dir / "pcfg_prince_ling_Default.txt"
         cache.write_text("stale")
         old = (rules_dir.stat().st_mtime - 100)
         os.utime(cache, (old, old))

--- a/tests/test_main_pcfg.py
+++ b/tests/test_main_pcfg.py
@@ -201,3 +201,34 @@ class TestHcatPrinceLing:
             main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
 
         assert run_calls[0][0] == sys.executable
+
+    def test_resolves_ruleset_case_insensitively(self, main_module, tmp_path, monkeypatch):
+        rules_dir, opt_dir = self._setup_pcfg_dirs(tmp_path, main_module, monkeypatch)
+        cache = opt_dir / "pcfg_prince_ling_DEFAULT.txt"
+        cache.write_text("stale")
+        old = (rules_dir.stat().st_mtime - 100)
+        os.utime(cache, (old, old))
+
+        # Simulate a config.json predating the default-casing fix, where
+        # "DEFAULT" was backfilled to disk instead of "Default".
+        monkeypatch.setattr(main_module, "pcfgRuleset", "DEFAULT")
+
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            for i, part in enumerate(cmd):
+                if part == "--output":
+                    Path(cmd[i + 1]).write_text("regenerated")
+            class R:
+                returncode = 0
+            return R()
+
+        with patch("hate_crack.main.subprocess.run", side_effect=fake_run), \
+             patch("hate_crack.main.hcatPrince") as mock_prince:
+            main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
+
+        # Should have found the on-disk "Default" dir and proceeded, not
+        # printed "PCFG ruleset not found" and returned early.
+        assert len(run_calls) == 1
+        assert mock_prince.called


### PR DESCRIPTION
## Summary
- pcfgRuleset now defaults to "Default" (matching pcfg_cracker/Rules/Default on disk) instead of "DEFAULT", which only resolved by accident on case-insensitive filesystems.
- Updated config.json.example to match.

Fixes #148

Stacked on #156 — merge that one first.

## Test plan
- [x] HATE_CRACK_SKIP_INIT=1 uv run pytest -v