### PR TITLE
docs(changelog): cut 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
-## [Unreleased]
+## [2.17.0] - 2026-07-29
 
 ### Added
 


### PR DESCRIPTION
Renames the `[Unreleased]` CHANGELOG section to `[2.17.0] - 2026-07-29` ahead of the weekly integration merge into `main`.

A `feat:` commit is present since v2.16.0, so auto-tag will compute a minor bump to v2.17.0.

Suite: 1179 passed, 29 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)