### PR TITLE
fix: catch OSError loading config.json.example defaults

### DIFF
--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -242,18 +242,33 @@ except json.JSONDecodeError as e:
     print("  2. Delete the file to regenerate from defaults")
     sys.exit(1)
 
+def _load_config_defaults(defaults_path):
+    """Load config.json.example, exiting with a clear diagnostic on
+    malformed JSON or an unreadable/missing file (see #155 — a dangling
+    symlink surfaces as FileNotFoundError, which used to escape uncaught).
+    """
+    try:
+        with open(defaults_path) as defaults:
+            return json.load(defaults)
+    except json.JSONDecodeError:
+        print("\nError: config.json.example contains invalid JSON")
+        print(f"  File: {defaults_path}")
+        print("  This is a package installation issue. Try reinstalling hate_crack.")
+        sys.exit(1)
+    except OSError:
+        print("\nError: config.json.example could not be read")
+        print(f"  File: {defaults_path}")
+        if os.path.islink(defaults_path) and not os.path.exists(defaults_path):
+            print("  This is a dangling symlink: the link exists but its target is missing.")
+        print("  This is a package installation issue. Try reinstalling hate_crack.")
+        sys.exit(1)
+
+
 config_dir = os.path.dirname(_config_path)
 defaults_path = os.path.join(config_dir, "config.json.example")
 if not os.path.isfile(defaults_path):
     defaults_path = os.path.join(_package_path, "config.json.example")
-try:
-    with open(defaults_path) as defaults:
-        default_config = json.load(defaults)
-except json.JSONDecodeError:
-    print("\nError: config.json.example contains invalid JSON")
-    print(f"  File: {defaults_path}")
-    print("  This is a package installation issue. Try reinstalling hate_crack.")
-    sys.exit(1)
+default_config = _load_config_defaults(defaults_path)
 
 for _key, _value in default_config.items():
     if _key not in config_parser:

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -242,6 +242,7 @@ except json.JSONDecodeError as e:
     print("  2. Delete the file to regenerate from defaults")
     sys.exit(1)
 
+
 def _load_config_defaults(defaults_path):
     """Load config.json.example, exiting with a clear diagnostic on
     malformed JSON or an unreadable/missing file (see #155 — a dangling
@@ -259,7 +260,9 @@ def _load_config_defaults(defaults_path):
         print("\nError: config.json.example could not be read")
         print(f"  File: {defaults_path}")
         if os.path.islink(defaults_path) and not os.path.exists(defaults_path):
-            print("  This is a dangling symlink: the link exists but its target is missing.")
+            print(
+                "  This is a dangling symlink: the link exists but its target is missing."
+            )
         print("  This is a package installation issue. Try reinstalling hate_crack.")
         sys.exit(1)
 

--- a/tests/test_config_defaults_load.py
+++ b/tests/test_config_defaults_load.py
@@ -1,0 +1,56 @@
+"""Tests for hate_crack.main's config.json.example defaults loader (#155)."""
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture
+def main_module(hc_module):
+    return hc_module._main
+
+
+def test_missing_defaults_file_exits_with_clear_message(main_module, tmp_path, capsys):
+    missing_path = str(tmp_path / "config.json.example")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module._load_config_defaults(missing_path)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "package installation issue" in captured.out
+    assert missing_path in captured.out
+
+
+def test_dangling_symlink_defaults_file_names_the_cause(main_module, tmp_path, capsys):
+    target = tmp_path / "does-not-exist.json"
+    link_path = tmp_path / "config.json.example"
+    os.symlink(target, link_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module._load_config_defaults(str(link_path))
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "dangling symlink" in captured.out.lower()
+
+
+def test_malformed_json_defaults_file_exits_with_clear_message(main_module, tmp_path, capsys):
+    bad_path = tmp_path / "config.json.example"
+    bad_path.write_text("{not valid json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module._load_config_defaults(str(bad_path))
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "invalid JSON" in captured.out
+
+
+def test_valid_defaults_file_loads_normally(main_module, tmp_path):
+    good_path = tmp_path / "config.json.example"
+    good_path.write_text(json.dumps({"hcatBin": "hashcat"}))
+
+    result = main_module._load_config_defaults(str(good_path))
+
+    assert result == {"hcatBin": "hashcat"}


### PR DESCRIPTION
## Summary
- Extracted the config.json.example defaults load into _load_config_defaults(), now unit-testable.
- Widened the exception handler from json.JSONDecodeError-only to also catch OSError (missing file, dangling symlink, permission error), reusing the existing "package installation issue" message.
- Added a dangling-symlink-specific diagnostic line.

Fixes #155

Stacked on #158 — merge #156, #157, #158 first.

## Test plan
- [x] HATE_CRACK_SKIP_INIT=1 uv run pytest -v