### PR TITLE
feat(llm): add LLM Pattern Rules attack mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Added
+
+- **LLM Pattern Rules mode** (option 4 in the LLM Attack submenu). Mirrors the
+  Spoonman Attack's shape — a baseword list run through hashcat rules — but
+  infers the basewords rather than extracting them. Spoonman's `rulegen` is
+  lossless and therefore literal: it can only emit cores that already appear in
+  its corpus. This mode instead asks the local model to identify the word
+  families behind a sample (company and products, site names, local teams,
+  seasons, mascots) and enumerate members the sample does not contain, then runs
+  those basewords against rule file(s) chosen from the rules directory. The
+  pattern source is either the session's cracked passwords or a sample wordlist;
+  model output is normalized to lowercase letters only, since the rules supply
+  case, digits, and punctuation. Basewords land in `<hashfile>.llm_patterns`,
+  which `cleanup()` removes on exit.
+
 ## [2.17.2] - 2026-07-29
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -924,6 +924,13 @@ Uses a local Ollama instance to generate password candidates for a capture-the-f
 * Alternatively derives basewords from a sample **wordlist**, or from the **cracked passwords** of the current session (`<hashfile>.out`) so the model mirrors the target organization's own password conventions and produces new candidates in that style (only offered once something has been cracked)
 * A live spinner with an elapsed-seconds counter runs during generation, and requests are bounded by `ollamaTimeout` so a model stuck loading into VRAM reports a timeout instead of hanging
 
+**Pattern rules mode** (option 4 in the LLM submenu) takes the same shape as the [Spoonman Attack](#spoonman-attack) — a baseword list run through hashcat rules — but infers the basewords instead of extracting them. Spoonman can only produce cores that already appear in its corpus; this asks the model to name the *word families* behind a sample (the company and its products, site names, local sports teams, seasons, mascots) and enumerate members the sample does not contain.
+
+* Pattern source is either the current session's cracked passwords (offered first, and only once something has been cracked, since those reveal the target's real conventions) or a sample wordlist
+* Prompts for rule file(s) from the rules directory using the standard rule picker, including chained rules (`1+2`) and YOLO (all rules); each selected chain runs as its own pass
+* Model output is normalized to lowercase letters only, discarding anything under 3 characters — the rules supply case, digits, and punctuation, so an undecorated baseword avoids being decorated twice
+* Inferred basewords are written to `<hashfile>.llm_patterns`, which is per-run scratch and removed on exit
+
 #### OMEN Attack
 Uses the Ordered Markov ENumerator (OMEN) to train a statistical password model from a wordlist and generate password candidates. This attack learns patterns from known passwords and generates new candidates based on those patterns.
 

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -601,6 +601,36 @@ def _prompt_with_default(label: str, default: Any) -> str:
     return input(f"{label}: ").strip()
 
 
+def _pick_pattern_source(ctx: Any, cracked_path: str | None):
+    """Pick the corpus the LLM infers patterns from. Returns a path or None.
+
+    Cracked passwords are offered first and only when *cracked_path* is set,
+    because plaintexts already recovered from this target reveal its real
+    conventions — a generic wordlist only reveals the internet's.
+    """
+    if cracked_path:
+        items = [
+            ("1", "Cracked passwords (current session)"),
+            ("2", "Sample wordlist"),
+            ("99", "Cancel"),
+        ]
+        while True:
+            choice = interactive_menu(
+                items,
+                title="\nLLM Pattern Rules — pattern source",
+                prompt="\n\tSelect source: ",
+            )
+            if choice is None or choice == "99":
+                return None
+            if choice == "1":
+                return cracked_path
+            if choice == "2":
+                break
+            print("\t[!] Invalid selection.")
+
+    return _pick_training_wordlist(ctx, title="LLM Pattern Source Wordlists")
+
+
 def ollama_attack(ctx: Any) -> None:
     _notify.prompt_notify_for_attack("LLM")
     # Cracked-password mode is only offered when this session actually has
@@ -614,6 +644,9 @@ def ollama_attack(ctx: Any) -> None:
     ]
     if has_cracked:
         items.append(("3", "Cracked passwords (current session)"))
+    # Deliberately "4" whether or not "3" was offered: renumbering it per
+    # session would move the option under an operator between runs.
+    items.append(("4", "Pattern rules (LLM finds patterns, hashcat rules mutate them)"))
     items.append(("99", "Cancel"))
 
     while True:
