### PR TITLE
release: integrate nightly-dev for week of 2026-07-29 (v2.17.1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,17 @@ updates:
     #   curl -s https://pypi.org/pypi/atomic-agents/json \
     #     | python3 -c "import json,sys;print([r for r in json.load(sys.stdin)['info']['requires_dist'] if 'instructor' in r])"
     # Until then Dependabot would re-open the same unmergeable PR weekly.
+    #
+    # This entry has no versions/update-types qualifier, so it suppresses
+    # ALL update types for instructor, including security updates, not just
+    # routine version bumps. That is intentional and should not be narrowed
+    # with update-types: the pin is exact (==1.14.5), so even a patch bump
+    # is equally unsatisfiable and Dependabot would just open a different
+    # unmergeable PR. The backstop for a vulnerable instructor is pip-audit,
+    # which runs in .github/workflows/ci.yml and will fail CI if a flagged
+    # version is ever resolved. If pip-audit flags instructor, fix it by
+    # addressing the atomic-agents pin (upstream fix, or pinning around it)
+    # — not by relaxing this ignore entry.
     ignore:
       - dependency-name: "instructor"
     # "chore" deliberately does NOT match the feat|fix|perf patterns in

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,19 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # atomic-agents pins instructor==1.14.5 exactly and imports its internals
+    # (instructor.core.client, instructor.processing.multimodal,
+    # instructor.dsl.partial, instructor.processing.schema), all of which
+    # 1.15.x reorganized. Bumping is unsatisfiable, and forcing it with an
+    # override resolves but then fails at import with
+    # "module 'instructor' has no attribute 'core'".
+    #
+    # REMOVE THIS as soon as atomic-agents relaxes the pin: check with
+    #   curl -s https://pypi.org/pypi/atomic-agents/json \
+    #     | python3 -c "import json,sys;print([r for r in json.load(sys.stdin)['info']['requires_dist'] if 'instructor' in r])"
+    # Until then Dependabot would re-open the same unmergeable PR weekly.
+    ignore:
+      - dependency-name: "instructor"
     # "chore" deliberately does NOT match the feat|fix|perf patterns in
     # .github/workflows/auto-tag.yml, so dependency PRs never auto-cut a tag.
     commit-message:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
-## [Unreleased]
+## [2.17.1] - 2026-07-29
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Changed
+
+- **Dependency floors raised.** `openai` >=2.50.0, `openpyxl` >=3.1.5,
+  consolidating #178 and #179. (#180)
+- **`instructor` excluded from Dependabot as a durable policy, not a
+  temporary skip.** `atomic-agents` 2.9.1 pins `instructor==1.14.5` exactly
+  and imports internals (`instructor.core.client`,
+  `instructor.processing.multimodal`, `instructor.dsl.partial`,
+  `instructor.processing.schema`) that `instructor` 1.15.x reorganized.
+  Forcing the bump with an override resolves but fails at import with
+  `AttributeError: module 'instructor' has no attribute 'core'`, so the
+  `.github/dependabot.yml` `ignore` entry stays until `atomic-agents`
+  relaxes its pin. (#141)
+
 ## [2.17.0] - 2026-07-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ testpaths = [
 dev = [
     "ty==0.0.64",
     "ruff==0.16.0",
-    "pytest==9.0.3",
+    "pytest==9.1.1",
     "pytest-cov==7.1.0",
     "pytest-timeout>=2.4.0",
     "pexpect>=4.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "requests>=2.34.2",
-    "openpyxl>=3.0.0",
+    "openpyxl>=3.1.5",
     "packaging>=26.2",
     "simple-term-menu==1.6.6",
     "click>=8.4.2",
@@ -18,7 +18,7 @@ dependencies = [
     # Imported directly by hate_crack/llm.py; declared explicitly rather than
     # relying on atomic-agents pulling them in transitively.
     "instructor>=1.14.5",
-    "openai>=2.49.0",
+    "openai>=2.50.0",
     "pydantic>=2.13.4",
 ]
 


### PR DESCRIPTION
Weekly integration merge of `nightly-dev` into `main`, cutting **v2.17.1**.

## Contents

| PR | Change |
|----|--------|
| #180 | Consolidated the three open Dependabot PRs: `openai>=2.50.0`, `openpyxl>=3.1.5`, and a Dependabot `ignore` for `instructor` (unsatisfiable — `atomic-agents` pins it exactly) |
| #181 | Documented the dependency floors and the instructor ignore as a durable policy, including that it suppresses security updates and that `pip-audit` is the backstop |
| #182 | pytest dev-dependency bump 9.0.3 → 9.1.1 |
| #183 | Promoted `[Unreleased]` to `[2.17.1] - 2026-07-29` |

## Patch release, and auto-tag will skip this

All four commits are chore/docs — no feature or fix work — so `auto-tag.yml` returns `bump = none` and **will not cut a tag**. I ran its bump logic against this exact commit range to confirm. `v2.17.1` will be tagged by hand after this merges, the same way `v2.16.0` was when a `refactor:` subject caused the same skip.

## Testing

- Full suite on the merged `nightly-dev` tip: **1179 passed, 29 skipped**
- pytest 9.1.1 confirmed actually resolved, with no collection or deprecation fallout
- Post-merge state verified to still carry everything from #180/#181 (#182 branched from a stale base, so this was checked explicitly rather than assumed)

**Known flake, unrelated:** `tests/test_notify_tailer.py::TestCrackTailerBurstCap` failed once on #183's first CI run. It is timing-based (`_wait_until` polling a background tailer thread), #183 was documentation-only, the class passes 10/10 consecutively locally, and a re-run of the identical commit went green. This is its second occurrence — it deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)