### PR TITLE
ci: tag nightly-dev with pre-releases, keep full tags on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+      # Required for nightly-tag.yml, which triggers on this workflow completing
+      # for nightly-dev. Without it, pushes to nightly-dev run no CI at all.
+      - nightly-dev
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -1,0 +1,143 @@
+name: Nightly Tag
+
+# Tags nightly-dev with a PEP 440 pre-release (e.g. v2.17.0-rc.3) after CI
+# passes. Full releases are cut only by auto-tag.yml, and only on main, when
+# nightly-dev is merged down at the weekly integration.
+#
+# The tag names the version the weekly merge will cut, so v2.17.0-rc.3 means
+# "third validated nightly build heading for 2.17.0". setuptools-scm resolves it
+# to 2.17.0rc3, which PEP 440 orders after 2.16.0 and before 2.17.0.
+#
+# -rc is used rather than -dev because setuptools-scm rejects any tag ending in
+# .devN for N>0 ("create a new supported one ending in .dev0"), reserving the
+# dev segment for its own commit-distance counting. That rules out an
+# incrementing dev scheme.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+    branches:
+      - nightly-dev
+
+permissions:
+  contents: write
+
+# Two merges landing back-to-back would otherwise both compute the same rc
+# counter and the second push would fail. Serialize instead of cancelling so no
+# merge gets skipped.
+concurrency:
+  group: nightly-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # workflow_run defaults to the tip of the default branch, which is not
+          # the commit CI validated.
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Determine pre-release tag
+        id: bump
+        run: |
+          # Latest FULL release tag. The anchored pattern deliberately excludes
+          # pre-release tags, so this matches auto-tag.yml's baseline exactly.
+          latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -z "$latest_tag" ]; then
+            base_version="0.1.0"
+            shas=$(git log --format=%H)
+          else
+            echo "Latest release tag: $latest_tag"
+            base_version="${latest_tag#v}"
+            shas=$(git log "$latest_tag"..HEAD --format=%H)
+          fi
+
+          if [ -z "$shas" ]; then
+            echo "No new commits since $latest_tag"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          major=$(echo "$base_version" | cut -d. -f1)
+          minor=$(echo "$base_version" | cut -d. -f2)
+          patch=$(echo "$base_version" | cut -d. -f3)
+
+          # Same bump precedence as auto-tag.yml (major > minor > patch), so the
+          # tag names the version the weekly merge to main will cut.
+          bump="none"
+          while IFS= read -r sha; do
+            [ -n "$sha" ] || continue
+            body=$(git log -1 --format=%B "$sha")
+            subject=${body%%$'\n'*}
+
+            if [[ "$subject" =~ ^[a-zA-Z]+(\(.+\))?!: ]]; then
+              bump="major"
+            elif grep -qE '^(BREAKING CHANGE|BREAKING-CHANGE):' <<<"$body"; then
+              bump="major"
+            elif [[ "$subject" =~ ^feat(\(.+\))?: ]] && [ "$bump" != "major" ]; then
+              bump="minor"
+            elif [[ "$subject" =~ ^(fix|perf)(\(.+\))?: ]] && [ "$bump" = "none" ]; then
+              bump="patch"
+            fi
+          done <<EOF
+          $shas
+          EOF
+
+          if [ "$bump" = "none" ]; then
+            # Unlike auto-tag.yml, a chore/docs-only nightly still gets a tag so
+            # every validated nightly commit is addressable. It carries the next
+            # patch version, since that is what a release would be.
+            echo "No feat/fix/perf/breaking commits; tagging as a patch pre-release"
+            bump="patch"
+          fi
+
+          if [ "$bump" = "major" ]; then
+            major=$((major + 1)); minor=0; patch=0
+          elif [ "$bump" = "minor" ]; then
+            minor=$((minor + 1)); patch=0
+          else
+            patch=$((patch + 1))
+          fi
+
+          next="${major}.${minor}.${patch}"
+
+          # Increment the rc counter for this target version. Tags for other
+          # versions are irrelevant.
+          last_n=$(git tag --list "v${next}-rc.*" \
+            | sed -E "s/^v${next}-rc\.([0-9]+)$/\1/" \
+            | grep -E '^[0-9]+$' \
+            | sort -n \
+            | tail -1 || true)
+          n=$(( ${last_n:-0} + 1 ))
+
+          new_tag="v${next}-rc.${n}"
+          echo "Bump: $bump -> $new_tag"
+          echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create pre-release tag
+        if: steps.bump.outputs.skip != 'true'
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/$NEW_TAG" >/dev/null; then
+            echo "Tag $NEW_TAG already exists, nothing to push"
+          else
+            git tag "$NEW_TAG"
+            git push origin "refs/tags/$NEW_TAG"
+          fi
+
+      # No GitHub release is created. These tags exist to make nightly builds
+      # addressable and to give setuptools-scm a version; releases are cut on
+      # main by auto-tag.yml.


### PR DESCRIPTION
## Summary

`nightly-dev` cut no tags at all, so validated nightly builds weren't addressable and `setuptools-scm` had nothing newer than the last release to resolve against. This adds `nightly-tag.yml`, which tags each CI-validated push to `nightly-dev`.

| Branch | Workflow | Tag | GitHub release |
|--------|----------|-----|----------------|
| `main` | `auto-tag.yml` (unchanged) | full, `v2.17.0` | yes |
| `nightly-dev` | `nightly-tag.yml` (new) | pre-release, `v2.17.0-rc.4` | no |

The tag names the version the weekly merge will cut, with a per-version counter. No GitHub release is created for nightlies — releases stay a `main` concern.

## Why `-rc` and not `-dev`

`setuptools-scm` **rejects** any tag ending in `.devN` for N>0 — it errors with `Please drop the tag or create a new supported one ending in .dev0`, reserving the dev segment for its own commit-distance counting. I confirmed this by tagging each candidate format locally and reading back `get_version()`:

| Tag | `setuptools-scm` result |
|-----|------------------------|
| `v2.17.0.dev1` | **rejected** |
| `v2.17.0-dev1` | **rejected** |
| `v2.17.0.dev0` | `2.17.0.dev0` — accepted, but only `.dev0` is legal, so no counter |
| `v2.17.0-rc.1` | `2.17.0rc1` |
| `v2.17.0a1` | `2.17.0a1` |

So a literal incrementing `-dev.N` scheme is not available. `-rc.N` was chosen over `a.N`. There's a comment in the workflow and a note in CLAUDE.md warning against "fixing" the naming back to `-dev`.

## Verification

I ran the tagging logic against the real repo state rather than eyeballing it:

- Current `nightly-dev` (one `feat:`, one `fix:`, one `chore:`) → computes **`v2.17.0-rc.1`**, correctly minor-bumping from `v2.16.0`.
- Counter increments: with `rc.1` present → `rc.2`; with `rc.10` present → **`rc.11`**, not `rc.2`, confirming numeric rather than lexical ordering.
- A stale `v2.99.0-rc.7` for an unrelated version does not interfere.
- auto-tag's baseline lookup still returns `v2.16.0` with pre-release tags present, so the weekly merge is unaffected.
- PEP 440 ordering confirmed: `2.16.0 < 2.17.0rc1 < 2.17.0`.

## Note on ci.yml

`ci.yml` gains `nightly-dev` to its push triggers. This is required, not cosmetic: CI previously ran on `main` pushes and PRs only, so nothing ran on a `nightly-dev` push and the `workflow_run` trigger would never have fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)