### PR TITLE
fix: resolve pcfg ruleset dir casing correctly on case-insensitive filesystems

### DIFF
--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2783,12 +2783,18 @@ def _resolve_pcfg_ruleset_dir(pcfg_root, ruleset_name):
     Older config.json files may have "DEFAULT" backfilled to disk from
     before the default changed to "Default" (see #148) — match whatever
     casing exists on disk rather than requiring an exact match.
+
+    ``os.path.isdir()`` alone can't be used for the fast path: on
+    case-insensitive filesystems (macOS/Windows default) it returns True
+    for a wrong-cased path too, which would make callers report the
+    casing they asked for instead of what's actually on disk.
     """
     exact = os.path.join(pcfg_root, "Rules", ruleset_name)
-    if os.path.isdir(exact):
-        return exact
     rules_root = os.path.join(pcfg_root, "Rules")
     if os.path.isdir(rules_root):
+        for entry in os.listdir(rules_root):
+            if entry == ruleset_name:
+                return os.path.join(rules_root, entry)
         for entry in os.listdir(rules_root):
             if entry.lower() == ruleset_name.lower():
                 return os.path.join(rules_root, entry)


### PR DESCRIPTION
## Summary
- Root cause of the flaky `test_regenerates_when_cache_stale` failure: `_resolve_pcfg_ruleset_dir`'s "exact match" fast path used `os.path.isdir(exact)`, which returns `True` for a wrong-cased path on case-insensitive filesystems (macOS/Windows default). Whenever `pcfgRuleset` ended up as `"DEFAULT"` (e.g. from an older on-disk config), the function would return that literal casing back to the caller instead of the real directory name (`Default`) — even though the case-insensitive fallback scan existed specifically to prevent this.
- Reordered the resolution: try a real case-sensitive match first, then fall back to the case-insensitive scan, so the resolved `--rule` value always reflects what's actually on disk regardless of the casing passed in.

## Test plan
- [x] `HATE_CRACK_SKIP_INIT=1 uv run pytest -q` — 1084 passed, 24 skipped
- [x] Manually verified `_resolve_pcfg_ruleset_dir(root, "DEFAULT")` and `_resolve_pcfg_ruleset_dir(root, "Default")` both now return the real `Rules/Default` path