### PR TITLE
fix: share config.json.example defaults between api.py and main.py

### DIFF
--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -491,79 +491,97 @@ class TransmissionSession:
                     self.remove(entry["id"])
 
 
-def get_hcat_wordlists_dir():
+def _load_config_defaults():
+    """Load config.json.example, searching the same candidate order main.py
+    uses: alongside the resolved config.json (if any), then this package's
+    directory. Returns {} if no readable, well-formed example is found —
+    callers fall back to their own hardcoded defaults in that case.
+    """
+    candidates = []
+    config_path = _resolve_config_path()
+    if config_path:
+        candidates.append(os.path.dirname(config_path))
+    candidates.append(os.path.dirname(os.path.realpath(__file__)))
+    for candidate_dir in candidates:
+        example_path = os.path.join(candidate_dir, "config.json.example")
+        if os.path.isfile(example_path):
+            try:
+                with open(example_path) as f:
+                    return json.load(f)
+            except (OSError, json.JSONDecodeError):
+                continue
+    return {}
+
+
+def _load_merged_config():
+    """config.json.example defaults overlaid with config.json, mirroring
+    the merge main.py performs at import time. Fixes #153: api.py's
+    helpers previously read config.json directly and fell back to their
+    own hardcoded (cwd-relative) defaults when a key was absent, silently
+    diverging from main.py whenever a user's config.json predated a key.
+    """
+    merged = _load_config_defaults()
     config_path = _resolve_config_path()
     if config_path:
         try:
             with open(config_path) as f:
-                config = json.load(f)
-            path = config.get("hcatWordlists")
-            if path:
-                path = os.path.expanduser(path)
-                if not os.path.isabs(path):
-                    path = os.path.normpath(os.path.join(_get_hate_path(), path))
-                os.makedirs(path, exist_ok=True)
-                return path
-        except Exception:
+                merged.update(json.load(f))
+        except (OSError, json.JSONDecodeError):
             pass
+    return merged
+
+
+def get_hcat_wordlists_dir():
+    config = _load_merged_config()
+    path = config.get("hcatWordlists")
+    if path:
+        path = os.path.expanduser(path)
+        if not os.path.isabs(path):
+            path = os.path.normpath(os.path.join(_get_hate_path(), path))
+        os.makedirs(path, exist_ok=True)
+        return path
     default = os.path.join(os.getcwd(), "wordlists")
     os.makedirs(default, exist_ok=True)
     return default
 
 
 def get_rules_dir():
-    config_path = _resolve_config_path()
-    if config_path:
-        try:
-            with open(config_path) as f:
-                config = json.load(f)
-            path = config.get("rules_directory")
-            if path:
-                path = os.path.expanduser(path)
-                if not os.path.isabs(path):
-                    path = os.path.normpath(os.path.join(_get_hate_path(), path))
-                os.makedirs(path, exist_ok=True)
-                return path
-        except Exception:
-            pass
+    config = _load_merged_config()
+    path = config.get("rules_directory")
+    if path:
+        path = os.path.expanduser(path)
+        if not os.path.isabs(path):
+            path = os.path.normpath(os.path.join(_get_hate_path(), path))
+        os.makedirs(path, exist_ok=True)
+        return path
     default = os.path.join(os.getcwd(), "rules")
     os.makedirs(default, exist_ok=True)
     return default
 
 
 def get_hcat_tuning_args():
-    config_path = _resolve_config_path()
-    if config_path:
-        try:
-            with open(config_path) as f:
-                config = json.load(f)
-            tuning = config.get("hcatTuning")
-            if tuning:
-                import shlex
+    config = _load_merged_config()
+    tuning = config.get("hcatTuning")
+    if tuning:
+        import shlex
 
-                return shlex.split(tuning)
-        except Exception:
-            pass
+        return shlex.split(tuning)
     return []
 
 
 def get_hcat_potfile_path():
     """Return the resolved potfile path from config, or the default."""
-    config_path = _resolve_config_path()
-    if config_path:
-        try:
-            with open(config_path) as f:
-                config = json.load(f)
-            if "hcatPotfilePath" in config:
-                raw = (config["hcatPotfilePath"] or "").strip()
-                if raw == "":
-                    return ""
-                expanded = os.path.expanduser(raw)
-                if not os.path.isabs(expanded):
-                    expanded = os.path.join(os.path.dirname(config_path), expanded)
-                return expanded
-        except Exception:
-            pass
+    config = _load_merged_config()
+    if "hcatPotfilePath" in config:
+        raw = (config["hcatPotfilePath"] or "").strip()
+        if raw == "":
+            return ""
+        expanded = os.path.expanduser(raw)
+        if not os.path.isabs(expanded):
+            config_path = _resolve_config_path()
+            base_dir = os.path.dirname(config_path) if config_path else _get_hate_path()
+            expanded = os.path.join(base_dir, expanded)
+        return expanded
     return os.path.expanduser("~/.hashcat/hashcat.potfile")
 
 

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -578,9 +578,7 @@ def get_hcat_potfile_path():
             return ""
         expanded = os.path.expanduser(raw)
         if not os.path.isabs(expanded):
