### PR TITLE
docs(changelog): cut 2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
-## [Unreleased]
+## [2.17.1] - 2026-07-29
 
 ### Changed
 


### PR DESCRIPTION
Promotes `[Unreleased]` to `[2.17.1] - 2026-07-29` ahead of the weekly `nightly-dev` → `main` integration merge.

**Patch, not minor.** The three commits since `v2.17.0` are all chore/docs — the dependency floor bumps (#180), the instructor ignore policy documentation (#181), and a pytest dev-dependency bump (#182). No feature or fix work.

**Note for whoever merges the integration PR:** `auto-tag.yml` will **skip** it. I ran its bump logic against this commit range and it returns `bump = none`, because it only recognizes `feat|fix|perf` subjects and breaking-change markers. So `v2.17.1` has to be tagged by hand after the merge — the same situation as `v2.16.0`, which `refactor:` caused auto-tag to skip.

## Testing

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)