### PR TITLE
fix: replace brittle config.json.example test guards

### DIFF
--- a/tests/test_config_json_example.py
+++ b/tests/test_config_json_example.py
@@ -5,18 +5,51 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ROOT_EXAMPLE = os.path.join(REPO_ROOT, "config.json.example")
 PACKAGED_EXAMPLE = os.path.join(REPO_ROOT, "hate_crack", "config.json.example")
 
+# Source of truth for config.json.example's key set. Update this set
+# whenever a config key is added or removed — it's what would have caught
+# the #150 drift (10 missing keys, 4 dead passgpt* keys shipped in a prior
+# release) regardless of whether the packaged copy is a symlink, a
+# dereferenced regular file (wheel/sdist builds), or a flattened copy
+# (git-archive tarball, docker COPY of hate_crack/ alone).
+EXPECTED_KEYS = {
+    "hcatPath", "hcatBin", "hcatTuning", "hcatPotfilePath", "hcatDebugLogPath",
+    "hcatWordlists", "hcatOptimizedWordlists", "rules_directory",
+    "hcatDictionaryWordlist", "hcatCombinationWordlist", "hcatCombinator3Wordlist",
+    "hcatCombinatorXWordlist", "hcatHybridlist", "hcatMiddleCombinatorMasks",
+    "hcatMiddleBaseList", "hcatThoroughCombinatorMasks", "hcatThoroughBaseList",
+    "hcatGoodMeasureBaseList", "hcatPrinceBaseList", "pipalPath", "pipal_count",
+    "bandrelmaxruntime", "bandrel_common_basedwords", "hashview_url",
+    "hashview_api_key", "hashmob_api_key", "ollamaModel", "ollamaNumCtx",
+    "ollamaTimeout", "ollamaMaxSampleLines", "ollamaAutoResearch",
+    "omenTrainingList", "omenMaxCandidates", "pcfgRuleset", "pcfgMaxCandidates",
+    "pcfgPrinceLingMaxCandidates", "check_for_updates", "optimizedKernelAttacks",
+    "notify_enabled", "notify_pushover_token", "notify_pushover_user",
+    "notify_per_crack_enabled", "notify_attack_allowlist",
+    "notify_suppress_in_orchestrators", "notify_max_cracks_per_burst",
+    "notify_poll_interval_seconds",
+}
 
-def test_packaged_example_is_symlink_to_root():
-    assert os.path.islink(PACKAGED_EXAMPLE), (
-        "hate_crack/config.json.example must be a symlink to the root "
-        "config.json.example so there is a single source of truth for defaults"
-    )
+
+def test_root_example_has_expected_keys():
+    with open(ROOT_EXAMPLE) as f:
+        root_config = json.load(f)
+    assert set(root_config.keys()) == EXPECTED_KEYS
 
 
-def test_packaged_and_root_examples_have_identical_content():
+def test_packaged_example_matches_root_content():
+    """The invariant that matters is content parity, not symlink-ness.
+
+    In the source tree hate_crack/config.json.example is a symlink to the
+    root copy (same inode) — comparing it to itself here is a no-op, and
+    test_root_example_has_expected_keys is the substantive check for that
+    environment. In any tree where the packaged copy is a distinct file
+    (built wheel/sdist, git-archive tarball, docker COPY of hate_crack/
+    alone) this comparison is the one that would actually catch drift.
+    """
+    if os.path.realpath(PACKAGED_EXAMPLE) == os.path.realpath(ROOT_EXAMPLE):
+        return
     with open(ROOT_EXAMPLE) as f:
         root_config = json.load(f)
     with open(PACKAGED_EXAMPLE) as f:
         packaged_config = json.load(f)
-
     assert packaged_config == root_config


### PR DESCRIPTION
## Summary
- Dropped the islink assertion (fails outside the source tree — setuptools dereferences symlinks in wheels/sdists) and the tautological content-identity check (same inode in the source tree).
- Added an explicit EXPECTED_KEYS set asserted against the root config.json.example, plus a content-parity check that only matters (and is only exercised) when the packaged copy is a distinct file.

Fixes #154

Stacked on #159 — merge #156 through #159 first.

## Test plan
- [x] HATE_CRACK_SKIP_INIT=1 uv run pytest -v