-            config_path = _resolve_config_path()
-            base_dir = os.path.dirname(config_path) if config_path else _get_hate_path()
-            expanded = os.path.join(base_dir, expanded)
+            expanded = os.path.join(_get_hate_path(), expanded)
         return expanded
     return os.path.expanduser("~/.hashcat/hashcat.potfile")
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2857,6 +2857,7 @@ def hcatPrinceLing(hcatHashType, hcatHashFile):
     if not os.path.isdir(ruleset_dir):
         print(f"PCFG ruleset not found: {ruleset_dir}")
         return
+    resolved_ruleset_name = os.path.basename(ruleset_dir)
 
     cache_dir = (
         hcatOptimizedWordlists
@@ -2864,7 +2865,9 @@ def hcatPrinceLing(hcatHashType, hcatHashFile):
         else str(hcatOptimizedWordlists)
     )
     os.makedirs(cache_dir, exist_ok=True)
-    cache_path = os.path.join(cache_dir, f"pcfg_prince_ling_{pcfgRuleset}.txt")
+    cache_path = os.path.join(
+        cache_dir, f"pcfg_prince_ling_{resolved_ruleset_name}.txt"
+    )
     tmp_path = cache_path + ".tmp"
 
     # Staleness check: regenerate iff ruleset dir mtime > cache mtime (strict)
@@ -2881,7 +2884,7 @@ def hcatPrinceLing(hcatHashType, hcatHashFile):
             sys.executable,
             prince_ling_script,
             "--rule",
-            pcfgRuleset,
+            resolved_ruleset_name,
             "--output",
             tmp_path,
             "--size",

--- a/tests/test_api_downloads.py
+++ b/tests/test_api_downloads.py
@@ -397,7 +397,8 @@ class TestGetHcatPotfilePath:
         config_data = {"hcatPotfilePath": "hashcat.potfile"}
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps(config_data))
-        with patch("hate_crack.api._resolve_config_path", return_value=str(config_file)):
+        with patch("hate_crack.api._resolve_config_path", return_value=str(config_file)), \
+             patch("hate_crack.api._get_hate_path", return_value=str(tmp_path)):
             result = get_hcat_potfile_path()
         assert result == str(tmp_path / "hashcat.potfile")
 

--- a/tests/test_main_pcfg.py
+++ b/tests/test_main_pcfg.py
@@ -239,7 +239,9 @@ class TestHcatPrinceLing:
 
     def test_resolves_ruleset_case_insensitively(self, main_module, tmp_path, monkeypatch):
         rules_dir, opt_dir = self._setup_pcfg_dirs(tmp_path, main_module, monkeypatch)
-        cache = opt_dir / "pcfg_prince_ling_DEFAULT.txt"
+        # Cache file uses the resolved on-disk basename ("Default"), not the
+        # raw (legacy, all-caps) config value.
+        cache = opt_dir / "pcfg_prince_ling_Default.txt"
         cache.write_text("stale")
         old = (rules_dir.stat().st_mtime - 100)
         os.utime(cache, (old, old))
@@ -247,6 +249,21 @@ class TestHcatPrinceLing:
         # Simulate a config.json predating the default-casing fix, where
         # "DEFAULT" was backfilled to disk instead of "Default".
         monkeypatch.setattr(main_module, "pcfgRuleset", "DEFAULT")
+
+        # Force case-sensitive isdir semantics for this test: on
+        # case-insensitive-but-case-preserving filesystems (e.g. macOS
+        # APFS), os.path.isdir(".../DEFAULT") would spuriously match the
+        # real ".../Default" dir, masking the fallback path this test is
+        # meant to exercise (and which is what actually runs on CI's
+        # case-sensitive Linux filesystem).
+        real_isdir = os.path.isdir
+
+        def case_sensitive_isdir(path):
+            parent, name = os.path.split(path)
+            try:
+                return name in os.listdir(parent) and real_isdir(path)
+            except FileNotFoundError:
+                return False
 
         run_calls = []
 
@@ -260,10 +277,19 @@ class TestHcatPrinceLing:
             return R()
 
         with patch("hate_crack.main.subprocess.run", side_effect=fake_run), \
-             patch("hate_crack.main.hcatPrince") as mock_prince:
+             patch("hate_crack.main.hcatPrince") as mock_prince, \
+             patch("hate_crack.main.os.path.isdir", side_effect=case_sensitive_isdir):
             main_module.hcatPrinceLing("0", str(tmp_path / "hashes.txt"))
 
         # Should have found the on-disk "Default" dir and proceeded, not
         # printed "PCFG ruleset not found" and returned early.
         assert len(run_calls) == 1
