### PR TITLE
chore(deps): consolidate open dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,19 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # atomic-agents pins instructor==1.14.5 exactly and imports its internals
+    # (instructor.core.client, instructor.processing.multimodal,
+    # instructor.dsl.partial, instructor.processing.schema), all of which
+    # 1.15.x reorganized. Bumping is unsatisfiable, and forcing it with an
+    # override resolves but then fails at import with
+    # "module 'instructor' has no attribute 'core'".
+    #
+    # REMOVE THIS as soon as atomic-agents relaxes the pin: check with
+    #   curl -s https://pypi.org/pypi/atomic-agents/json \
+    #     | python3 -c "import json,sys;print([r for r in json.load(sys.stdin)['info']['requires_dist'] if 'instructor' in r])"
+    # Until then Dependabot would re-open the same unmergeable PR weekly.
+    ignore:
+      - dependency-name: "instructor"
     # "chore" deliberately does NOT match the feat|fix|perf patterns in
     # .github/workflows/auto-tag.yml, so dependency PRs never auto-cut a tag.
     commit-message:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "requests>=2.34.2",
-    "openpyxl>=3.0.0",
+    "openpyxl>=3.1.5",
     "packaging>=26.2",
     "simple-term-menu==1.6.6",
     "click>=8.4.2",
@@ -18,7 +18,7 @@ dependencies = [
     # Imported directly by hate_crack/llm.py; declared explicitly rather than
     # relying on atomic-agents pulling them in transitively.
     "instructor>=1.14.5",
-    "openai>=2.49.0",
+    "openai>=2.50.0",
     "pydantic>=2.13.4",
 ]
 


### PR DESCRIPTION
Consolidates the three open Dependabot PRs into one.

| PR | Dependency | Outcome |
|----|-----------|---------|
| #178 | openai `>=2.49.0` -> `>=2.50.0` | bumped |
| #179 | openpyxl `>=3.0.0` -> `>=3.1.5` | bumped |
| #141 | instructor `>=1.14.5` -> `>=1.15.4` | **declined**, ignore rule added |

## Why #141 is declined rather than bumped

`atomic-agents` 2.9.1 (latest, 2026-07-13) declares `instructor==1.14.5` — an
exact pin — so `instructor>=1.15.4` is unsatisfiable. Forcing it with
`[tool.uv] override-dependencies` resolves, then fails at import:

```
AttributeError: module 'instructor' has no attribute 'core'
```

`atomic-agents` imports instructor internals (`instructor.core.client`,
`instructor.processing.multimodal`, `instructor.dsl.partial`,
`instructor.processing.schema`) that 1.15.x reorganized, so an override would
break the LLM attack. `instructor` 1.14.5 carries no known advisory — pip-audit
is green with it.

The `ignore` entry stops Dependabot re-opening the same unmergeable PR every
week. It carries a comment with the one-liner to check when the upstream pin
lifts, at which point the entry should be removed.

## Testing

- `openpyxl 3.1.5` and `openai 2.50.0` confirmed installed after `uv sync`
- `HATE_CRACK_SKIP_INIT=1 uv run pytest -q` -> 1179 passed, 29 skipped (unchanged)
- `ruff check` / `ruff format --check` clean on `hate_crack`
- `dependabot.yml` re-parsed to confirm `ignore` nested under the `uv` entry only

## Trade-off

Bundling three dependency changes means a revert reverts all of them. Accepted
here because the two bumps are independent no-ops in the test suite and the
third changes no installed version at all.