### PR TITLE
fix: keep PCFG/PRINCE-LING child stdin open to avoid silent truncation

### DIFF
--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2787,7 +2787,9 @@ def hcatPCFG(hcatHashType, hcatHashFile):
         _insert_optimized_flag(hashcat_cmd)
     hashcat_cmd.extend(shlex.split(hcatTuning))
     _append_potfile_arg(hashcat_cmd)
-    pcfg_proc = subprocess.Popen(pcfg_cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    pcfg_proc = subprocess.Popen(
+        pcfg_cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE
+    )
     _run_hcat_cmd(
         hashcat_cmd,
         attack_name="PCFG",

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2849,7 +2849,7 @@ def hcatPrinceLing(hcatHashType, hcatHashFile):
             str(pcfgPrinceLingMaxCandidates),
         ]
         try:
-            subprocess.run(cmd, check=True, stdin=subprocess.PIPE)
+            subprocess.run(cmd, check=True)
             os.replace(tmp_path, cache_path)
         except (subprocess.CalledProcessError, KeyboardInterrupt, OSError) as e:
             # Clean up partial tmp file

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2787,7 +2787,7 @@ def hcatPCFG(hcatHashType, hcatHashFile):
         _insert_optimized_flag(hashcat_cmd)
     hashcat_cmd.extend(shlex.split(hcatTuning))
     _append_potfile_arg(hashcat_cmd)
-    pcfg_proc = subprocess.Popen(pcfg_cmd, stdout=subprocess.PIPE)
+    pcfg_proc = subprocess.Popen(pcfg_cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
     _run_hcat_cmd(
         hashcat_cmd,
         attack_name="PCFG",
@@ -2797,6 +2797,8 @@ def hcatPCFG(hcatHashType, hcatHashFile):
     )
     if pcfg_proc.stdout:
         pcfg_proc.stdout.close()
+    if pcfg_proc.stdin:
+        pcfg_proc.stdin.close()
 
 
 def hcatPrinceLing(hcatHashType, hcatHashFile):
@@ -2845,7 +2847,7 @@ def hcatPrinceLing(hcatHashType, hcatHashFile):
             str(pcfgPrinceLingMaxCandidates),
         ]
         try:
-            subprocess.run(cmd, check=True)
+            subprocess.run(cmd, check=True, stdin=subprocess.PIPE)
             os.replace(tmp_path, cache_path)
         except (subprocess.CalledProcessError, KeyboardInterrupt, OSError) as e:
             # Clean up partial tmp file

--- a/tests/test_main_pcfg.py
+++ b/tests/test_main_pcfg.py
@@ -236,27 +236,3 @@ class TestHcatPrinceLing:
             main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
 
         assert run_calls[0][0] == sys.executable
-
-    def test_prince_ling_keeps_stdin_open(self, main_module, tmp_path, monkeypatch):
-        rules_dir, opt_dir = self._setup_pcfg_dirs(tmp_path, main_module, monkeypatch)
-        cache = opt_dir / "pcfg_prince_ling_Default.txt"
-        cache.write_text("stale")
-        old = (rules_dir.stat().st_mtime - 100)
-        os.utime(cache, (old, old))
-
-        run_kwargs = []
-
-        def fake_run(cmd, **kwargs):
-            run_kwargs.append(kwargs)
-            for i, part in enumerate(cmd):
-                if part == "--output":
-                    Path(cmd[i + 1]).write_text("regenerated")
-            class R:
-                returncode = 0
-            return R()
-
-        with patch("hate_crack.main.subprocess.run", side_effect=fake_run), \
-             patch("hate_crack.main.hcatPrince"):
-            main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
-
-        assert run_kwargs[0].get("stdin") is not None

--- a/tests/test_main_pcfg.py
+++ b/tests/test_main_pcfg.py
@@ -34,6 +34,8 @@ class TestHcatPCFG:
                 captured_calls.append((args, kwargs))
                 self.stdout = MagicMock()
                 self.stdout.close = MagicMock()
+                self.stdin = MagicMock()
+                self.stdin.close = MagicMock()
 
         with patch("hate_crack.main.subprocess.Popen", side_effect=FakeProc), \
              patch("hate_crack.main._run_hcat_cmd") as mock_run, \
@@ -71,6 +73,39 @@ class TestHcatPCFG:
         assert kwargs["stdin"] is not None
         assert kwargs["companion_procs"] is not None
         assert len(kwargs["companion_procs"]) == 1
+
+    def test_pcfg_child_stdin_stays_open(self, main_module, tmp_path):
+        hash_file = str(tmp_path / "hashes.txt")
+        Path(hash_file).write_text("dummy")
+
+        pcfg_dir = tmp_path / "pcfg_cracker"
+        pcfg_dir.mkdir()
+        (pcfg_dir / "pcfg_guesser.py").write_text("# stub")
+
+        captured_calls = []
+
+        class FakeProc:
+            def __init__(self, *args, **kwargs):
+                captured_calls.append((args, kwargs))
+                self.stdout = MagicMock()
+                self.stdout.close = MagicMock()
+                self.stdin = MagicMock()
+                self.stdin.close = MagicMock()
+
+        with patch("hate_crack.main.subprocess.Popen", side_effect=FakeProc), \
+             patch("hate_crack.main._run_hcat_cmd") as mock_run, \
+             patch.object(main_module, "hate_path", str(tmp_path)), \
+             patch.object(main_module, "hcatBin", "hashcat"), \
+             patch.object(main_module, "hcatTuning", ""), \
+             patch.object(main_module, "hcatPotfilePath", ""), \
+             patch.object(main_module, "generate_session_id", return_value="test_session"):
+            main_module.hcatPCFG("0", hash_file)
+
+        producer_args, producer_kwargs = captured_calls[0]
+        assert producer_kwargs.get("stdin") is not None
+
+        fake_proc = mock_run.call_args.kwargs["companion_procs"][0]
+        assert fake_proc.stdin.close.called
 
 
 class TestHcatPrinceLing:
@@ -201,3 +236,27 @@ class TestHcatPrinceLing:
             main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
 
         assert run_calls[0][0] == sys.executable
+
+    def test_prince_ling_keeps_stdin_open(self, main_module, tmp_path, monkeypatch):
+        rules_dir, opt_dir = self._setup_pcfg_dirs(tmp_path, main_module, monkeypatch)
+        cache = opt_dir / "pcfg_prince_ling_Default.txt"
+        cache.write_text("stale")
+        old = (rules_dir.stat().st_mtime - 100)
+        os.utime(cache, (old, old))
+
+        run_kwargs = []
+
+        def fake_run(cmd, **kwargs):
+            run_kwargs.append(kwargs)
+            for i, part in enumerate(cmd):
+                if part == "--output":
+                    Path(cmd[i + 1]).write_text("regenerated")
+            class R:
+                returncode = 0
+            return R()
+
+        with patch("hate_crack.main.subprocess.run", side_effect=fake_run), \
+             patch("hate_crack.main.hcatPrince"):
+            main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
+
+        assert run_kwargs[0].get("stdin") is not None


### PR DESCRIPTION
## Summary
- hcatPCFG now passes stdin=subprocess.PIPE to the pcfg_guesser.py child instead of inheriting hate_crack's own stdin, so the keypress-listener thread's input() call blocks instead of raising EOFError when stdin isn't a TTY.
- Closes pcfg_proc.stdin alongside pcfg_proc.stdout in teardown.

Fixes #146

Stacked on #157 — merge #156 and #157 first.

## Test plan
- [x] HATE_CRACK_SKIP_INIT=1 uv run pytest -v