@@ -642,6 +675,19 @@ def ollama_attack(ctx: Any) -> None:
             return
         elif choice == "3" and has_cracked:
             ctx.hcatOllama(ctx.hcatHashType, ctx.hcatHashFile, "cracked", out_path)
+            return
+        elif choice == "4":
+            source = _pick_pattern_source(ctx, out_path if has_cracked else None)
+            if not source:
+                return
+            selected_rules = _select_rules(ctx)
+            if selected_rules is None:
+                return
+            # All chains are handed over at once so the model is queried once
+            # rather than once per rule file — see hcatOllamaPatterns.
+            ctx.hcatOllamaPatterns(
+                ctx.hcatHashType, ctx.hcatHashFile, source, selected_rules
+            )
             return
         else:
             # Without this the menu just silently redraws and the user cannot

--- a/hate_crack/llm.py
+++ b/hate_crack/llm.py
@@ -157,10 +157,43 @@ _CRACKED_PROMPT = SystemPromptGenerator(
     ],
 )
 
+_PATTERN_PROMPT = SystemPromptGenerator(
+    background=[
+        "You are a security professional working an authorized penetration test.",
+        "The sample passwords you are shown come from the target environment, so "
+        "the words behind them reveal what that organization's users draw on when "
+        "they invent a password.",
+        "Your output is a baseword list. A separate hashcat rule file will supply "
+        "all of the capitalization, digits, years, separators, suffixes, and "
+        "leetspeak — so decorating a baseword yourself only wastes a slot.",
+    ],
+    steps=[
+        "Strip each sample password down to the word or words behind it, ignoring "
+        "case, digits, and punctuation.",
+        "Group those words into the semantic families they belong to: the company "
+        "and its products, site or department names, local sports teams and city "
+        "names, seasons and months, hobbies, mascots, keyboard walks.",
+        "For every family you identify, list more members of that family than the "
+        "sample actually contains — the point is to predict the words other users "
+        "at this organization chose, not to echo the ones already recovered.",
+    ],
+    output_instructions=[
+        "Return lowercase letters only. No digits, punctuation, spaces, or "
+        "capitals anywhere in a baseword — the rules add those.",
+        "One baseword per list entry. Multi-word basewords run together, e.g. "
+        "'acmewidgets', not 'acme widgets'.",
+        "Skip generic filler such as 'password', 'welcome', 'letmein', and "
+        "'qwerty'. Stock wordlists already cover those, so they crowd out the "
+        "organization-specific guesses that make this list worth running.",
+        "Do not include explanations, numbering, or duplicate entries.",
+    ],
+)
+
 _PROMPTS = {
     "target": _TARGET_PROMPT,
     "wordlist": _WORDLIST_PROMPT,
     "cracked": _CRACKED_PROMPT,
+    "pattern": _PATTERN_PROMPT,
 }
 
 
@@ -181,6 +214,15 @@ def _build_request(mode: str, context_data: dict) -> str:
         return (
             "Here are sample passwords. Study their patterns and generate basewords "
             "for a denylist:\n" + sample
+        )
+    if mode == "pattern":
+        sample = context_data.get("sample", "")
+        return (
+            "Here is a sample of passwords from the target environment. Identify "
+            "the semantic families of words behind them, then return as many "
+            "lowercase letters-only basewords from those families as you can, "
+            "including words the sample does not contain. Hashcat rules will "
+            "mutate these, so add no digits, capitals, or punctuation:\n" + sample
         )
     if mode == "cracked":
         sample = context_data.get("sample", "")

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2356,6 +2356,128 @@ def hcatOllama(hcatHashType, hcatHashFile, mode, context_data):
             return
 
 
