### PR TITLE
fix(spoonman): store derived wordlist beside the hash file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Changed
+
+- **Spoonman Attack output is now ephemeral.** Derived basewords and rules are
+  written to `<hash file>.spoonman/` beside the hash file, matching the other
+  ephemeral wordlists (`.expanded`, `.combined`), instead of persisting under
+  `<hcatOptimizedWordlists>/spoonman/<corpus name>/`. The directory is removed
+  by the temp-file cleanup on exit. Derivation is still skipped when the corpus
+  has not changed since a prior run against the same hash file. This also
+  removes the collision between two different corpora that share a filename.
+
 ## [2.17.1] - 2026-07-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1022,7 +1022,7 @@ Each password is split into its letters-only lowercased core (the baseword) plus
 
 * Prompts for the corpus, then for how much of the rule file to run: the full set, top 99%, or top 95%
 * Rules are sorted by how many passwords each one rebuilds, so a truncated file keeps the most productive rules — top 95% coverage typically needs a small fraction of the rules
-* Output is cached under `<hcatOptimizedWordlists>/spoonman/<corpus name>/`: `basewords.txt`, `rules.full.rule`, the capped rule files, and `coverage.txt` with per-milestone rule counts. Derivation is skipped on later runs unless the corpus has been modified since
+* Output is written beside the hash file in `<hash file>.spoonman/`, alongside the other ephemeral wordlists: `basewords.txt`, `rules.full.rule`, the capped rule files, and `coverage.txt` with per-milestone rule counts. Derivation is skipped on later runs of the same hash file unless the corpus has been modified since, and the directory is removed on exit by the temp-file cleanup
 * Passwords that cannot be expressed as a rule are written verbatim as their own baseword with a `:` no-op, so coverage stays complete. This covers two hashcat limits: rule positions cannot address past index 35, and hashcat rejects any rule with more than 31 functions — silently, when valid rules share the file
 * The derivation self-checks every password by reconstructing it in-process, and reports any failures rather than reporting success
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2944,13 +2944,10 @@ def hcatSpoonman(hcatHashType, hcatHashFile, corpus, coverage=None):
         print(f"Error: corpus not found: {corpus}")
         return
 
-    cache_dir = os.path.join(
-        hcatOptimizedWordlists
-        if isinstance(hcatOptimizedWordlists, str)
-        else str(hcatOptimizedWordlists),
-        "spoonman",
-        os.path.basename(corpus),
-    )
+    # Derived basewords/rules are per-run scratch, so they live beside the hash
+    # file like the other ephemeral wordlists (.expanded, .combined) and are
+    # removed by cleanup().
+    cache_dir = f"{hcatHashFile}.spoonman"
     # Deriving is O(corpus), so reuse a previous run's output unless the corpus
     # has changed since. Mirrors the staleness check in hcatPrinceLing.
     basewords_path = os.path.join(cache_dir, "basewords.txt")
@@ -3434,6 +3431,8 @@ def cleanup():
             os.remove(hcatHashFile + ".working")
         if os.path.exists(hcatHashFile + ".expanded"):
             os.remove(hcatHashFile + ".expanded")
+        if os.path.isdir(hcatHashFile + ".spoonman"):
+            shutil.rmtree(hcatHashFile + ".spoonman", ignore_errors=True)
         if os.path.exists(hcatHashFileOrig + ".combined"):
             os.remove(hcatHashFileOrig + ".combined")
         if os.path.exists(hcatHashFileOrig + ".lm"):

--- a/tests/test_main_spoonman.py
+++ b/tests/test_main_spoonman.py
@@ -21,10 +21,14 @@ def corpus(tmp_path):
 
 
 class TestHcatSpoonman:
+    def _hash_file(self, tmp_path):
+        return str(tmp_path / "hashes.txt")
+
     def _run(self, main_module, tmp_path, corpus, monkeypatch, **kwargs):
-        monkeypatch.setattr(main_module, "hcatOptimizedWordlists", str(tmp_path / "opt"))
         with patch.object(main_module, "hcatQuickDictionary") as quick:
-            main_module.hcatSpoonman("1000", "hashes.txt", corpus, **kwargs)
+            main_module.hcatSpoonman(
+                "1000", self._hash_file(tmp_path), corpus, **kwargs
+            )
         return quick
 
     def test_derives_then_delegates_to_quick_dictionary(
@@ -35,7 +39,7 @@ class TestHcatSpoonman:
         quick.assert_called_once()
         args, kwargs = quick.call_args
         assert args[0] == "1000"
-        assert args[1] == "hashes.txt"
+        assert args[1] == self._hash_file(tmp_path)
         assert args[2].startswith("-r ")
         assert args[2].endswith("rules.full.rule")
         assert args[3].endswith("basewords.txt")
@@ -48,11 +52,27 @@ class TestHcatSpoonman:
         quick = self._run(main_module, tmp_path, corpus, monkeypatch, coverage=95)
         assert quick.call_args[0][2].endswith("rules.top95.rule")
 
-    def test_cache_dir_is_namespaced_per_corpus(
+    def test_output_lives_beside_the_hash_file(
         self, main_module, tmp_path, corpus, monkeypatch
     ):
         quick = self._run(main_module, tmp_path, corpus, monkeypatch)
-        assert os.path.join("spoonman", "cracked.txt") in quick.call_args[0][3]
+        expected_dir = self._hash_file(tmp_path) + ".spoonman"
+        assert os.path.dirname(quick.call_args[0][3]) == expected_dir
+        assert os.path.isdir(expected_dir)
+
+    def test_cleanup_removes_derived_output(
+        self, main_module, tmp_path, corpus, monkeypatch
+    ):
+        hash_file = self._hash_file(tmp_path)
+        self._run(main_module, tmp_path, corpus, monkeypatch)
+        assert os.path.isdir(hash_file + ".spoonman")
+
+        monkeypatch.setattr(main_module, "hcatHashFile", hash_file, raising=False)
+        monkeypatch.setattr(main_module, "hcatHashFileOrig", hash_file, raising=False)
+        monkeypatch.setattr(main_module, "hcatHashType", "1000", raising=False)
+        monkeypatch.setattr(main_module, "pwdump_format", False, raising=False)
+        main_module.cleanup()
+        assert not os.path.exists(hash_file + ".spoonman")
 
     def test_missing_corpus_reports_and_does_not_run_hashcat(
         self, main_module, tmp_path, monkeypatch, capsys


### PR DESCRIPTION
## What

Spoonman Attack output (`basewords.txt`, `rules.*.rule`, `coverage.txt`) was
persisted under `<hcatOptimizedWordlists>/spoonman/<corpus name>/`. It is now
written to `<hash file>.spoonman/` beside the hash file, matching the other
ephemeral wordlists (`.expanded`, `.combined`), and removed by `cleanup()` on
exit.

## Why

- The output is per-run scratch, not a curated wordlist, so it does not belong
  in the optimized-wordlists tree where it accumulated across engagements.
- The old cache dir was keyed on `os.path.basename(corpus)`, so two different
  corpora with the same filename shared — and clobbered — one directory.

The corpus-mtime staleness check is unchanged; a rerun against the same hash
file still skips derivation.

## Testing

- `HATE_CRACK_SKIP_INIT=1 uv run pytest -q` → 1180 passed, 29 skipped
- bandit baseline gate clean
- `test_main_spoonman.py` updated: the per-corpus namespacing test is replaced
  by one asserting output lands beside the hash file, plus a new test that
  `cleanup()` removes the directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)