### PR TITLE
ci: place nightly-tag.yml on main so workflow_run dispatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+      # Required for nightly-tag.yml, which triggers on this workflow completing
+      # for nightly-dev. Without it, pushes to nightly-dev run no CI at all.
+      - nightly-dev
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -1,0 +1,148 @@
+name: Nightly Tag
+
+# Tags nightly-dev with a PEP 440 pre-release (e.g. v2.17.0-rc.3) after CI
+# passes. Full releases are cut only by auto-tag.yml, and only on main, when
+# nightly-dev is merged down at the weekly integration.
+#
+# The tag names the version the weekly merge will cut, so v2.17.0-rc.3 means
+# "third validated nightly build heading for 2.17.0". setuptools-scm resolves it
+# to 2.17.0rc3, which PEP 440 orders after 2.16.0 and before 2.17.0.
+#
+# -rc is used rather than -dev because setuptools-scm rejects any tag ending in
+# .devN for N>0 ("create a new supported one ending in .dev0"), reserving the
+# dev segment for its own commit-distance counting. That rules out an
+# incrementing dev scheme.
+#
+# This file MUST live on the default branch (main). GitHub only dispatches
+# workflow_run for workflows present on the default branch, so a copy that
+# exists solely on nightly-dev never fires - verified the hard way: CI passed on
+# nightly-dev and this workflow did not run.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+    branches:
+      - nightly-dev
+
+permissions:
+  contents: write
+
+# Two merges landing back-to-back would otherwise both compute the same rc
+# counter and the second push would fail. Serialize instead of cancelling so no
+# merge gets skipped.
+concurrency:
+  group: nightly-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # workflow_run defaults to the tip of the default branch, which is not
+          # the commit CI validated.
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Determine pre-release tag
+        id: bump
+        run: |
+          # Latest FULL release tag. The anchored pattern deliberately excludes
+          # pre-release tags, so this matches auto-tag.yml's baseline exactly.
+          latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -z "$latest_tag" ]; then
+            base_version="0.1.0"
+            shas=$(git log --format=%H)
+          else
+            echo "Latest release tag: $latest_tag"
+            base_version="${latest_tag#v}"
+            shas=$(git log "$latest_tag"..HEAD --format=%H)
+          fi
+
+          if [ -z "$shas" ]; then
+            echo "No new commits since $latest_tag"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          major=$(echo "$base_version" | cut -d. -f1)
+          minor=$(echo "$base_version" | cut -d. -f2)
+          patch=$(echo "$base_version" | cut -d. -f3)
+
+          # Same bump precedence as auto-tag.yml (major > minor > patch), so the
+          # tag names the version the weekly merge to main will cut.
+          bump="none"
+          while IFS= read -r sha; do
+            [ -n "$sha" ] || continue
+            body=$(git log -1 --format=%B "$sha")
+            subject=${body%%$'\n'*}
+
+            if [[ "$subject" =~ ^[a-zA-Z]+(\(.+\))?!: ]]; then
+              bump="major"
+            elif grep -qE '^(BREAKING CHANGE|BREAKING-CHANGE):' <<<"$body"; then
+              bump="major"
+            elif [[ "$subject" =~ ^feat(\(.+\))?: ]] && [ "$bump" != "major" ]; then
+              bump="minor"
+            elif [[ "$subject" =~ ^(fix|perf)(\(.+\))?: ]] && [ "$bump" = "none" ]; then
+              bump="patch"
+            fi
+          done <<EOF
+          $shas
+          EOF
+
+          if [ "$bump" = "none" ]; then
+            # Unlike auto-tag.yml, a chore/docs-only nightly still gets a tag so
+            # every validated nightly commit is addressable. It carries the next
+            # patch version, since that is what a release would be.
+            echo "No feat/fix/perf/breaking commits; tagging as a patch pre-release"
+            bump="patch"
+          fi
+
+          if [ "$bump" = "major" ]; then
+            major=$((major + 1)); minor=0; patch=0
+          elif [ "$bump" = "minor" ]; then
+            minor=$((minor + 1)); patch=0
+          else
+            patch=$((patch + 1))
+          fi
+
+          next="${major}.${minor}.${patch}"
+
+          # Increment the rc counter for this target version. Tags for other
+          # versions are irrelevant.
+          last_n=$(git tag --list "v${next}-rc.*" \
+            | sed -E "s/^v${next}-rc\.([0-9]+)$/\1/" \
+            | grep -E '^[0-9]+$' \
+            | sort -n \
+            | tail -1 || true)
+          n=$(( ${last_n:-0} + 1 ))
+
+          new_tag="v${next}-rc.${n}"
+          echo "Bump: $bump -> $new_tag"
+          echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create pre-release tag
+        if: steps.bump.outputs.skip != 'true'
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/$NEW_TAG" >/dev/null; then
+            echo "Tag $NEW_TAG already exists, nothing to push"
+          else
+            git tag "$NEW_TAG"
+            git push origin "refs/tags/$NEW_TAG"
+          fi
+
+      # No GitHub release is created. These tags exist to make nightly builds
+      # addressable and to give setuptools-scm a version; releases are cut on
+      # main by auto-tag.yml.


### PR DESCRIPTION
## Summary

`nightly-tag.yml` landed on `nightly-dev` in #173, where **it can never fire**. GitHub only dispatches `workflow_run` events for workflows that exist on the repository's default branch. I caught this by watching the merge of #173: CI ran on `nightly-dev` and completed successfully, and the tagger did not run at all — no queued run, no skipped run, nothing.

This PR puts the file on `main` so the trigger actually dispatches.

## Why this targets `main`, against the new policy

This is a deliberate, narrow exception. The workflow cannot function anywhere else, and routing it through the weekly integration merge would leave nightly tagging silently broken until that merge happened — the failure mode being "no tags appear and nobody notices."

Same shape as the security-fix escape hatch in the branching policy: goes to `main`, and `nightly-dev` already has the identical content from #173, so the branches do not diverge.

## Safety

The workflow still filters `branches: [nightly-dev]`, so having it on `main` does **not** tag `main`. `auto-tag.yml` remains the only workflow that cuts full releases, and only for `main`.

Content is byte-identical to what #173 merged, except for an added comment recording the default-branch requirement so this doesn't get "cleaned up" later.

`ci.yml`'s `nightly-dev` push trigger comes along in the same commit to keep the two branches' workflow definitions in sync.

## Follow-up

Once this lands, the next push to `nightly-dev` gets tagged. The current `nightly-dev` HEAD predates a working tagger, so I'll tag `v2.17.0-rc.1` by hand to establish the baseline the counter increments from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)