+MIN_PATTERN_LEN = 3
+
+
+def _clean_pattern(raw):
+    """Reduce one model-returned pattern to a bare lowercase baseword.
+
+    Returns "" for anything unusable. The prompt asks for lowercase letters
+    only, but the rule file is what supplies case, digits, and punctuation — so
+    a model that decorates its answer anyway would otherwise get decorated a
+    second time by the rules, producing candidates like "Summer2024!123". The
+    filter is applied here rather than trusted to the prompt for that reason.
+    """
+    if not isinstance(raw, str):
+        return ""
+    letters = "".join(c for c in raw.lower() if "a" <= c <= "z")
+    if len(letters) < MIN_PATTERN_LEN:
+        return ""
+    return letters
+
+
+def hcatOllamaPatterns(hcatHashType, hcatHashFile, source_path, rule_chains=""):
+    """LLM Pattern Rules: infer pattern basewords from a corpus, then apply rules.
+
+    The Spoonman attack (see hcatSpoonman and hate_crack/rulegen.py) extracts
+    basewords mechanically, so it can only ever produce cores that already
+    appear in the corpus. This asks the model to generalize instead — to name
+    the word families behind the sample and enumerate members the sample does
+    not contain — and then subjects those basewords to *rule_chains*.
+
+    *rule_chains* is one already-formatted hashcat rule argument (such as
+    "-r best64.rule", or "" for no rules) as produced by
+    attacks._select_rules, or a list of them. Inference happens once and every
+    chain runs against the same baseword file: unlike the local generators the
+    other multi-chain attacks use, a round trip to the model costs tens of
+    seconds and is not deterministic, so inferring per chain would both stall
+    the run and change the basewords underneath it between passes.
+    """
+    if not os.path.isfile(source_path):
+        print(f"Error: pattern source not found: {source_path}")
+        return
+
+    sampled = _sample_plaintext_file(
+        source_path, ollamaMaxSampleLines, source_label="pattern source"
+    )
+    if sampled is None:
+        return
+    if not sampled:
+        print(f"Error: no passwords read from {source_path}.")
+        return
+
+    try:
+        with spinner(f"Inferring password patterns via Ollama ({ollamaModel})..."):
+            raw_patterns = llm.generate_candidates(
+                ollamaUrl,
+                ollamaModel,
+                ollamaNumCtx,
+                "pattern",
+                {"sample": "\n".join(sampled)},
+                timeout=ollamaTimeout,
+            )
+    except llm.LLMTimeoutError:
+        print(f"Error: the Ollama request timed out after {ollamaTimeout:g} seconds.")
+        print(
+            f"The model ({ollamaModel}) may still be loading into VRAM. Retry, or "
+            'raise "ollamaTimeout" in config.json to wait longer.'
+        )
+        return
+    except ValueError as e:
+        print(f"Error: {e}")
+        return
+    except Exception as e:
+        print(f"Error inferring patterns: {e}")
+        print(
+            "Ensure Ollama is running (ollama serve) and the model is pulled "
+            f"(ollama pull {ollamaModel})."
+        )
+        return
+
+    seen = set()
+    patterns = []
+    for raw in raw_patterns:
+        cleaned = _clean_pattern(raw)
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            patterns.append(cleaned)
+
+    if not patterns:
+        print(
+            "Error: none of the model's output survived cleanup — every entry was "
+            f"under {MIN_PATTERN_LEN} letters once digits and punctuation were "
+            "stripped."
+        )
+        return
+
+    # Per-run scratch beside the hash file, like .ollama_candidates and
+    # .spoonman; removed by cleanup().
+    patterns_path = f"{hcatHashFile}.llm_patterns"
+    try:
+        with open(patterns_path, "w") as f:
+            for pattern in patterns:
+                f.write(pattern + "\n")
+    except OSError as e:
+        print(f"Error writing patterns file: {e}")
+        return
+
+    discarded = len(raw_patterns) - len(patterns)
+    summary = f"Inferred {len(patterns)} pattern basewords -> {patterns_path}"
+    if discarded > 0:
+        summary += f" ({discarded} discarded during cleanup)"
+    print(summary)
+
+    chains = [rule_chains] if isinstance(rule_chains, str) else list(rule_chains)
+    for rule_chain in chains:
+        hcatQuickDictionary(
+            hcatHashType,
+            hcatHashFile,
+            rule_chain,
+            patterns_path,
+            attack_name="LLM Patterns",
+        )
+
+
 # Middle fast Combinator Attack
 def hcatMiddleCombinator(hcatHashType, hcatHashFile):
     global hcatProcess
@@ -3435,6 +3557,8 @@ def cleanup():
             os.remove(hcatHashFile + ".working")
         if os.path.exists(hcatHashFile + ".expanded"):
             os.remove(hcatHashFile + ".expanded")
