### PR TITLE
chore: gitignore config.json backups (untracked live API keys)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
 config.json
+# Timestamped/editor backups of config.json carry the same populated API keys as
+# config.json itself. Only the exact name was ignored, so a `git add -A` in a
+# checkout holding one would have staged live credentials into a public repo.
+config.json.bak*
+config.json.*.bak
+config.json.orig
+config.json.save
+config.json~
+# Playwright MCP scratch output (console logs, traces, screenshots).
+.playwright-mcp/
 hashcat.pot
 hate_crack/__init__.pyc
 hate_crack/_version.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+### Security
+
+- **`config.json` backups are now gitignored.** Only the exact name
+  `config.json` was ignored, so a timestamped or editor backup
+  (`config.json.bak-<date>`, `config.json.orig`, `config.json~`) sat untracked
+  but stageable in a checkout while holding the same populated
+  `hashview_api_key` / `hashmob_api_key` values as the live config. Since this
+  is a public repo and CI has no secret scanning, a `git add -A` was the only
+  step between a local backup and published credentials. `.playwright-mcp/`
+  scratch output is ignored for the same reason.
+
 ### Changed
 
 - **CI now lints and format-checks `tests/` alongside `hate_crack/`.** The ruff


### PR DESCRIPTION
Found while cleaning up the working tree after #189/#190.

`.gitignore` listed only the exact name `config.json`. My local checkout had a `config.json.bak-20260728` — untracked, but **not ignored**, so it appeared in `git status` as stageable. It contains the same populated `hashview_api_key` and `hashmob_api_key` as the live config.

This repo is public and CI has no secret scanning. The prek `detect-private-key` hook is the only gate anywhere in the pipeline, and it matches PEM-style key blocks, not API key material. So `git add -A` in a checkout holding such a backup was the only step between a local file and published credentials — the same class of problem as the credential purge on 2026-07-27.

Adds the common backup suffixes (`config.json.bak*`, `config.json.*.bak`, `.orig`, `.save`, `~`) and `.playwright-mcp/` scratch output.

## Verification

`git check-ignore` confirms all five backup shapes and `.playwright-mcp/console.log` are matched, and that `config.json.example` is **not** ignored (it must stay tracked — the config auto-creation path depends on it).

No existing tracked file matches the new patterns, so nothing is dropped from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)