### PR TITLE
feat(cli): add --nightly update channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ### Added
 
+- **`--nightly` update channel.** `--nightly` (or `--update --nightly`) updates
+  from the `nightly-dev` branch instead of `main`, for work that has passed CI
+  but has not been cut into a release. `--update` is unchanged and still tracks
+  releases on `main`. The startup update check only ever offers releases: it
+  reads GitHub's "latest release" endpoint, which excludes pre-releases, and
+  nightly builds publish no GitHub release at all.
+
 - **Spoonman Attack (main menu `22`).** Derives a baseword list and a
   frequency-sorted hashcat rule file from a corpus of known plaintext
   passwords, such that the baseword x rule cross product reconstructs the

--- a/README.md
+++ b/README.md
@@ -414,6 +414,8 @@ Common options:
 - `--pipal-path <PATH>`: Override pipal path.
 - `--maxruntime <SECONDS>`: Override max runtime.
 - `--bandrel-basewords <PATH>`: Override bandrel basewords file.
+- `--update`: Update to the latest release and reinstall. Switches the checkout to `main` if it is on another branch, since release tags live there.
+- `--nightly`: Update to the latest nightly instead, from the `nightly-dev` branch. Nightlies have passed CI but are not part of a cut release. Can also be written `--update --nightly`.
 - `--debug`: Enable debug logging (writes to stderr).
 
 ### Hashview Integration
@@ -601,6 +603,22 @@ hate_crack can automatically check GitHub for newer releases on startup. This fe
 - **`check_for_updates`** — Enable automatic version checks on startup (default: `true`).
 - When enabled, hate_crack fetches the latest release info from GitHub and displays a notice if an update is available.
 - The check runs asynchronously and does not block startup. Network errors are silently ignored.
+
+##### Update Channels
+
+| Channel | Flag | Source | What you get |
+|---------|------|--------|--------------|
+| Release | `--update` | `main` | The latest cut release. This is the default and what the startup check offers. |
+| Nightly | `--nightly` | `nightly-dev` | Work that has passed CI but has not been released yet. |
+
+The startup check only ever offers releases. It reads GitHub's "latest release"
+endpoint, which excludes pre-releases, and nightly builds publish no GitHub
+release at all — so enabling `check_for_updates` will never pull you onto a
+nightly.
+
+Either flag switches your checkout to the corresponding branch first (and
+refuses to do so if you have uncommitted changes). If you are running a nightly
+and want to go back to released code, `--update` moves you back to `main`.
 
 #### Automatic Found Hash Merging (Download Left Only)
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1015,8 +1015,14 @@ def ascii_art():
     )
 
 
-def _run_upgrade():
-    """Run `git pull && git fetch --tags && make install` in the repo root."""
+def _run_upgrade(branch="main"):
+    """Run `git pull && git fetch --tags && make install` in the repo root.
+
+    *branch* selects the update channel. ``"main"`` is the released channel that
+    ``--update`` uses; ``"nightly-dev"`` is the pre-release channel behind
+    ``--nightly``, carrying work that has passed CI but has not been cut into a
+    release yet. See the Branching Policy in CLAUDE.md.
+    """
     import subprocess
 
     print()
@@ -1031,7 +1037,7 @@ def _run_upgrade():
     if git_root_result.returncode != 0:
         print(
             "\n  Could not find a git repository to upgrade from."
-            "\n  Run manually: git pull && git fetch --tags && make install\n"
+            f"\n  Run manually: git pull origin {branch} && git fetch --tags && make install\n"
         )
         raise SystemExit(1)
     repo_root = git_root_result.stdout.strip()
@@ -1049,7 +1055,7 @@ def _run_upgrade():
     if fetch_result.returncode != 0:
         print(
             f"\n  Failed to fetch from origin:\n  {fetch_result.stderr.strip()}\n"
-            "\n  Upgrade manually: git fetch --tags && git checkout main && git pull origin main && make install\n"
+            f"\n  Upgrade manually: git fetch --tags && git checkout {branch} && git pull origin {branch} && make install\n"
         )
         raise SystemExit(1)
 
@@ -1069,9 +1075,11 @@ def _run_upgrade():
         capture_output=True,
         text=True,
     )