+        if os.path.exists(hcatHashFile + ".llm_patterns"):
+            os.remove(hcatHashFile + ".llm_patterns")
         if os.path.isdir(hcatHashFile + ".spoonman"):
             shutil.rmtree(hcatHashFile + ".spoonman", ignore_errors=True)
         if os.path.exists(hcatHashFileOrig + ".combined"):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -146,7 +146,7 @@ def test_cracked_prompt_is_offensive_not_denylist():
 
 
 def test_prompts_map_covers_every_supported_mode():
-    assert set(llm._PROMPTS) == {"target", "wordlist", "cracked"}
+    assert set(llm._PROMPTS) == {"target", "wordlist", "cracked", "pattern"}
 
 
 def test_dedupes_and_caps_length():

--- a/tests/test_llm_pattern_rules.py
+++ b/tests/test_llm_pattern_rules.py
@@ -1,0 +1,396 @@
+"""Tests for the LLM Pattern Rules attack (pattern inference is mocked).
+
+Covers the three layers: the "pattern" prompt/request in hate_crack.llm, the
+_clean_pattern filter and hcatOllamaPatterns orchestration in hate_crack.main,
+and the mode-4 wiring in hate_crack.attacks.
+"""
+
+import os
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+os.environ["HATE_CRACK_SKIP_INIT"] = "1"
+from hate_crack import attacks as hc_attacks  # noqa: E402
+from hate_crack import llm  # noqa: E402
+from hate_crack import main as hc_main  # noqa: E402
+
+OLLAMA_URL = "http://localhost:11434"
+MODEL = "qwen2.5:32b"
+
+
+# --------------------------------------------------------------------------
+# Layer 1: hate_crack.llm
+# --------------------------------------------------------------------------
+
+
+def test_pattern_mode_has_a_prompt():
+    assert "pattern" in llm._PROMPTS
+
+
+def test_pattern_request_embeds_the_sample():
+    request = llm._build_request("pattern", {"sample": "Acme2024!\nWidget99"})
+    assert "Acme2024!" in request and "Widget99" in request
+
+
+def test_pattern_request_asks_for_undecorated_basewords():
+    request = llm._build_request("pattern", {"sample": "x"})
+    assert "lowercase" in request.lower()
+
+
+def test_unknown_mode_still_rejected():
+    with pytest.raises(ValueError):
+        llm._build_request("patterns", {"sample": "x"})
+
+
+# --------------------------------------------------------------------------
+# Layer 2: _clean_pattern
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("summer", "summer"),
+        ("Summer2024!", "summer"),
+        ("ACME", "acme"),
+        ("acme widgets", "acmewidgets"),
+        ("s3cr3t", "scrt"),
+        ("a1", ""),  # under MIN_PATTERN_LEN once digits are stripped
+        ("123456", ""),
+        ("", ""),
+        ("   ", ""),
+        (None, ""),
+        (12345, ""),
+    ],
+)
+def test_clean_pattern(raw, expected):
+    assert hc_main._clean_pattern(raw) == expected
+
+
+# --------------------------------------------------------------------------
+# Layer 2: hcatOllamaPatterns orchestration
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pattern_env(tmp_path):
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.touch()
+    corpus = tmp_path / "corpus.txt"
+    corpus.write_text("Acme2024!\nSummer99\nWidget1\n")
+    return SimpleNamespace(
+        tmp_path=tmp_path, hash_file=str(hash_file), corpus=str(corpus)
+    )
+
+
+@contextmanager
+def pattern_globals(tmp_path):
+    rules_dir = str(tmp_path / "rules")
+    os.makedirs(rules_dir, exist_ok=True)
+    with (
+        mock.patch.object(hc_main, "ollamaUrl", OLLAMA_URL),
+        mock.patch.object(hc_main, "ollamaModel", MODEL),
+        mock.patch.object(hc_main, "ollamaNumCtx", 2048),
+        mock.patch.object(hc_main, "ollamaTimeout", 300.0),
+        mock.patch.object(hc_main, "ollamaMaxSampleLines", 500),
+        mock.patch.object(hc_main, "rulesDirectory", rules_dir),
+    ):
+        yield
+
+
+def test_patterns_written_and_rules_passed_through(pattern_env):
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch(
+            "hate_crack.main.llm.generate_candidates",
+            return_value=["Acme2024!", "widgets", "summer"],
+        ) as gen,
+        mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000", pattern_env.hash_file, pattern_env.corpus, "-r best64.rule"
+        )
+
+    assert gen.call_args[0][3] == "pattern"
+    assert "Acme2024!" in gen.call_args[0][4]["sample"]
+
+    patterns_path = f"{pattern_env.hash_file}.llm_patterns"
+    assert open(patterns_path).read().split() == ["acme", "widgets", "summer"]
+
+    quick.assert_called_once()
+    args = quick.call_args[0]
+    assert args[2] == "-r best64.rule"
+    assert args[3] == patterns_path
+    assert quick.call_args[1]["attack_name"] == "LLM Patterns"
+
+
+def test_no_rules_chain_is_allowed(pattern_env):
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch("hate_crack.main.llm.generate_candidates", return_value=["summer"]),
+        mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000", pattern_env.hash_file, pattern_env.corpus, ""
+        )
+    assert quick.call_args[0][2] == ""
+
+
+def test_chained_rules_pass_through_verbatim(pattern_env):
+    chain = " -r best64.rule -r toggles1.rule"
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch("hate_crack.main.llm.generate_candidates", return_value=["summer"]),
+        mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000", pattern_env.hash_file, pattern_env.corpus, chain
+        )
+    assert quick.call_args[0][2] == chain
+
+
+def test_multiple_chains_infer_once_and_reuse_the_baseword_file(pattern_env):
+    """A round trip to the model is slow and non-deterministic, so it runs once."""
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch(
+            "hate_crack.main.llm.generate_candidates", return_value=["summer"]
+        ) as gen,
+        mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000",
+            pattern_env.hash_file,
+            pattern_env.corpus,
+            ["-r a.rule", " -r b.rule -r c.rule", ""],
+        )
+
+    gen.assert_called_once()
+    assert quick.call_count == 3
+    assert [c[0][2] for c in quick.call_args_list] == [
+        "-r a.rule",
+        " -r b.rule -r c.rule",
+        "",
+    ]
+    # Every pass runs against the same inferred baseword file.
+    assert {c[0][3] for c in quick.call_args_list} == {
+        f"{pattern_env.hash_file}.llm_patterns"
+    }
+
+
+def test_empty_chain_list_infers_but_runs_nothing(pattern_env):
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch("hate_crack.main.llm.generate_candidates", return_value=["summer"]),
+        mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000", pattern_env.hash_file, pattern_env.corpus, []
+        )
+    quick.assert_not_called()
+
+
+def test_duplicate_patterns_deduped_after_cleaning(pattern_env):
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch(
+            "hate_crack.main.llm.generate_candidates",
+            # All three clean to "acme" — the model decorated its own output.
+            return_value=["acme", "ACME", "Acme2024"],
+        ),
+        mock.patch("hate_crack.main.hcatQuickDictionary"),
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000", pattern_env.hash_file, pattern_env.corpus, ""
+        )
+    patterns_path = f"{pattern_env.hash_file}.llm_patterns"
+    assert open(patterns_path).read().split() == ["acme"]
+
+
+def test_missing_source_skips_the_model(pattern_env):
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch("hate_crack.main.llm.generate_candidates") as gen,
+        mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000", pattern_env.hash_file, str(pattern_env.tmp_path / "nope.txt"), ""
+        )
+    gen.assert_not_called()
+    quick.assert_not_called()
+
+
+def test_all_output_filtered_out_skips_hashcat(pattern_env):
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch(
+            "hate_crack.main.llm.generate_candidates", return_value=["1", "22", "!!"]
+        ),
+        mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000", pattern_env.hash_file, pattern_env.corpus, ""
+        )
+    quick.assert_not_called()
+    assert not os.path.exists(f"{pattern_env.hash_file}.llm_patterns")
+
+
+def test_timeout_skips_hashcat(pattern_env):
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch(
+            "hate_crack.main.llm.generate_candidates",
+            side_effect=llm.LLMTimeoutError("boom"),
+        ),
+        mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000", pattern_env.hash_file, pattern_env.corpus, ""
+        )
+    quick.assert_not_called()
+
+
+def test_connection_failure_skips_hashcat(pattern_env):
+    with (
+        pattern_globals(pattern_env.tmp_path),
+        mock.patch(
+            "hate_crack.main.llm.generate_candidates",
+            side_effect=RuntimeError("connection refused"),
+        ),
+        mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
+    ):
+        hc_main.hcatOllamaPatterns(
+            "1000", pattern_env.hash_file, pattern_env.corpus, ""
+        )
+    quick.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Layer 3: attacks.ollama_attack mode 4
+# --------------------------------------------------------------------------
+
+
+def _pattern_ctx(tmp_path, has_cracked=False):
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.touch()
+    if has_cracked:
+        (tmp_path / "hashes.txt.out").write_text("hash:Summer2024!\n")
+    return SimpleNamespace(
+        hcatHashType="1000",
+        hcatHashFile=str(hash_file),
+        hcatWordlists=str(tmp_path),
+        rulesDirectory=str(tmp_path),
+        hcatOllamaPatterns=mock.MagicMock(),
+        hcatOllama=mock.MagicMock(),
+    )
+
+
+def test_mode_4_offered_with_and_without_cracked(tmp_path):
+    """The key stays "4" either way so it does not move between sessions."""
+    seen = {}
+
+    def fake_menu(items, **kwargs):
+        seen["items"] = items
+        return "99"
+
+    for has_cracked in (False, True):
+        ctx = _pattern_ctx(tmp_path, has_cracked=has_cracked)
+        with (
+            mock.patch.object(hc_attacks, "interactive_menu", fake_menu),
+            mock.patch.object(hc_attacks._notify, "prompt_notify_for_attack"),
+        ):
+            hc_attacks.ollama_attack(ctx)
+        labels = dict(seen["items"])
+        assert "Pattern rules" in labels["4"]
+        assert ("3" in labels) is has_cracked
+
+
+def test_mode_4_hands_all_chains_over_in_one_call(tmp_path):
+    """Every chain goes over at once so the model is queried once, not per rule."""
+    ctx = _pattern_ctx(tmp_path)
+    corpus = tmp_path / "corpus.txt"
+    corpus.write_text("Summer2024!\n")
+
+    with (
+        mock.patch.object(hc_attacks, "interactive_menu", return_value="4"),
+        mock.patch.object(hc_attacks._notify, "prompt_notify_for_attack"),
+        mock.patch.object(hc_attacks, "_pick_pattern_source", return_value=str(corpus)),
+        mock.patch.object(
+            hc_attacks, "_select_rules", return_value=["-r a.rule", "-r b.rule"]
+        ),
+    ):
+        hc_attacks.ollama_attack(ctx)
+
+    ctx.hcatOllamaPatterns.assert_called_once()
+    assert ctx.hcatOllamaPatterns.call_args[0][3] == ["-r a.rule", "-r b.rule"]
+
+
+def test_mode_4_rule_cancel_runs_nothing(tmp_path):
+    ctx = _pattern_ctx(tmp_path)
+    with (
+        mock.patch.object(hc_attacks, "interactive_menu", return_value="4"),
+        mock.patch.object(hc_attacks._notify, "prompt_notify_for_attack"),
+        mock.patch.object(hc_attacks, "_pick_pattern_source", return_value="/x"),
+        mock.patch.object(hc_attacks, "_select_rules", return_value=None),
+    ):
+        hc_attacks.ollama_attack(ctx)
+    ctx.hcatOllamaPatterns.assert_not_called()
+
+
+def test_mode_4_source_cancel_skips_rule_picker(tmp_path):
+    ctx = _pattern_ctx(tmp_path)
+    with (
+        mock.patch.object(hc_attacks, "interactive_menu", return_value="4"),
+        mock.patch.object(hc_attacks._notify, "prompt_notify_for_attack"),
+        mock.patch.object(hc_attacks, "_pick_pattern_source", return_value=None),
+        mock.patch.object(hc_attacks, "_select_rules") as sel,
+    ):
+        hc_attacks.ollama_attack(ctx)
+    sel.assert_not_called()
+    ctx.hcatOllamaPatterns.assert_not_called()
+
+
+def test_pick_pattern_source_prefers_cracked_when_available(tmp_path):
+    ctx = _pattern_ctx(tmp_path, has_cracked=True)
+    with mock.patch.object(hc_attacks, "interactive_menu", return_value="1"):
+        assert hc_attacks._pick_pattern_source(ctx, "/tmp/cracked.out") == (
+            "/tmp/cracked.out"
+        )
+
+
+def test_pick_pattern_source_falls_through_to_wordlist(tmp_path):
+    ctx = _pattern_ctx(tmp_path)
+    with mock.patch.object(
+        hc_attacks, "_pick_training_wordlist", return_value="/tmp/wl.txt"
+    ):
+        assert hc_attacks._pick_pattern_source(ctx, None) == "/tmp/wl.txt"
+
+
+def test_pick_pattern_source_cancel_returns_none(tmp_path):
+    ctx = _pattern_ctx(tmp_path, has_cracked=True)
+    with mock.patch.object(hc_attacks, "interactive_menu", return_value="99"):
+        assert hc_attacks._pick_pattern_source(ctx, "/tmp/cracked.out") is None
+
+
+# --------------------------------------------------------------------------
+# Cleanup
+# --------------------------------------------------------------------------
+
+
+def test_llm_patterns_removed_by_cleanup(tmp_path, monkeypatch):
+    """Mirrors test_main_spoonman.test_cleanup_removes_derived_output."""
+    hash_file = str(tmp_path / "hashes.txt")
+    patterns_path = hash_file + ".llm_patterns"
+    with open(patterns_path, "w") as f:
+        f.write("acme\n")
+
+    monkeypatch.setattr(hc_main, "hcatHashFile", hash_file, raising=False)
+    monkeypatch.setattr(hc_main, "hcatHashFileOrig", hash_file, raising=False)
+    monkeypatch.setattr(hc_main, "hcatHashType", "1000", raising=False)
+    monkeypatch.setattr(hc_main, "pwdump_format", False, raising=False)
+    hc_main.cleanup()
+
+    assert not os.path.exists(patterns_path)


