### PR TITLE
fix(menu): drop duplicate download entries from the no-hash-file menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   guard a corpus containing such passwords would quietly fall short of the
   coverage it reported.
 
+### Changed
+
+- **No-hash-file menu no longer duplicates the download entries.** The Weakpass
+  and Hashmob wordlist downloads already live in Wordlist Tools, and the Hashmob
+  rule download already lives in Rule File Tools, so the three top-level copies
+  were removed. The menu is now `1` Hashview API, `2` Wordlist Tools, `3` Rule
+  File Tools, `4` Exit. The `--weakpass`, `--hashmob`, and `--rules` CLI flags
+  are unaffected; they short-circuit before this menu is drawn.
+
 ## [2.16.0] - 2026-07-29
 
 ### Changed

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -5299,12 +5299,9 @@ def main():
             check_for_updates()
         _no_hash_items = [
             ("1", "Hashview API"),
-            ("2", "Download wordlists from Weakpass"),
-            ("3", "Download wordlists from Hashmob.net"),
-            ("4", "Download rules from Hashmob.net"),
-            ("5", "Wordlist Tools"),
-            ("6", "Rule File Tools"),
-            ("7", "Exit"),
+            ("2", "Wordlist Tools"),
+            ("3", "Rule File Tools"),
+            ("4", "Exit"),
         ]
         menu_loop = True
         while menu_loop:
@@ -5326,26 +5323,11 @@ def main():
                     # Otherwise continue the menu loop
                 else:
                     menu_loop = False
-            elif choice == "2" or args.weakpass:
-                weakpass_wordlist_menu(rank=args.rank)
-                if args.weakpass:
-                    sys.exit(0)
-                # Otherwise continue the menu loop
-            elif choice == "3" or args.hashmob:
-                download_hashmob_wordlists(print_fn=print)
-                if args.hashmob:
-                    sys.exit(0)
-                # Otherwise continue the menu loop
-            elif choice == "4" or args.rules:
-                download_hashmob_rules(print_fn=print, rules_dir=rulesDirectory)
-                if args.rules:
-                    sys.exit(0)
-                # Otherwise continue the menu loop
-            elif choice == "5":
+            elif choice == "2":
                 wordlist_tools_submenu()
-            elif choice == "6":
+            elif choice == "3":
                 rule_tools_submenu()
-            elif choice == "7":
+            elif choice == "4":
                 sys.exit(0)
             else:
                 if (

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -116,21 +116,21 @@ def test_weakpass_default_rank(monkeypatch):
 # ---------------------------------------------------------------------------
 def test_potfile_path_flag(monkeypatch):
     monkeypatch.setattr(hc_main, "ascii_art", lambda: None)
-    monkeypatch.setattr("builtins.input", lambda _prompt="": "7")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "4")
     _run_main(monkeypatch, ["--potfile-path", "/tmp/test.pot"])
     assert hc_main.hcatPotfilePath == "/tmp/test.pot"
 
 
 def test_no_potfile_path_flag(monkeypatch):
     monkeypatch.setattr(hc_main, "ascii_art", lambda: None)
-    monkeypatch.setattr("builtins.input", lambda _prompt="": "7")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "4")
     _run_main(monkeypatch, ["--no-potfile-path"])
     assert hc_main.hcatPotfilePath == ""
 
 
 def test_potfile_path_empty_string_reverts_to_default(monkeypatch):
     monkeypatch.setattr(hc_main, "ascii_art", lambda: None)
-    monkeypatch.setattr("builtins.input", lambda _prompt="": "7")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "4")
     _run_main(monkeypatch, ["--potfile-path", ""])
     assert hc_main.hcatPotfilePath == ""
 
@@ -140,7 +140,7 @@ def test_potfile_path_empty_string_reverts_to_default(monkeypatch):
 # ---------------------------------------------------------------------------
 def test_debug_flag(monkeypatch):
     monkeypatch.setattr(hc_main, "ascii_art", lambda: None)
-    monkeypatch.setattr("builtins.input", lambda _prompt="": "7")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "4")
     _run_main(monkeypatch, ["--debug"])
     assert hc_main.debug_mode is True
 
@@ -167,7 +167,7 @@ def test_positional_hashfile_only_enters_menu(monkeypatch, tmp_path):
     hashfile = tmp_path / "hashes.txt"
     hashfile.write_text("aabbccdd\n")
     monkeypatch.setattr(hc_main, "ascii_art", lambda: None)
-    monkeypatch.setattr("builtins.input", lambda _prompt="": "7")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "4")
     code = _run_main(monkeypatch, [str(hashfile)])
     assert code == 0
 
@@ -175,7 +175,7 @@ def test_positional_hashfile_only_enters_menu(monkeypatch, tmp_path):
 def test_no_args_enters_menu(monkeypatch):
     """No arguments falls through to the interactive menu."""
     monkeypatch.setattr(hc_main, "ascii_art", lambda: None)
-    monkeypatch.setattr("builtins.input", lambda _prompt="": "7")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "4")
     code = _run_main(monkeypatch, [])
     assert code == 0
 
@@ -383,7 +383,7 @@ def test_argparse_missing_required_args(monkeypatch, argv):
 def test_potfile_path_and_no_potfile_path_conflict(monkeypatch):
     """Both --potfile-path and --no-potfile-path should still parse (not mutually exclusive in argparse)."""
     monkeypatch.setattr(hc_main, "ascii_art", lambda: None)
-    monkeypatch.setattr("builtins.input", lambda _prompt="": "7")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "4")
     # --potfile-path wins because it's checked second in the dispatch logic
     code = _run_main(monkeypatch, ["--potfile-path", "/tmp/test.pot", "--no-potfile-path"])
     assert code == 0


### PR DESCRIPTION
The no-hash-file menu listed the Weakpass/Hashmob wordlist downloads and the
Hashmob rule download at the top level, even though those entries already exist
in the Wordlist Tools and Rule File Tools submenus. This removes the duplicates.

Menu is now:

    [1] Hashview API
    [2] Wordlist Tools
    [3] Rule File Tools
    [4] Exit

`--weakpass`, `--hashmob`, and `--rules` are unaffected — they `sys.exit()`
before this menu is drawn, so the `or args.*` clauses in the removed branches
were dead code.

Seven tests in `tests/test_cli_flags.py` fed `"7"` to exit the menu; they now
feed `"4"`. Full suite: 1171 passed, 29 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)