+        cmd = run_calls[0]
+        # The subprocess argv and cache filename must both use the resolved
+        # on-disk basename ("Default"), not the raw monkeypatched "DEFAULT"
+        # value, since prince_ling.py does its own case-sensitive Rules/
+        # lookup internally.
+        assert "--rule" in cmd
+        assert cmd[cmd.index("--rule") + 1] == "Default"
+        assert cache.exists()
         assert mock_prince.called

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,8 +116,9 @@ def test_get_hcat_wordlists_dir_no_config_uses_example_default(tmp_path, monkeyp
 
 def test_get_hcat_wordlists_dir_true_fallback_when_no_example(tmp_path, monkeypatch):
     """Last-resort cwd fallback still applies if config.json.example itself
-    can't be found or read (e.g. Task 5's _load_config_defaults would exit
-    at the main.py import site, but api.py's helper degrades gracefully)."""
+    can't be found or read (e.g. hate_crack.main's equivalent loader exits
+    at import time on an unreadable example; api.py's degrades gracefully
+    instead)."""
     monkeypatch.setattr(api, "_resolve_config_path", lambda: None)
     monkeypatch.setattr(api, "_load_config_defaults", lambda: {})
     monkeypatch.chdir(tmp_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import importlib
@@ -98,8 +99,27 @@ def test_get_hcat_wordlists_dir_from_config(tmp_path, monkeypatch):
     assert os.path.isdir(result)
 
 
-def test_get_hcat_wordlists_dir_fallback_cwd(tmp_path, monkeypatch):
+def test_get_hcat_wordlists_dir_no_config_uses_example_default(tmp_path, monkeypatch):
+    """Regression test for #153: with no config.json on disk, api.py must
+    resolve the same default main.py does (config.json.example's
+    hcatWordlists, relative to hate_path) rather than a hardcoded
+    cwd-relative fallback that only main.py knew to avoid.
+    """
     monkeypatch.setattr(api, "_resolve_config_path", lambda: None)
+    monkeypatch.setattr(api, "_get_hate_path", lambda: str(tmp_path))
+
+    result = api.get_hcat_wordlists_dir()
+
+    assert result == str(tmp_path / "wordlists")
+    assert os.path.isdir(result)
+
+
+def test_get_hcat_wordlists_dir_true_fallback_when_no_example(tmp_path, monkeypatch):
+    """Last-resort cwd fallback still applies if config.json.example itself
+    can't be found or read (e.g. Task 5's _load_config_defaults would exit
+    at the main.py import site, but api.py's helper degrades gracefully)."""
+    monkeypatch.setattr(api, "_resolve_config_path", lambda: None)
+    monkeypatch.setattr(api, "_load_config_defaults", lambda: {})
     monkeypatch.chdir(tmp_path)
 
     result = api.get_hcat_wordlists_dir()
@@ -120,14 +140,37 @@ def test_get_rules_dir_from_config(tmp_path, monkeypatch):
     assert os.path.isdir(result)
 
 
-def test_get_rules_dir_fallback_cwd(tmp_path, monkeypatch):
+def test_get_rules_dir_no_config_uses_example_default(tmp_path, monkeypatch):
+    """Regression test for #153: api.py's rules_directory default must match
+    main.py's ('./hashcat/rules' from config.json.example), not the
+    hardcoded '<cwd>/rules' this helper used before the fix.
+    """
     monkeypatch.setattr(api, "_resolve_config_path", lambda: None)
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(api, "_get_hate_path", lambda: str(tmp_path))
 
     result = api.get_rules_dir()
 
-    assert result == str(tmp_path / "rules")
+    assert result == str(tmp_path / "hashcat" / "rules")
     assert os.path.isdir(result)
+
+
+def test_get_hcat_tuning_args_merges_example_default(monkeypatch):
+    monkeypatch.setattr(api, "_resolve_config_path", lambda: None)
+
+    result = api.get_hcat_tuning_args()
+
+    # config.json.example ships hcatTuning: "" — merged default, empty split
+    assert result == []
+
+
+def test_get_hcat_tuning_args_config_overrides_default(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"hcatTuning": "-O -w 3"}))
+    monkeypatch.setattr(api, "_resolve_config_path", lambda: str(config_file))
+
+    result = api.get_hcat_tuning_args()
+
+    assert result == ["-O", "-w", "3"]
 
 
 def test_cleanup_torrent_files_removes_only_torrents(tmp_path):


### PR DESCRIPTION
## Summary
- api.py's four config-reading helpers (get_hcat_wordlists_dir, get_rules_dir, get_hcat_tuning_args, get_hcat_potfile_path) now merge config.json over config.json.example the same way main.py does, instead of reading config.json directly and falling back to divergent hardcoded (cwd-relative) defaults.
- Added _load_config_defaults()/_load_merged_config() to hate_crack/api.py.

Fixes #153

Stacked on #160 — merge #156 through #160 first.

## Test plan
- [x] HATE_CRACK_SKIP_INIT=1 uv run pytest -v