### PR DESCRIPTION
## What

Adds option 4 to the LLM Attack submenu: **Pattern rules (LLM finds patterns, hashcat rules mutate them)**.

It takes the same shape as the Spoonman Attack — a baseword list run through hashcat rules — but infers the basewords instead of extracting them. Spoonman's `rulegen` is lossless and therefore literal: every baseword it emits is the letters-only core of a password already present in its corpus. This mode asks the local model to generalize, naming the *word families* behind a sample (company and products, site names, local sports teams, seasons, mascots) and enumerating members the sample does not contain. Those basewords then run against rule file(s) chosen from the rules directory.

## How it's wired

| Layer | Change |
|---|---|
| `hate_crack/llm.py` | `"pattern"` prompt + `_build_request` branch, reusing the existing candidate schema and dedupe/cap logic |
| `hate_crack/main.py` | `_clean_pattern` + `hcatOllamaPatterns`; `.llm_patterns` added to `cleanup()` |
| `hate_crack/attacks.py` | mode-4 wiring and `_pick_pattern_source` |

Pattern source is the session's cracked passwords (offered first, and only once something has been cracked) or a sample wordlist. Rule selection uses the standard `_select_rules` picker, so chained rules (`1+2`) and YOLO both work.

## Two decisions worth reviewing

