### PR TITLE
docs(changelog): document dep floor bumps and instructor ignore policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,17 @@ updates:
     #   curl -s https://pypi.org/pypi/atomic-agents/json \
     #     | python3 -c "import json,sys;print([r for r in json.load(sys.stdin)['info']['requires_dist'] if 'instructor' in r])"
     # Until then Dependabot would re-open the same unmergeable PR weekly.
+    #
+    # This entry has no versions/update-types qualifier, so it suppresses
+    # ALL update types for instructor, including security updates, not just
+    # routine version bumps. That is intentional and should not be narrowed
+    # with update-types: the pin is exact (==1.14.5), so even a patch bump
+    # is equally unsatisfiable and Dependabot would just open a different
+    # unmergeable PR. The backstop for a vulnerable instructor is pip-audit,
+    # which runs in .github/workflows/ci.yml and will fail CI if a flagged
+    # version is ever resolved. If pip-audit flags instructor, fix it by
+    # addressing the atomic-agents pin (upstream fix, or pinning around it)
+    # — not by relaxing this ignore entry.
     ignore:
       - dependency-name: "instructor"
     # "chore" deliberately does NOT match the feat|fix|perf patterns in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Changed
+
+- **Dependency floors raised.** `openai` >=2.50.0, `openpyxl` >=3.1.5,
+  consolidating #178 and #179. (#180)
+- **`instructor` excluded from Dependabot as a durable policy, not a
+  temporary skip.** `atomic-agents` 2.9.1 pins `instructor==1.14.5` exactly
+  and imports internals (`instructor.core.client`,
+  `instructor.processing.multimodal`, `instructor.dsl.partial`,
+  `instructor.processing.schema`) that `instructor` 1.15.x reorganized.
+  Forcing the bump with an override resolves but fails at import with
+  `AttributeError: module 'instructor' has no attribute 'core'`, so the
+  `.github/dependabot.yml` `ignore` entry stays until `atomic-agents`
+  relaxes its pin. (#141)
+
 ## [2.17.0] - 2026-07-29
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds an `[Unreleased]` CHANGELOG section documenting the raised `openai`/`openpyxl` floors (#178, #179, landed in #180) and the durable `instructor` Dependabot ignore policy (resolves #141).
- Extends the `.github/dependabot.yml` comment above `ignore:` to clarify it suppresses security updates too, names pip-audit as the backstop, and states the ignore should not be narrowed with `update-types`.

## Test plan
- [x] `uv run --with pyyaml python -c "..."` confirms `ignore` still nested only under the `uv` ecosystem entry
- [x] `HATE_CRACK_SKIP_INIT=1 uv run pytest -q` → 1179 passed, 29 skipped