-    branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+    current_branch = (
+        branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+    )
 
-    if branch and branch != "main":
+    if current_branch and current_branch != branch:
         status = subprocess.run(
             ["git", "status", "--porcelain"],
             cwd=repo_root,
@@ -1080,33 +1088,35 @@ def _run_upgrade():
         )
         if status.stdout.strip():
             print(
-                f"\n  Cannot auto-upgrade: uncommitted changes on '{branch}'."
+                f"\n  Cannot auto-upgrade: uncommitted changes on '{current_branch}'."
                 "\n  Commit or stash them, then re-run."
-                "\n  Or upgrade manually: git checkout main && git pull origin main && make install\n"
+                f"\n  Or upgrade manually: git checkout {branch} && git pull origin {branch} && make install\n"
             )
             raise SystemExit(1)
 
-        print(f"\n  Switching from '{branch}' to 'main' to pick up the release tag...")
+        print(
+            f"\n  Switching from '{current_branch}' to '{branch}' to pick up the new tag..."
+        )
         checkout = subprocess.run(
             # -B creates/resets a local `main` pointing at origin/main so this
             # works whether or not a local `main` already exists (e.g. a stale
             # master-only clone that has never had a main branch).
-            ["git", "checkout", "-B", "main", "origin/main"],
+            ["git", "checkout", "-B", branch, f"origin/{branch}"],
             cwd=repo_root,
             capture_output=True,
             text=True,
         )
         if checkout.returncode != 0:
             print(
-                f"\n  Failed to switch to main:\n  {checkout.stderr.strip()}\n"
-                "\n  Upgrade manually: git checkout main && git pull origin main && make install\n"
+                f"\n  Failed to switch to {branch}:\n  {checkout.stderr.strip()}\n"
+                f"\n  Upgrade manually: git checkout {branch} && git pull origin {branch} && make install\n"
             )
             raise SystemExit(1)
 
         # Repair the upstream so a later manual `git pull` consults
         # origin/main rather than a dangling branch.master.merge ref.
         subprocess.run(
-            ["git", "branch", "--set-upstream-to=origin/main", "main"],
+            ["git", "branch", f"--set-upstream-to=origin/{branch}", branch],
             cwd=repo_root,
             capture_output=True,
             text=True,
@@ -1123,7 +1133,8 @@ def _run_upgrade():
         # make install handles system deps and the CLI shim.
         # uv sync --reinstall-package forces setuptools-scm to regenerate the
         # version from the new tag so the version number updates correctly.
-        f"git pull origin main && git fetch --tags && make install && {uv} sync --reinstall-package hate_crack",
+        f"git pull origin {branch} && git fetch --tags && make install "
+        f"&& {uv} sync --reinstall-package hate_crack",
         shell=True,
         cwd=repo_root,
     )
