### PR TITLE
feat(attacks): add Spoonman Attack (baseword + rule derivation from a corpus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   passwords, such that the baseword x rule cross product reconstructs the
   corpus. Rules are ordered most-productive-first so the file is truncatable;
   the menu offers the full set, top 99%, or top 95% coverage. Output is cached
-  per corpus under `<hcatOptimizedWordlists>/spoonman/`. Contributed by
-  @Spoonman1091. (#169)
+  per corpus under `<hcatOptimizedWordlists>/spoonman/` and reused until the
+  corpus changes. Contributed by @Spoonman1091. (#169)
 
   The derivation enforces hashcat's limit of 31 functions per rule, falling
   back to emitting the password as its own literal baseword. hashcat drops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Added
+
+- **Spoonman Attack (main menu `22`).** Derives a baseword list and a
+  frequency-sorted hashcat rule file from a corpus of known plaintext
+  passwords, such that the baseword x rule cross product reconstructs the
+  corpus. Rules are ordered most-productive-first so the file is truncatable;
+  the menu offers the full set, top 99%, or top 95% coverage. Output is cached
+  per corpus under `<hcatOptimizedWordlists>/spoonman/`. Contributed by
+  @Spoonman1091. (#169)
+
+  The derivation enforces hashcat's limit of 31 functions per rule, falling
+  back to emitting the password as its own literal baseword. hashcat drops
+  over-long rules *silently* when valid rules share the file, so without the
+  guard a corpus containing such passwords would quietly fall short of the
+  coverage it reported.
+
 ## [2.16.0] - 2026-07-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1004,7 +1004,7 @@ Each password is split into its letters-only lowercased core (the baseword) plus
 
 * Prompts for the corpus, then for how much of the rule file to run: the full set, top 99%, or top 95%
 * Rules are sorted by how many passwords each one rebuilds, so a truncated file keeps the most productive rules — top 95% coverage typically needs a small fraction of the rules
-* Output is cached under `<hcatOptimizedWordlists>/spoonman/<corpus name>/`: `basewords.txt`, `rules.full.rule`, the capped rule files, and `coverage.txt` with per-milestone rule counts
+* Output is cached under `<hcatOptimizedWordlists>/spoonman/<corpus name>/`: `basewords.txt`, `rules.full.rule`, the capped rule files, and `coverage.txt` with per-milestone rule counts. Derivation is skipped on later runs unless the corpus has been modified since
 * Passwords that cannot be expressed as a rule are written verbatim as their own baseword with a `:` no-op, so coverage stays complete. This covers two hashcat limits: rule positions cannot address past index 35, and hashcat rejects any rule with more than 31 functions — silently, when valid rules share the file
 * The derivation self-checks every password by reconstructing it in-process, and reports any failures rather than reporting success
 

--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ All tests use mocked API calls, so they can run without connectivity to a Hashvi
   (19) Combipow Passphrase Attack
   (20) PCFG Attack
   (21) PRINCE-LING Attack
+  (22) Spoonman Attack
 
   (80) Wordlist Tools
   (81) Rule File Tools
@@ -995,6 +996,17 @@ Uses pcfg_cracker's `prince_ling.py` to derive an optimized PRINCE base wordlist
 * Regenerates only when the ruleset directory is newer than the cached wordlist, so retraining a grammar invalidates the cache automatically
 * Generation is written to a temporary file and atomically moved into place; a failed or interrupted run cleans up its partial file and leaves any existing cache intact
 * Base wordlist size is capped by `pcfgPrinceLingMaxCandidates` (default 10,000,000)
+
+#### Spoonman Attack
+Derives a baseword list and a hashcat rule file from a corpus of known plaintext passwords — a previous engagement's cracked output, a leak dump, or any password list — such that the baseword x rule cross product reconstructs the corpus exactly. Contributed as issue #169 by @Spoonman1091.
+
+Each password is split into its letters-only lowercased core (the baseword) plus a rule that rebuilds the original from it, using `l`/`u`/`c` for casing, `T{p}` toggles, `${x}`/`^{x}` for trailing and leading characters, and `i{p}{x}` for interior ones.
+
+* Prompts for the corpus, then for how much of the rule file to run: the full set, top 99%, or top 95%
+* Rules are sorted by how many passwords each one rebuilds, so a truncated file keeps the most productive rules — top 95% coverage typically needs a small fraction of the rules
+* Output is cached under `<hcatOptimizedWordlists>/spoonman/<corpus name>/`: `basewords.txt`, `rules.full.rule`, the capped rule files, and `coverage.txt` with per-milestone rule counts
+* Passwords that cannot be expressed as a rule are written verbatim as their own baseword with a `:` no-op, so coverage stays complete. This covers two hashcat limits: rule positions cannot address past index 35, and hashcat rejects any rule with more than 31 functions — silently, when valid rules share the file
+* The derivation self-checks every password by reconstructing it in-process, and reports any failures rather than reporting success
 
 #### Wordlist Tools (option 80)
 A submenu of wordlist preprocessing utilities using hashcat-utils binaries. All tools read from and write to files on disk. All file and directory path prompts support tab completion.

--- a/hate_crack.py
+++ b/hate_crack.py
@@ -95,6 +95,7 @@ def get_main_menu_options():
         "19": _attacks.combipow_crack,
         "20": _attacks.pcfg_attack,
         "21": _attacks.prince_ling_attack,
+        "22": _attacks.spoonman_attack,
         "80": _attacks.wordlist_tools_submenu,
         "81": _attacks.rule_tools_submenu,
         "82": notifications_submenu,

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -440,6 +440,45 @@ def prince_ling_attack(ctx: Any) -> None:
     ctx.hcatPrinceLing(ctx.hcatHashType, ctx.hcatHashFile)
 
 
+def spoonman_attack(ctx: Any) -> None:
+    """Derive basewords + rules from a password corpus, then crack with them.
+
+    Contributed as issue #169 by @Spoonman1091.
+    """
+    print("\n" + "=" * 60)
+    print("SPOONMAN ATTACK")
+    print("=" * 60)
+    print("Derives a baseword list and hashcat rules from a corpus of known")
+    print("passwords, such as a previous engagement's cracked output. The rule")
+    print("file is sorted most-productive-first, so a capped set gets most of")
+    print("the coverage for a fraction of the keyspace.")
+    print("=" * 60)
+
+    corpus = ctx.select_file_with_autocomplete(
+        "\n[*] Enter path to password corpus", base_dir=ctx.hcatWordlists
+    ).strip()
+    if not corpus:
+        print("[!] No corpus specified.")
+        return
+    if not os.path.isfile(corpus):
+        print(f"[!] Corpus not found: {corpus}")
+        return
+
+    items = [
+        ("1", "Full rule set (reconstructs 100% of the corpus)"),
+        ("2", "Top 99% coverage"),
+        ("3", "Top 95% coverage"),
+        ("99", "Back to Main Menu"),
+    ]
+    choice = interactive_menu(items, title="\nRule set size:")
+    if choice is None or choice == "99":
+        return
+    coverage = {"1": None, "2": 99, "3": 95}.get(choice)
+
+    _notify.prompt_notify_for_attack("Spoonman")
+    ctx.hcatSpoonman(ctx.hcatHashType, ctx.hcatHashFile, corpus, coverage=coverage)
+
+
 def yolo_combination(ctx: Any) -> None:
     _notify.prompt_notify_for_attack("YOLO Combination")
     ctx.hcatYoloCombination(ctx.hcatHashType, ctx.hcatHashFile)

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2940,25 +2940,35 @@ def hcatSpoonman(hcatHashType, hcatHashFile, corpus, coverage=None):
         "spoonman",
         os.path.basename(corpus),
     )
-    print(f"[*] Deriving basewords and rules from {corpus}")
-    try:
-        result = _rulegen.generate(corpus, cache_dir)
-    except (OSError, ValueError) as e:
-        print(f"Rule derivation failed: {e}")
-        return
-
-    rules_path = result["rules"]
+    # Deriving is O(corpus), so reuse a previous run's output unless the corpus
+    # has changed since. Mirrors the staleness check in hcatPrinceLing.
+    basewords_path = os.path.join(cache_dir, "basewords.txt")
+    rules_path = os.path.join(cache_dir, "rules.full.rule")
     if coverage is not None:
-        rules_path = result["capped_rules"].get(coverage, rules_path)
-    print(f"[*] Basewords: {result['basewords']}")
+        rules_path = os.path.join(cache_dir, f"rules.top{coverage}.rule")
+    cached = os.path.isfile(basewords_path) and os.path.isfile(rules_path)
+    if cached and os.path.getmtime(corpus) <= os.path.getmtime(basewords_path):
+        print(f"[*] Reusing derived basewords and rules in {cache_dir}")
+    else:
+        print(f"[*] Deriving basewords and rules from {corpus}")
+        try:
+            result = _rulegen.generate(corpus, cache_dir)
+        except (OSError, ValueError) as e:
+            print(f"Rule derivation failed: {e}")
+            return
+        basewords_path = result["basewords"]
+        rules_path = result["rules"]
+        if coverage is not None:
+            rules_path = result["capped_rules"].get(coverage, rules_path)
+    print(f"[*] Basewords: {basewords_path}")
     print(f"[*] Rules:     {rules_path}")
-    print(f"[*] Coverage:  {result['coverage']}")
+    print(f"[*] Coverage:  {os.path.join(cache_dir, 'coverage.txt')}")
 
     hcatQuickDictionary(
         hcatHashType,
         hcatHashFile,
         f"-r {shlex.quote(rules_path)}",
-        result["basewords"],
+        basewords_path,
         attack_name="Spoonman",
     )
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -76,6 +76,7 @@ from hate_crack import attacks as _attacks  # noqa: E402
 from hate_crack import llm  # noqa: E402
 from hate_crack import noninteractive as _noninteractive  # noqa: E402
 from hate_crack.progress import spinner  # noqa: E402
+from hate_crack import rulegen as _rulegen  # noqa: E402
 from hate_crack.menu import interactive_menu  # noqa: E402
 from hate_crack.username_detect import detect_username_hash_format  # noqa: E402
 
@@ -2920,6 +2921,48 @@ def hcatPrinceLing(hcatHashType, hcatHashFile):
         hcatPrinceBaseList = original_base
 
 
+def hcatSpoonman(hcatHashType, hcatHashFile, corpus, coverage=None):
+    """Spoonman Attack: derive basewords + rules from *corpus*, then crack with them.
+
+    ``coverage`` picks which generated rule file to run: ``None`` for the full
+    set (100% corpus reconstruction), or an int matching one of the capped
+    files (e.g. ``95`` for rules.top95.rule). See hate_crack/rulegen.py and
+    issue #169.
+    """
+    if not os.path.isfile(corpus):
+        print(f"Error: corpus not found: {corpus}")
+        return
+
+    cache_dir = os.path.join(
+        hcatOptimizedWordlists
+        if isinstance(hcatOptimizedWordlists, str)
+        else str(hcatOptimizedWordlists),
+        "spoonman",
+        os.path.basename(corpus),
+    )
+    print(f"[*] Deriving basewords and rules from {corpus}")
+    try:
+        result = _rulegen.generate(corpus, cache_dir)
+    except (OSError, ValueError) as e:
+        print(f"Rule derivation failed: {e}")
+        return
+
+    rules_path = result["rules"]
+    if coverage is not None:
+        rules_path = result["capped_rules"].get(coverage, rules_path)
+    print(f"[*] Basewords: {result['basewords']}")
+    print(f"[*] Rules:     {rules_path}")
+    print(f"[*] Coverage:  {result['coverage']}")
+
+    hcatQuickDictionary(
+        hcatHashType,
+        hcatHashFile,
+        f"-r {shlex.quote(rules_path)}",
+        result["basewords"],
+        attack_name="Spoonman",
+    )
+
+
 def hcatPermute(hcatHashType, hcatHashFile, wordlist):
     global hcatProcess, hcatPermuteCount
     permute_path = os.path.join(hate_path, "hashcat-utils", "bin", "permute.bin")
@@ -4255,6 +4298,10 @@ def prince_ling_attack():
     return _attacks.prince_ling_attack(_attack_ctx())
 
 
+def spoonman_attack():
+    return _attacks.spoonman_attack(_attack_ctx())
+
+
 def wordlist_filter_len(infile: str, outfile: str, min_len: int, max_len: int) -> bool:
     """Filter wordlist keeping only words between min_len and max_len (inclusive)."""
     len_bin = os.path.join(hate_path, "hashcat-utils/bin/len.bin")
@@ -4743,6 +4790,7 @@ def get_main_menu_items():
         ("19", "Combipow Passphrase Attack"),
         ("20", "PCFG Attack"),
         ("21", "PRINCE-LING Attack"),
+        ("22", "Spoonman Attack"),
         ("80", "Wordlist Tools"),
         ("81", "Rule File Tools"),
         ("82", "Notifications"),
@@ -4785,6 +4833,7 @@ def get_main_menu_options():
         "19": combipow_crack,
         "20": pcfg_attack,
         "21": prince_ling_attack,
+        "22": spoonman_attack,
         "80": wordlist_tools_submenu,
         "81": rule_tools_submenu,
         "82": notifications_submenu,

--- a/hate_crack/rulegen.py
+++ b/hate_crack/rulegen.py
@@ -1,0 +1,294 @@
+"""Derive basewords + hashcat rules that reconstruct every password in a corpus.
+
+Contributed by @Spoonman1091 in trustedsec/hate_crack#169.
+
+Baseword model: the letters-only core of each password, lowercased. Each
+password is paired with a rule that rebuilds it exactly, using ops hashcat
+supports natively:
+
+    :            no-op
+    l u c        lowercase all / uppercase all / capitalize
+    T{p}         toggle case at position p        (p in 0-9A-Z = 0..35)
+    ${x}         append char x
+    ^{x}         prepend char x
+    i{p}{x}      insert char x at position p
+
+The baseword list and the rule list together reconstruct 100% of the corpus,
+so the rule file is truncatable: it is sorted by how many passwords each rule
+rebuilds, most productive first.
+
+Two hashcat limits bound what a rule can express, and both fall back to
+emitting the password verbatim as its own baseword with a ``:`` no-op rule:
+
+* Positions are encoded in a 36-character alphabet, so ``T``/``i`` cannot
+  address past index 35.
+* hashcat rejects any rule with more than ``MAX_RULE_FUNCTIONS`` functions.
+  It does so *silently* when other valid rules are present in the same file,
+  which is why the op count is enforced here rather than discovered later as
+  missing coverage.
+"""
+
+import os
+from collections import Counter
+
+POS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+# hashcat's rule engine accepts at most this many functions in a single rule.
+# Verified against hashcat v7: 31 functions run, 32 yields "No valid rules
+# left" when the rule stands alone and is dropped without warning when it
+# shares a file with valid rules.
+MAX_RULE_FUNCTIONS = 31
+
+
+def _pos(n):
+    """Return the rule-alphabet character for index *n*, or None if unaddressable."""
+    return POS[n] if 0 <= n < len(POS) else None
+
+
+def _isalpha(c):
+    return ("a" <= c <= "z") or ("A" <= c <= "Z")
+
+
+def count_ops(rule):
+    """Return the number of hashcat functions in *rule*.
+
+    Raises ValueError on an op this module does not emit.
+    """
+    count = 0
+    i = 0
+    while i < len(rule):
+        op = rule[i]
+        if op in ":luc":
+            i += 1
+        elif op in "T$^":
+            i += 2
+        elif op == "i":
+            i += 3
+        else:
+            raise ValueError(f"unknown op {op!r} in rule {rule!r}")
+        count += 1
+    return count
+
+
+def derive(pw):
+    """Return ``(baseword, rule)`` such that applying *rule* to *baseword* yields *pw*.
+
+    Falls back to ``(pw, ":")`` — the password as its own literal baseword —
+    whenever the transformation cannot be expressed within hashcat's limits.
+    """
+    if pw == "":
+        return ("", ":")
+    letters = [c for c in pw if _isalpha(c)]
+    if not letters:
+        return (pw, ":")
+    base = "".join(c.lower() for c in letters)
+    idxs = [i for i, c in enumerate(pw) if _isalpha(c)]
+    first, last = idxs[0], idxs[-1]
+    prefix, core, suffix = pw[:first], pw[first : last + 1], pw[last + 1 :]
+
+    ops = []
+    # Case ops apply to the pure-lowercase base, so positions are 0..len(base)-1.
+    up = [c.isupper() for c in letters]
+    if not any(up):
+        pass
+    elif up[0] and not any(up[1:]):
+        ops.append("c")
+    elif all(up):
+        ops.append("u")
+    else:
+        for i, is_upper in enumerate(up):
+            if is_upper:
+                p = _pos(i)
+                if p is None:
+                    return (pw, ":")
+                ops.append("T" + p)
+    # Interior non-letters, inserted at core-relative indices in increasing
+    # order so each insert accounts for the shift from the ones before it.
+    for idx, c in enumerate(core):
+        if not _isalpha(c):
+            p = _pos(idx)
+            if p is None:
+                return (pw, ":")
+            ops.append("i" + p + c)
+    # Trailing non-letters append; position-independent, so these merge well
+    # across passwords.
+    for c in suffix:
+        ops.append("$" + c)
+    # Leading non-letters prepend, reversed so the final order comes out right.
+    for c in reversed(prefix):
+        ops.append("^" + c)
+
+    if len(ops) > MAX_RULE_FUNCTIONS:
+        return (pw, ":")
+
+    return (base, "".join(ops) if ops else ":")
+
+
+def apply_rule(word, rule):
+    """Reference implementation of the op subset :func:`derive` emits.
+
+    Mirrors hashcat's semantics for these ops so callers can verify a derived
+    pair without shelling out. It deliberately does not model
+    :data:`MAX_RULE_FUNCTIONS`; :func:`derive` enforces that instead.
+    """
+    s = word
+    i = 0
+    while i < len(rule):
+        op = rule[i]
+        if op == ":":
+            i += 1
+        elif op == "l":
+            s = s.lower()
+            i += 1
+        elif op == "u":
+            s = s.upper()
+            i += 1
+        elif op == "c":
+            s = (s[:1].upper() + s[1:].lower()) if s else s
+            i += 1
+        elif op == "T":
+            p = POS.index(rule[i + 1])
+            if p < len(s):
+                ch = s[p]
+                s = s[:p] + (ch.lower() if ch.isupper() else ch.upper()) + s[p + 1 :]
+            i += 2
+        elif op == "$":
+            s = s + rule[i + 1]
+            i += 2
+        elif op == "^":
+            s = rule[i + 1] + s
+            i += 2
+        elif op == "i":
+            p = POS.index(rule[i + 1])
+            ch = rule[i + 2]
+            p = min(p, len(s))
+            s = s[:p] + ch + s[p:]
+            i += 3
+        else:
+            raise ValueError(f"unknown op {op!r} in rule {rule!r}")
+    return s
+
+
+def _is_printable_ascii(pw):
+    return all(0x20 <= ord(c) <= 0x7E for c in pw)
+
+
+def generate(
+    corpus_path,
+    outdir,
+    cover=(95, 99),
+    ascii_only=False,
+    verify=True,
+    print_fn=print,
+):
+    """Derive basewords and rules from *corpus_path*, writing them under *outdir*.
+
+    Returns a dict with the output paths and corpus statistics. ``verify``
+    reconstructs every password through :func:`apply_rule` as a self-check;
+    it is cheap relative to reading the corpus but can be skipped.
+    """
+    os.makedirs(outdir, exist_ok=True)
+    base_counts = Counter()
+    rule_counts = Counter()
+    total = 0
+    skipped = 0
+    literal_fallbacks = 0
+    selfcheck_failures = []
+
+    with open(corpus_path, encoding="latin-1") as fh:
+        for line in fh:
+            pw = line.rstrip("\r\n")
+            if pw == "":
+                continue
+            if ascii_only and not _is_printable_ascii(pw):
+                skipped += 1
+                continue
+            total += 1
+            base, rule = derive(pw)
+            if base == pw and rule == ":" and any(not _isalpha(c) for c in pw):
+                literal_fallbacks += 1
+            if verify and apply_rule(base, rule) != pw:
+                selfcheck_failures.append(pw)
+            base_counts[base] += 1
+            rule_counts[rule] += 1
+
+    if total == 0:
+        raise ValueError(f"no passwords read from {corpus_path}")
+
+    def _path(name):
+        return os.path.join(outdir, name)
+
+    basewords_path = _path("basewords.txt")
+    with open(basewords_path, "w", encoding="latin-1") as f:
+        for base, _ in base_counts.most_common():
+            f.write(base + "\n")
+
+    ranked = rule_counts.most_common()
+    rules_path = _path("rules.full.rule")
+    with open(rules_path, "w", encoding="latin-1") as f:
+        for rule, _ in ranked:
+            f.write(rule + "\n")
+
+    capped_paths = {}
+    for target in cover:
+        needed = float(target) / 100.0 * total
+        cumulative = 0
+        count = 0
+        for _, hits in ranked:
+            cumulative += hits
+            count += 1
+            if cumulative >= needed:
+                break
+        capped = _path(f"rules.top{target}.rule")
+        with open(capped, "w", encoding="latin-1") as f:
+            for rule, _ in ranked[:count]:
+                f.write(rule + "\n")
+        capped_paths[target] = capped
+
+    # Rules needed to reach each coverage milestone.
+    milestones = {}
+    cumulative = 0
+    for i, (_, hits) in enumerate(ranked, start=1):
+        cumulative += hits
+        pct = 100.0 * cumulative / total
+        for mark in (50, 80, 90, 95, 99, 100):
+            if mark not in milestones and pct >= mark:
+                milestones[mark] = i
+
+    coverage_path = _path("coverage.txt")
+    with open(coverage_path, "w", encoding="latin-1") as f:
+        f.write(f"corpus:              {corpus_path}\n")
+        f.write(f"passwords:           {total}\n")
+        f.write(f"skipped (non-ascii): {skipped}\n")
+        f.write(f"unique basewords:    {len(base_counts)}\n")
+        f.write(f"unique rules:        {len(rule_counts)}\n")
+        f.write(f"literal fallbacks:   {literal_fallbacks}\n")
+        if verify:
+            f.write(f"self-check failures: {len(selfcheck_failures)} (must be 0)\n")
+        f.write("\nrules needed for coverage:\n")
+        for mark in sorted(milestones):
+            f.write(f"  {mark:3d}%: {milestones[mark]} rules\n")
+
+    print_fn(
+        f"[*] {total} passwords -> {len(base_counts)} basewords, "
+        f"{len(rule_counts)} rules ({literal_fallbacks} literal fallbacks)"
+    )
+    if selfcheck_failures:
+        print_fn(
+            f"[!] {len(selfcheck_failures)} passwords failed the reconstruction "
+            "self-check; coverage is below 100%."
+        )
+
+    return {
+        "basewords": basewords_path,
+        "rules": rules_path,
+        "capped_rules": capped_paths,
+        "coverage": coverage_path,
+        "total": total,
+        "skipped": skipped,
+        "basewords_count": len(base_counts),
+        "rules_count": len(rule_counts),
+        "literal_fallbacks": literal_fallbacks,
+        "selfcheck_failures": selfcheck_failures,
+        "milestones": milestones,
+    }

--- a/tests/test_main_spoonman.py
+++ b/tests/test_main_spoonman.py
@@ -1,0 +1,148 @@
+"""Tests for hcatSpoonman and the Spoonman Attack handler (#169)."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hate_crack import attacks
+
+
+@pytest.fixture
+def main_module(hc_module):
+    return hc_module._main
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    path = tmp_path / "cracked.txt"
+    path.write_text("Password1!\npassword\nSummer2026\n", encoding="latin-1")
+    return str(path)
+
+
+class TestHcatSpoonman:
+    def _run(self, main_module, tmp_path, corpus, monkeypatch, **kwargs):
+        monkeypatch.setattr(main_module, "hcatOptimizedWordlists", str(tmp_path / "opt"))
+        with patch.object(main_module, "hcatQuickDictionary") as quick:
+            main_module.hcatSpoonman("1000", "hashes.txt", corpus, **kwargs)
+        return quick
+
+    def test_derives_then_delegates_to_quick_dictionary(
+        self, main_module, tmp_path, corpus, monkeypatch
+    ):
+        quick = self._run(main_module, tmp_path, corpus, monkeypatch)
+
+        quick.assert_called_once()
+        args, kwargs = quick.call_args
+        assert args[0] == "1000"
+        assert args[1] == "hashes.txt"
+        assert args[2].startswith("-r ")
+        assert args[2].endswith("rules.full.rule")
+        assert args[3].endswith("basewords.txt")
+        assert kwargs["attack_name"] == "Spoonman"
+        assert os.path.isfile(args[3])
+
+    def test_coverage_selects_capped_rule_file(
+        self, main_module, tmp_path, corpus, monkeypatch
+    ):
+        quick = self._run(main_module, tmp_path, corpus, monkeypatch, coverage=95)
+        assert quick.call_args[0][2].endswith("rules.top95.rule")
+
+    def test_cache_dir_is_namespaced_per_corpus(
+        self, main_module, tmp_path, corpus, monkeypatch
+    ):
+        quick = self._run(main_module, tmp_path, corpus, monkeypatch)
+        assert os.path.join("spoonman", "cracked.txt") in quick.call_args[0][3]
+
+    def test_missing_corpus_reports_and_does_not_run_hashcat(
+        self, main_module, tmp_path, monkeypatch, capsys
+    ):
+        quick = self._run(
+            main_module, tmp_path, str(tmp_path / "nope.txt"), monkeypatch
+        )
+        quick.assert_not_called()
+        assert "corpus not found" in capsys.readouterr().out
+
+    def test_empty_corpus_reports_and_does_not_run_hashcat(
+        self, main_module, tmp_path, monkeypatch, capsys
+    ):
+        empty = tmp_path / "empty.txt"
+        empty.write_text("", encoding="latin-1")
+        quick = self._run(main_module, tmp_path, str(empty), monkeypatch)
+        quick.assert_not_called()
+        assert "Rule derivation failed" in capsys.readouterr().out
+
+    def test_reuses_cache_when_corpus_unchanged(
+        self, main_module, tmp_path, corpus, monkeypatch, capsys
+    ):
+        self._run(main_module, tmp_path, corpus, monkeypatch)
+        capsys.readouterr()
+
+        with patch("hate_crack.rulegen.generate") as generate:
+            self._run(main_module, tmp_path, corpus, monkeypatch)
+        generate.assert_not_called()
+        assert "Reusing derived" in capsys.readouterr().out
+
+    def test_regenerates_when_corpus_is_newer_than_cache(
+        self, main_module, tmp_path, corpus, monkeypatch, capsys
+    ):
+        quick = self._run(main_module, tmp_path, corpus, monkeypatch)
+        basewords = quick.call_args[0][3]
+        # Corpus modified after the cache was written.
+        os.utime(corpus, (os.path.getmtime(basewords) + 10,) * 2)
+        capsys.readouterr()
+
+        self._run(main_module, tmp_path, corpus, monkeypatch)
+        assert "Deriving basewords" in capsys.readouterr().out
+
+    def test_cached_run_still_honours_coverage(
+        self, main_module, tmp_path, corpus, monkeypatch
+    ):
+        self._run(main_module, tmp_path, corpus, monkeypatch)
+        quick = self._run(main_module, tmp_path, corpus, monkeypatch, coverage=99)
+        assert quick.call_args[0][2].endswith("rules.top99.rule")
+
+
+class TestSpoonmanAttackHandler:
+    def _ctx(self, tmp_path, corpus):
+        ctx = MagicMock()
+        ctx.hcatWordlists = str(tmp_path)
+        ctx.hcatHashType = "1000"
+        ctx.hcatHashFile = "hashes.txt"
+        ctx.select_file_with_autocomplete.return_value = corpus
+        return ctx
+
+    def test_passes_corpus_and_full_coverage(self, tmp_path, corpus):
+        ctx = self._ctx(tmp_path, corpus)
+        with patch("hate_crack.attacks.interactive_menu", return_value="1"):
+            attacks.spoonman_attack(ctx)
+        ctx.hcatSpoonman.assert_called_once_with(
+            "1000", "hashes.txt", corpus, coverage=None
+        )
+
+    @pytest.mark.parametrize(("choice", "expected"), [("2", 99), ("3", 95)])
+    def test_passes_capped_coverage(self, tmp_path, corpus, choice, expected):
+        ctx = self._ctx(tmp_path, corpus)
+        with patch("hate_crack.attacks.interactive_menu", return_value=choice):
+            attacks.spoonman_attack(ctx)
+        assert ctx.hcatSpoonman.call_args.kwargs["coverage"] == expected
+
+    def test_blank_corpus_aborts(self, tmp_path, corpus, capsys):
+        ctx = self._ctx(tmp_path, corpus)
+        ctx.select_file_with_autocomplete.return_value = "  "
+        attacks.spoonman_attack(ctx)
+        ctx.hcatSpoonman.assert_not_called()
+        assert "No corpus specified" in capsys.readouterr().out
+
+    def test_nonexistent_corpus_aborts(self, tmp_path, capsys):
+        ctx = self._ctx(tmp_path, str(tmp_path / "missing.txt"))
+        attacks.spoonman_attack(ctx)
+        ctx.hcatSpoonman.assert_not_called()
+        assert "Corpus not found" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("choice", ["99", None])
+    def test_back_out_of_rule_set_menu(self, tmp_path, corpus, choice):
+        ctx = self._ctx(tmp_path, corpus)
+        with patch("hate_crack.attacks.interactive_menu", return_value=choice):
+            attacks.spoonman_attack(ctx)
+        ctx.hcatSpoonman.assert_not_called()

--- a/tests/test_rulegen.py
+++ b/tests/test_rulegen.py
@@ -1,0 +1,197 @@
+"""Tests for hate_crack.rulegen (Spoonman Attack derivation, #169)."""
+
+import pytest
+
+from hate_crack import rulegen
+
+# A spread of shapes the derivation has to handle: casing patterns, leading and
+# trailing and interior non-letters, letterless input, and passphrases.
+CORPUS = [
+    "password",
+    "Password1!",
+    "PASSWORD",
+    "pAsSwOrD",
+    "Summer2026",
+    "Summer2026!",
+    "p@ssw0rd",
+    "Company#2026",
+    "john.smith",
+    "Tr0ub4dor&3",
+    "correct horse battery staple",
+    "!@#$%^",
+    "1234567890",
+    "Spring-2026!",
+    "aB1cD2eF3",
+    "MyD0g$Name!2026",
+    "...leading",
+    "trailing...",
+    "a.b.c.d.e",
+    "x",
+    "",
+]
+
+
+@pytest.mark.parametrize("pw", CORPUS)
+def test_derive_roundtrips(pw):
+    base, rule = rulegen.derive(pw)
+    assert rulegen.apply_rule(base, rule) == pw
+
+
+@pytest.mark.parametrize("pw", CORPUS)
+def test_derived_rules_respect_hashcat_function_limit(pw):
+    _, rule = rulegen.derive(pw)
+    assert rulegen.count_ops(rule) <= rulegen.MAX_RULE_FUNCTIONS
+
+
+class TestHashcatLimits:
+    def test_rule_over_function_limit_falls_back_to_literal(self):
+        # 32 trailing specials would need 34 ops (c + insert + 32 appends).
+        # hashcat drops rules over 31 functions *silently* when other valid
+        # rules share the file, so the fallback has to happen at derive time.
+        pw = "Passw0rd" + "!" * 32
+        base, rule = rulegen.derive(pw)
+        assert (base, rule) == (pw, ":")
+        assert rulegen.apply_rule(base, rule) == pw
+
+    def test_rule_at_function_limit_is_still_derived(self):
+        pw = "password" + "!" * 31
+        base, rule = rulegen.derive(pw)
+        assert base == "password"
+        assert rulegen.count_ops(rule) == rulegen.MAX_RULE_FUNCTIONS
+        assert rulegen.apply_rule(base, rule) == pw
+
+    def test_position_past_alphabet_falls_back_to_literal(self):
+        # Position 36 is unaddressable in the 0-9A-Z alphabet.
+        pw = "a" * 40 + "." + "b"
+        base, rule = rulegen.derive(pw)
+        assert (base, rule) == (pw, ":")
+
+
+class TestCountOps:
+    @pytest.mark.parametrize(
+        ("rule", "expected"),
+        [
+            (":", 1),
+            ("c", 1),
+            ("$1$2", 2),
+            ("^a^b", 2),
+            ("T0T1T2", 3),
+            ("i1.i3.", 2),
+            ("ci50$!", 3),
+        ],
+    )
+    def test_counts_ops(self, rule, expected):
+        assert rulegen.count_ops(rule) == expected
+
+    def test_rejects_unknown_op(self):
+        with pytest.raises(ValueError, match="unknown op"):
+            rulegen.count_ops("z")
+
+
+class TestDeriveShapes:
+    def test_all_lowercase_needs_no_case_op(self):
+        assert rulegen.derive("password") == ("password", ":")
+
+    def test_capitalized_uses_c(self):
+        assert rulegen.derive("Password") == ("password", "c")
+
+    def test_all_uppercase_uses_u(self):
+        assert rulegen.derive("PASSWORD") == ("password", "u")
+
+    def test_mixed_case_uses_toggles(self):
+        base, rule = rulegen.derive("pAsSwOrD")
+        assert base == "password"
+        assert rule == "T1T3T5T7"
+
+    def test_letterless_password_is_its_own_baseword(self):
+        assert rulegen.derive("!@#$%^") == ("!@#$%^", ":")
+
+    def test_interior_non_letters_use_inserts(self):
+        base, rule = rulegen.derive("a.b")
+        assert base == "ab"
+        assert rule == "i1."
+
+    def test_prefix_and_suffix_order(self):
+        base, rule = rulegen.derive("12ab!")
+        assert base == "ab"
+        # Appends come before prepends; prepends are emitted in reverse.
+        assert rule == "$!^2^1"
+        assert rulegen.apply_rule(base, rule) == "12ab!"
+
+
+class TestGenerate:
+    def _write_corpus(self, tmp_path, passwords):
+        path = tmp_path / "corpus.txt"
+        path.write_text("\n".join(passwords) + "\n", encoding="latin-1")
+        return str(path)
+
+    def test_writes_expected_files(self, tmp_path):
+        corpus = self._write_corpus(tmp_path, [p for p in CORPUS if p])
+        out = tmp_path / "out"
+        result = rulegen.generate(corpus, str(out), print_fn=lambda *a: None)
+
+        assert (out / "basewords.txt").is_file()
+        assert (out / "rules.full.rule").is_file()
+        assert (out / "rules.top95.rule").is_file()
+        assert (out / "rules.top99.rule").is_file()
+        assert (out / "coverage.txt").is_file()
+        assert result["selfcheck_failures"] == []
+        assert result["total"] == len([p for p in CORPUS if p])
+
+    def test_full_rule_set_reconstructs_whole_corpus(self, tmp_path):
+        passwords = [p for p in CORPUS if p]
+        corpus = self._write_corpus(tmp_path, passwords)
+        out = tmp_path / "out"
+        rulegen.generate(corpus, str(out), print_fn=lambda *a: None)
+
+        basewords = (out / "basewords.txt").read_text(encoding="latin-1").splitlines()
+        rules = (out / "rules.full.rule").read_text(encoding="latin-1").splitlines()
+        produced = {
+            rulegen.apply_rule(b, r) for b in basewords for r in rules
+        }
+        assert set(passwords) <= produced
+
+    def test_rules_sorted_most_productive_first(self, tmp_path):
+        # "a" and "b" need no rule (":"); "C" needs "c". So ":" outranks "c".
+        corpus = self._write_corpus(tmp_path, ["a", "b", "C"])
+        out = tmp_path / "out"
+        rulegen.generate(corpus, str(out), print_fn=lambda *a: None)
+        rules = (out / "rules.full.rule").read_text(encoding="latin-1").splitlines()
+        assert rules[0] == ":"
+
+    def test_capped_file_is_a_prefix_of_the_full_set(self, tmp_path):
+        corpus = self._write_corpus(tmp_path, [p for p in CORPUS if p])
+        out = tmp_path / "out"
+        rulegen.generate(corpus, str(out), print_fn=lambda *a: None)
+        full = (out / "rules.full.rule").read_text(encoding="latin-1").splitlines()
+        top95 = (out / "rules.top95.rule").read_text(encoding="latin-1").splitlines()
+        assert top95 == full[: len(top95)]
+
+    def test_ascii_only_skips_and_counts(self, tmp_path):
+        corpus = self._write_corpus(tmp_path, ["password", "pa\x01ssword"])
+        out = tmp_path / "out"
+        result = rulegen.generate(
+            corpus, str(out), ascii_only=True, print_fn=lambda *a: None
+        )
+        assert result["total"] == 1
+        assert result["skipped"] == 1
+
+    def test_blank_lines_are_ignored(self, tmp_path):
+        corpus = self._write_corpus(tmp_path, ["password", "", "secret"])
+        out = tmp_path / "out"
+        result = rulegen.generate(corpus, str(out), print_fn=lambda *a: None)
+        assert result["total"] == 2
+
+    def test_empty_corpus_raises(self, tmp_path):
+        corpus = self._write_corpus(tmp_path, [])
+        out = tmp_path / "out"
+        with pytest.raises(ValueError, match="no passwords"):
+            rulegen.generate(corpus, str(out), print_fn=lambda *a: None)
+
+    def test_coverage_report_names_the_corpus(self, tmp_path):
+        corpus = self._write_corpus(tmp_path, ["password", "Password"])
+        out = tmp_path / "out"
+        rulegen.generate(corpus, str(out), print_fn=lambda *a: None)
+        report = (out / "coverage.txt").read_text(encoding="latin-1")
+        assert corpus in report
+        assert "self-check failures: 0" in report

--- a/tests/test_ui_menu_options.py
+++ b/tests/test_ui_menu_options.py
@@ -32,6 +32,7 @@ MENU_OPTION_TEST_CASES = [
     ("19", CLI_MODULE._attacks, "combipow_crack", "combipow"),
     ("20", CLI_MODULE._attacks, "pcfg_attack", "pcfg"),
     ("21", CLI_MODULE._attacks, "prince_ling_attack", "prince-ling"),
+    ("22", CLI_MODULE._attacks, "spoonman_attack", "spoonman"),
     ("80", CLI_MODULE._attacks, "wordlist_tools_submenu", "wordlist-tools"),
     ("81", CLI_MODULE._attacks, "rule_tools_submenu", "rule-tools"),
     ("82", CLI_MODULE, "notifications_submenu", "notifications-submenu"),


### PR DESCRIPTION
Implements #169, contributed by @Spoonman1091. Opened as a **draft** — the branch is a dev branch for the feature, not a merge request yet.

## What it does

New main-menu attack **22, Spoonman Attack**. Given a corpus of known plaintext passwords (a previous engagement's cracked output, a leak dump), it derives a baseword list plus a hashcat rule file whose cross product reconstructs the corpus. Each password becomes its letters-only lowercased core plus a rule that rebuilds it (`l`/`u`/`c`, `T{p}`, `${x}`, `^{x}`, `i{p}{x}`).

Rules are sorted by how many passwords each rebuilds, so the file is truncatable — the menu offers the full set, top 99%, or top 95% coverage. Output is cached per corpus under `<hcatOptimizedWordlists>/spoonman/<corpus>/` and reused until the corpus changes.

## One substantive change from the attached script

**`derive()` now enforces hashcat's ceiling of 31 functions per rule**, falling back to emitting the password as its own literal baseword.

I verified the limit against hashcat v7 directly: 31 functions run, 32 gives `No valid rules left`, and when an over-long rule shares a file with valid rules **hashcat drops it silently** — empty stderr, no warning.

This matters because the script validated against its own `apply_rule()` simulator, which has no such limit. On an 18-password corpus containing `Passw0rd` + 32 exclamation marks (34 ops), it reported `selfcheck_fail=0` while really reconstructing **17/18** through hashcat. With the guard, the same corpus reconstructs **18/18**.

The author had already handled the analogous position limit (`T`/`i` cannot address past index 35) with the same literal-baseword fallback, so this is a missed sibling case rather than a design flaw.

## Verification

- **Fuzzed against real hashcat**: 3,936 distinct derived pairs pushed through `hashcat --stdout` over the full 13.7M-candidate cross product — **3,936/3,936 reconstructed, zero mismatches**.
- **Fuzzed against the reference simulator**: 58,519 random and hand-picked edge-case inputs (latin-1 bytes, whitespace, strings made only of hashcat operator characters, 80-char inputs, letterless inputs) — zero failures, and no derived rule exceeded the function limit.
- Suite: **1171 passed, 29 skipped**. `ruff check`/`format` clean on `hate_crack`.
- Spec-compliance review confirmed all six wiring steps including the duplicate mapping in `hate_crack.py`.

## Open question for review

`generate()` holds a `Counter` of every unique baseword and rule in memory, so peak usage scales with corpus *cardinality*. Fine for engagement-sized corpora; a multi-hundred-million-line dump would want a streaming or sharded pass. The reference script has the same property. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)