**Model output is normalized to lowercase letters only**, discarding anything under 3 characters (`_clean_pattern`). The rule file supplies case, digits, and punctuation, so a model that decorates its own answer anyway would get decorated a second time, stacking a suffix on top of one the model already added. Enforced in code rather than trusted to the prompt.

**Inference happens once, above the rule loop.** The other multi-chain attacks loop in `attacks.py` because their candidate generation is local and cheap to repeat. An Ollama round trip is neither: looping per chain would re-query the model for every rule file (a dozen times under YOLO) and, since the model is not deterministic, silently change the basewords between passes. `hcatOllamaPatterns` therefore accepts the whole chain list and runs them all against one baseword file.

## Notes

- No new config keys — reuses `ollamaUrl` / `ollamaModel` / `ollamaNumCtx` / `ollamaTimeout` / `ollamaMaxSampleLines`.
- Not a main-menu attack, so the duplicate menu mappings in `main.py` and `hate_crack.py` are untouched.
- `<hashfile>.llm_patterns` is per-run scratch, removed on exit like `.spoonman`.

## Verification

- `1222 passed, 29 skipped` (33 new tests in `tests/test_llm_pattern_rules.py`; one existing assertion in `test_llm.py` enumerated the prompt modes and was updated).
- `ruff check` / `ruff format --check` clean over `hate_crack` and `tests`.
- `bandit` exits 0 against the baseline.
- `ty` adds only the same warning class every neighboring `cleanup()` line already produces on `hcatHashFile + "<suffix>"`.
- The cleanup test was confirmed to fail when the `cleanup()` lines are removed, so it tests behavior rather than restating the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