@@ -4941,7 +4952,15 @@ def main():
         parser.add_argument(
             "--update",
             action="store_true",
-            help="Pull latest changes and reinstall (git pull && make clean && make && make install)",
+            help="Update to the latest release from main and reinstall",
+        )
+        parser.add_argument(
+            "--nightly",
+            action="store_true",
+            help=(
+                "Update to the latest nightly from nightly-dev instead of main. "
+                "Nightlies have passed CI but are not part of a cut release."
+            ),
         )
         parser.add_argument("--debug", action="store_true", help="Enable debug mode")
         parser.add_argument(
@@ -5145,8 +5164,10 @@ def main():
     maxruntime = config.maxruntime
     bandrelbasewords = config.bandrelbasewords
 
-    if args.update:
-        _run_upgrade()
+    if args.update or args.nightly:
+        # --nightly implies the upgrade action, so `--nightly` alone works and
+        # `--update --nightly` reads as "update, to the nightly channel".
+        _run_upgrade(branch="nightly-dev" if args.nightly else "main")
 
     if args.download_torrent:
         download_weakpass_torrent(

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -1,5 +1,6 @@
 """Tests for the startup version check feature."""
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -529,3 +530,140 @@ class TestRunUpgrade:
         assert mock_run.call_count == 4
         all_call_args = [c[0][0] for c in mock_run.call_args_list]
         assert ["git", "checkout", "-B", "main", "origin/main"] not in all_call_args
+
+
+class TestNightlyChannel:
+    """Tests for the --nightly update channel (_run_upgrade(branch=...))."""
+
+    def test_nightly_pulls_from_nightly_dev(self, hc_module, capsys):
+        git_root_proc = MagicMock(returncode=0, stdout="/fake/repo\n")
+        fetch_proc = MagicMock(returncode=0, stdout="", stderr="")
+        branch_proc = MagicMock(returncode=0, stdout="nightly-dev\n")
+        make_proc = MagicMock(returncode=0)
+
+        with patch(
+            "subprocess.run",
+            side_effect=[git_root_proc, fetch_proc, branch_proc, make_proc],
+        ) as mock_run, pytest.raises(SystemExit) as exc:
+            hc_module._run_upgrade(branch="nightly-dev")
+
+        assert exc.value.code == 0
+        make_cmd = mock_run.call_args_list[3][0][0]
+        assert "git pull origin nightly-dev" in make_cmd
+        assert "git pull origin main" not in make_cmd
+
+    def test_nightly_switches_from_main_to_nightly_dev(self, hc_module, capsys):
+        """The inverse of the main-channel switch: a user sitting on main who
+        asks for a nightly must be moved onto nightly-dev."""
+        git_root_proc = MagicMock(returncode=0, stdout="/fake/repo\n")
+        fetch_proc = MagicMock(returncode=0, stdout="", stderr="")
+        branch_proc = MagicMock(returncode=0, stdout="main\n")
+        status_proc = MagicMock(returncode=0, stdout="")
+        checkout_proc = MagicMock(returncode=0, stdout="", stderr="")
+        upstream_proc = MagicMock(returncode=0, stdout="", stderr="")
+        make_proc = MagicMock(returncode=0)
+
+        with patch(
+            "subprocess.run",
+            side_effect=[
+                git_root_proc,
+                fetch_proc,
+                branch_proc,
+                status_proc,
+                checkout_proc,
+                upstream_proc,
+                make_proc,
+            ],
+        ) as mock_run, pytest.raises(SystemExit) as exc:
+            hc_module._run_upgrade(branch="nightly-dev")
+
+        assert exc.value.code == 0
+        all_calls = [c[0][0] for c in mock_run.call_args_list]
+        assert [
+            "git",
+            "checkout",
+            "-B",
+            "nightly-dev",
+            "origin/nightly-dev",
+        ] in all_calls
+        assert [
+            "git",
+            "branch",
+            "--set-upstream-to=origin/nightly-dev",
+            "nightly-dev",
+        ] in all_calls
+        assert "Switching from 'main' to 'nightly-dev'" in capsys.readouterr().out
+
+    def test_default_branch_is_still_main(self, hc_module):
+        """--update must keep pulling releases from main."""
+        git_root_proc = MagicMock(returncode=0, stdout="/fake/repo\n")
+        fetch_proc = MagicMock(returncode=0, stdout="", stderr="")
+        branch_proc = MagicMock(returncode=0, stdout="main\n")
+        make_proc = MagicMock(returncode=0)
+
+        with patch(
+            "subprocess.run",
+            side_effect=[git_root_proc, fetch_proc, branch_proc, make_proc],
+        ) as mock_run, pytest.raises(SystemExit):
+            hc_module._run_upgrade()
+
+        assert "git pull origin main" in mock_run.call_args_list[3][0][0]
+
+    def test_uncommitted_changes_message_names_target_branch(
+        self, hc_module, capsys
+    ):
+        git_root_proc = MagicMock(returncode=0, stdout="/fake/repo\n")
+        fetch_proc = MagicMock(returncode=0, stdout="", stderr="")
+        branch_proc = MagicMock(returncode=0, stdout="main\n")
+        status_proc = MagicMock(returncode=0, stdout=" M hate_crack/main.py\n")
+
+        with patch(
+            "subprocess.run",
+            side_effect=[git_root_proc, fetch_proc, branch_proc, status_proc],
+        ), pytest.raises(SystemExit) as exc:
+            hc_module._run_upgrade(branch="nightly-dev")
+
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "uncommitted changes on 'main'" in out
+        assert "git checkout nightly-dev" in out
+
+
+class TestNightlyFlagWiring:
+    """The --nightly CLI flag routes to the nightly channel."""
+
+    @pytest.mark.parametrize(
+        ("argv", "expected_branch"),
+        [
+            (["--update"], "main"),
+            (["--nightly"], "nightly-dev"),
+            # Reads as "update, to the nightly channel".
+            (["--update", "--nightly"], "nightly-dev"),
+        ],
+    )
+    def test_flag_selects_channel(self, hc_module, monkeypatch, argv, expected_branch):
+        calls = []
+
+        def fake_upgrade(branch="main"):
+            calls.append(branch)
+            # The real _run_upgrade always exits; without this main() would
+            # fall through into the interactive menu and hang on input().
+            raise SystemExit(0)
+
+        monkeypatch.setattr(hc_module, "_run_upgrade", fake_upgrade)
+        monkeypatch.setattr(sys, "argv", ["hate_crack.py", *argv])
+        try:
+            hc_module.main()
+        except SystemExit:
+            pass
+        assert calls == [expected_branch]
+
+    def test_startup_check_never_offers_nightly(self, hc_module):
+        """check_for_updates() reads /releases/latest, which excludes
+        pre-releases -- and nightly-tag.yml publishes no release at all, so the
+        nightly channel is invisible to the startup nag by construction."""
+        import inspect
+
+        src = inspect.getsource(hc_module.check_for_updates)
+        assert "releases/latest" in src
+        assert "nightly" not in src


### PR DESCRIPTION
## Verification requested first: is `--update` release-only?

**Yes — confirmed on three independent levels.** `--update` cannot pull a nightly, before or after this change:

1. **`check_for_updates()`** queries `https://api.github.com/repos/trustedsec/hate_crack/releases/latest`. I hit that endpoint live: it returns `v2.16.0`, `prerelease: false`. The full releases list contains only `v2.16.0`, `v2.15.1`, `v2.15.0`, `v2.14.9` — **no `v2.17.0-rc.1`**, because `nightly-tag.yml` creates tags without GitHub releases.
2. **GitHub's `/releases/latest` excludes pre-releases by definition**, so even if a nightly did publish one, the startup check would skip it.
3. **`_run_upgrade()` hardcoded `main`** — `git checkout -B main origin/main`, `git pull origin main`, `--set-upstream-to=origin/main`. It could only ever land on `main`.

Point 3 had a side effect worth naming: a user sitting on `nightly-dev` who ran `--update` got silently yanked back to `main`. That's correct for the release channel, but it meant there was no way to stay on nightly — which is what this PR fixes.

## What this adds

`_run_upgrade(branch="main")` is now parameterized. `main` was hardcoded in six places: the checkout, the pull, the upstream repair, and three manual-recovery messages. All now follow the argument, so the fallback instructions printed on failure name the branch you actually asked for.

- `--nightly` — update from `nightly-dev`
- `--update --nightly` — same thing, reads naturally as "update, to the nightly channel"
- `--update` — unchanged, still `main`

Both still switch branches first and still refuse when the working tree is dirty. `--update` remains the way back from a nightly to released code.

## Testing

8 new tests (1179 passed, 29 skipped overall):

- nightly pulls `origin/nightly-dev`, and specifically **not** `origin/main`
- the inverse branch switch (on `main`, asked for nightly → `checkout -B nightly-dev origin/nightly-dev` plus matching upstream repair)
- `--update` default is still `main` — a regression guard on the whole point of this PR
- the dirty-tree refusal names the target branch in its recovery hint
- flag wiring parametrized across `--update`, `--nightly`, and both together
- a guard asserting `check_for_updates` still reads `/releases/latest` and mentions no nightly, so the startup nag can't drift onto the pre-release channel

Note for reviewers: `tests/test_version_check.py` defines its own `hc_module` fixture that returns `hate_crack.main` directly, unlike the conftest fixture which returns the root `hate_crack.py` wrapper. The new tests follow the local convention. The fake `_run_upgrade` raises `SystemExit` like the real one, otherwise `main()` falls through into the interactive menu and hangs on `input()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)