### PR TITLE
chore(ci): point Dependabot at nightly-dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
   # since 2025-12).
   - package-ecosystem: "uv"
     directory: "/"
+    # All PRs target nightly-dev; main receives work only via the weekly
+    # integration merge. Without this, Dependabot opens against the repo
+    # default branch (main) and bypasses that cadence.
+    target-branch: "nightly-dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -20,6 +24,7 @@ updates:
   # pins current (and refreshes the trailing "# vN" comment).
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "nightly-dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Dependabot opens PRs against the repo's default branch (`main`), so its updates were the one category bypassing the `nightly-dev` cadence every other PR now follows. Both ecosystem entries — `uv` and `github-actions` — now set `target-branch: "nightly-dev"`.

The `chore(deps)`/`chore(ci)` prefixes still don't match `auto-tag.yml`'s `feat|fix|perf` patterns, so these PRs continue to never cut a tag on their own. They now ride the weekly `nightly-dev` → `main` integration merge instead of landing on `main` directly.

## Trade-off worth naming

`target-branch` applies to Dependabot **security** updates too, not just scheduled version bumps. A security patch will therefore sit on `nightly-dev` until the weekly merge reaches `main`, where previously it landed on `main` as soon as it was merged.

When one is urgent, retarget that single PR to `main` and merge it down into `nightly-dev` afterwards to keep the branches from diverging — the same escape hatch the branching policy already defines for hand-written security fixes.

## Testing

Config-only change. Verified the file still parses as valid YAML and that both entries carry the new key. Nothing in `tests/` or `README.md` references the Dependabot config, so there was nothing to update alongside it.

GitHub validates `dependabot.yml` server-side on push; the config's effect can be confirmed on the next scheduled run (weekly) or by triggering "Check for updates" in the repo's Dependabot settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)