### PR TITLE
docs(changelog): cut 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
-## [Unreleased]
+## [2.16.0] - 2026-07-29
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Promotes `[Unreleased]` to `[2.16.0] - 2026-07-29` so the menu reorganization from #166 can be tagged.

#166 landed on `main` with a `refactor(menu):` subject, which `auto-tag`'s bump logic doesn't recognize (`feat`/`fix`/`perf`/breaking only), so it logged `No feat/fix/perf/breaking commits, skipping tag` and the change has been sitting untagged. Tagging manually after this merges — `release.yml` handles human-pushed tags.

**Minor, not patch:** the change removed four main-menu keys (`90`–`93`) that users may have in muscle memory. The entry spells out where each one went.

## Testing

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)