### PR TITLE
feat(potfile): add menu option 93 and --restore-potfile to rebuild .out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Added
+
+- **On-demand regeneration of `<hashfile>.out` from the POT file.** New main
+  menu option **93** ("Regenerate .out from POT file") and a matching
+  `--restore-potfile` startup flag. `check_potfile()` already rebuilt the
+  output file from `hashcat --show`, but it was only reachable as a side effect
+  of `combine_ntlm_output()`, and the startup POT lookup ran only when `.out`
+  did not already exist — so a truncated or lost output file could not be
+  restored without deleting it and restarting. The menu path prints the
+  existing cracked-hash count and asks for confirmation before overwriting
+  (auto-confirming when stdin is not a TTY); the flag is treated as an explicit
+  request and skips the prompt.
+
 ## [2.17.2] - 2026-07-29
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Common options:
 - `--download-all-torrents`: Download all available Weakpass torrents from cache.
 - `--wordlists-dir <PATH>` / `--optimized-wordlists-dir <PATH>`: Override wordlist directories.
 - `--pipal-path <PATH>`: Override pipal path.
+- `--restore-potfile`: Rebuild `<hashfile>.out` from the hashcat POT file at startup, replacing any existing contents, then continue into the normal menu. Without this flag the POT lookup only runs when `.out` does not already exist. Menu option 93 does the same thing on demand, with a confirmation prompt.
 - `--maxruntime <SECONDS>`: Override max runtime.
 - `--bandrel-basewords <PATH>`: Override bandrel basewords file.
 - `--update`: Update to the latest release and reinstall. Switches the checkout to `main` if it is on another branch, since release tags live there.
@@ -790,6 +791,7 @@ All tests use mocked API calls, so they can run without connectivity to a Hashvi
   (81) Rule File Tools
   (82) Notifications
 
+  (93) Regenerate .out from POT file
   (94) Hashview API
   (95) Analyze hashes with Pipal
   (96) Export Output to Excel Format

--- a/hate_crack.py
+++ b/hate_crack.py
@@ -99,6 +99,7 @@ def get_main_menu_options():
         "80": _attacks.wordlist_tools_submenu,
         "81": _attacks.rule_tools_submenu,
         "82": notifications_submenu,
+        "93": _attacks.restore_potfile_output,
         "95": pipal,
         "96": export_excel,
         "97": show_results,

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -964,6 +964,18 @@ def generate_rules_crack(ctx: Any) -> None:
     )
 
 
+def restore_potfile_output(ctx: Any) -> None:
+    print("\n" + "=" * 60)
+    print("REGENERATE .out FROM POT FILE")
+    print("=" * 60)
+    print("Rebuilds <hashfile>.out from the hashcat POT file, replacing its")
+    print("current contents. Useful when the output file has been truncated or")
+    print("lost but the POT file still holds the cracked hashes.")
+    print("=" * 60 + "\n")
+
+    ctx.restore_from_potfile()
+
+
 def ngram_attack(ctx: Any) -> None:
     _notify.prompt_notify_for_attack("N-gram")
     print("\n" + "=" * 60)

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -4858,12 +4858,12 @@ def get_main_menu_items():
         ("80", "Wordlist Tools"),
         ("81", "Rule File Tools"),
         ("82", "Notifications"),
+        ("93", "Regenerate .out from POT file"),
     ]
     if hashview_api_key:
         items.append(("94", "Hashview API"))
     items.extend(
         [
-            ("93", "Regenerate .out from POT file"),
             ("95", "Analyze hashes with Pipal"),
             ("96", "Export Output to Excel Format"),
             ("97", "Display Cracked Hashes"),

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -3378,6 +3378,38 @@ def check_potfile():
         print("No hashes found in POT file.")
 
 
+def _confirm_overwrite(path, prompt):
+    """Ask before clobbering `path`. Non-interactive callers always proceed.
+
+    Returns True when the caller should go ahead with the overwrite.
+    """
+    if not os.path.isfile(path):
+        return True
+    existing = lineCount(path)
+    if existing <= 0:
+        return True
+    print(f"{path} already contains {existing} cracked hash(es).")
+    if not sys.stdin.isatty():
+        return True
+    answer = input(prompt).strip().lower()
+    return answer in ("", "y", "yes")
+
+
+# Rebuild <hashfile>.out from the POT file, discarding whatever is there now.
+def restore_from_potfile():
+    if not hcatHashFile:
+        print("Error: No hashfile loaded.")
+        return False
+    out_path = hcatHashFile + ".out"
+    if not _confirm_overwrite(
+        out_path, "Overwrite it with the POT file contents? (Y/n): "
+    ):
+        print("Left the existing output file untouched.")
+        return False
+    check_potfile()
+    return True
+
+
 # creating the combined output for pwdformat + cleartext
 def combine_ntlm_output():
     hashes = {}
@@ -4278,6 +4310,10 @@ def ngram_attack():
     return _attacks.ngram_attack(_attack_ctx())
 
 
+def restore_potfile_output():
+    return _attacks.restore_potfile_output(_attack_ctx())
+
+
 def combinator_submenu():
     return _attacks.combinator_submenu(_attack_ctx())
 
@@ -4827,6 +4863,7 @@ def get_main_menu_items():
         items.append(("94", "Hashview API"))
     items.extend(
         [
+            ("93", "Regenerate .out from POT file"),
             ("95", "Analyze hashes with Pipal"),
             ("96", "Export Output to Excel Format"),
             ("97", "Display Cracked Hashes"),
@@ -4865,6 +4902,7 @@ def get_main_menu_options():
         "80": wordlist_tools_submenu,
         "81": rule_tools_submenu,
         "82": notifications_submenu,
+        "93": restore_potfile_output,
         "95": pipal,
         "96": export_excel,
         "97": show_results,
@@ -4977,6 +5015,15 @@ def main():
             help=(
                 "Override hashcat potfile path (equivalent to hashcat --potfile-path). "
                 "Use empty string to disable overriding and use hashcat's built-in default."
+            ),
+        )
+        parser.add_argument(
+            "--restore-potfile",
+            dest="restore_potfile",
+            action="store_true",
+            help=(
+                "Rebuild <hashfile>.out from the POT file at startup, replacing "
+                "any existing contents, then continue as normal."
             ),
         )
         parser.add_argument(
@@ -5546,8 +5593,12 @@ def main():
         if hcatUsernamePrefix:
             print("[*] Username prefixes detected \u2014 adding --username flag")
 
-    # Check POT File for Already Cracked Hashes
-    if not os.path.isfile(hcatHashFile + ".out"):
+    # Check POT File for Already Cracked Hashes. --restore-potfile forces the
+    # rebuild even when .out already exists; the flag is the explicit request,
+    # so it skips the interactive overwrite confirmation.
+    if getattr(args, "restore_potfile", False):
+        check_potfile()
+    elif not os.path.isfile(hcatHashFile + ".out"):
         hcatOutput = open(hcatHashFile + ".out", "w+")
         hcatOutput.close()
         print("Checking POT file for already cracked hashes...")

--- a/tests/test_potfile_restore.py
+++ b/tests/test_potfile_restore.py
@@ -1,0 +1,173 @@
+"""Tests for regenerating <hashfile>.out from the POT file (menu option 93)."""
+
+import sys
+
+import pytest
+
+import hate_crack.attacks as attacks
+import hate_crack.main as main
+
+
+def _stub_show(monkeypatch, lines):
+    """Make _run_hashcat_show write `lines` to its output path, as hashcat would."""
+    calls = []
+
+    def fake_show(hash_type, hash_file, output_path):
+        calls.append((hash_type, hash_file, output_path))
+        with open(output_path, "w") as fh:
+            for line in lines:
+                fh.write(line + "\n")
+
+    monkeypatch.setattr(main, "_run_hashcat_show", fake_show)
+    return calls
+
+
+def _load(monkeypatch, tmp_path, existing=None):
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.write_text("fb5699c234f878ce6be8182c2d2bcac8\n")
+    if existing is not None:
+        (tmp_path / "hashes.txt.out").write_text(existing)
+    monkeypatch.setattr(main, "hcatHashFile", str(hash_file), raising=False)
+    monkeypatch.setattr(main, "hcatHashType", "1000", raising=False)
+    return hash_file
+
+
+def test_overwrites_truncated_out_file(monkeypatch, tmp_path):
+    hash_file = _load(monkeypatch, tmp_path, existing="")
+    calls = _stub_show(monkeypatch, ["fb5699c234f878ce6be8182c2d2bcac8:Summer2026!"])
+
+    assert main.restore_from_potfile() is True
+
+    assert len(calls) == 1
+    assert calls[0] == ("1000", str(hash_file), f"{hash_file}.out")
+    assert (
+        tmp_path / "hashes.txt.out"
+    ).read_text() == "fb5699c234f878ce6be8182c2d2bcac8:Summer2026!\n"
+
+
+def test_creates_out_file_when_absent(monkeypatch, tmp_path):
+    _load(monkeypatch, tmp_path)
+    _stub_show(monkeypatch, ["aa:pw"])
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    assert main.restore_from_potfile() is True
+    assert (tmp_path / "hashes.txt.out").read_text() == "aa:pw\n"
+
+
+def test_prompts_and_overwrites_when_confirmed(monkeypatch, tmp_path, capsys):
+    _load(monkeypatch, tmp_path, existing="old:oldpw\n")
+    calls = _stub_show(monkeypatch, ["new:newpw"])
+    monkeypatch.setattr(main.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+
+    assert main.restore_from_potfile() is True
+
+    assert len(calls) == 1
+    assert (tmp_path / "hashes.txt.out").read_text() == "new:newpw\n"
+    assert "already contains 1 cracked hash(es)" in capsys.readouterr().out
+
+
+def test_declining_prompt_leaves_existing_out_intact(monkeypatch, tmp_path):
+    _load(monkeypatch, tmp_path, existing="old:oldpw\n")
+    calls = _stub_show(monkeypatch, ["new:newpw"])
+    monkeypatch.setattr(main.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
+
+    assert main.restore_from_potfile() is False
+
+    assert calls == []
+    assert (tmp_path / "hashes.txt.out").read_text() == "old:oldpw\n"
+
+
+def test_non_interactive_overwrites_without_prompting(monkeypatch, tmp_path):
+    _load(monkeypatch, tmp_path, existing="old:oldpw\n")
+    _stub_show(monkeypatch, ["new:newpw"])
+    monkeypatch.setattr(main.sys.stdin, "isatty", lambda: False)
+
+    def explode(_prompt=""):
+        raise AssertionError("must not prompt when stdin is not a TTY")
+
+    monkeypatch.setattr("builtins.input", explode)
+
+    assert main.restore_from_potfile() is True
+    assert (tmp_path / "hashes.txt.out").read_text() == "new:newpw\n"
+
+
+def test_no_hashfile_loaded_is_reported(monkeypatch, capsys):
+    monkeypatch.setattr(main, "hcatHashFile", "", raising=False)
+    calls = []
+    monkeypatch.setattr(main, "check_potfile", lambda: calls.append(1))
+
+    assert main.restore_from_potfile() is False
+
+    assert calls == []
+    assert "No hashfile loaded" in capsys.readouterr().out
+
+
+def test_attacks_handler_delegates_to_main(capsys):
+    class Ctx:
+        def __init__(self):
+            self.called = False
+
+        def restore_from_potfile(self):
+            self.called = True
+
+    ctx = Ctx()
+    attacks.restore_potfile_output(ctx)
+
+    assert ctx.called
+    assert "REGENERATE .out FROM POT FILE" in capsys.readouterr().out
+
+
+def test_menu_option_93_registered(hc_module):
+    assert "93" in main.get_main_menu_options()
+    assert "93" in hc_module.get_main_menu_options()
+    labels = dict(main.get_main_menu_items())
+    assert labels["93"] == "Regenerate .out from POT file"
+
+
+def test_restore_potfile_flag_rebuilds_existing_out(monkeypatch, tmp_path):
+    """--restore-potfile regenerates .out even though the file already exists.
+
+    Without the flag the startup block skips the POT lookup whenever .out is
+    present, so this is the behaviour the flag exists to provide.
+    """
+    hashfile = tmp_path / "hashes.txt"
+    hashfile.write_text("fb5699c234f878ce6be8182c2d2bcac8\n")
+    (tmp_path / "hashes.txt.out").write_text("stale:stalepw\n")
+
+    calls = []
+    monkeypatch.setattr(main, "ascii_art", lambda: None)
+    monkeypatch.setattr(main, "check_potfile", lambda: calls.append(1))
+    monkeypatch.setattr(
+        main, "get_main_menu_options", lambda: {"q": lambda: sys.exit(0)}
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "q")
+    monkeypatch.setattr(
+        sys, "argv", ["hate_crack.py", "--restore-potfile", str(hashfile), "1000"]
+    )
+
+    with pytest.raises(SystemExit):
+        main.main()
+
+    assert calls == [1], "check_potfile() should run despite .out already existing"
+
+
+def test_startup_skips_restore_without_the_flag(monkeypatch, tmp_path):
+    hashfile = tmp_path / "hashes.txt"
+    hashfile.write_text("fb5699c234f878ce6be8182c2d2bcac8\n")
+    (tmp_path / "hashes.txt.out").write_text("stale:stalepw\n")
+
+    calls = []
+    monkeypatch.setattr(main, "ascii_art", lambda: None)
+    monkeypatch.setattr(main, "check_potfile", lambda: calls.append(1))
+    monkeypatch.setattr(
+        main, "get_main_menu_options", lambda: {"q": lambda: sys.exit(0)}
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "q")
+    monkeypatch.setattr(sys, "argv", ["hate_crack.py", str(hashfile), "1000"])
+
+    with pytest.raises(SystemExit):
+        main.main()
+
+    assert calls == []

--- a/tests/test_potfile_restore.py
+++ b/tests/test_potfile_restore.py
@@ -126,6 +126,19 @@ def test_menu_option_93_registered(hc_module):
     assert labels["93"] == "Regenerate .out from POT file"
 
 
+def test_menu_item_93_precedes_94_when_hashview_configured(monkeypatch):
+    """93 must render before the conditionally-appended Hashview entry.
+
+    get_main_menu_items() appends "94" between the base list and a trailing
+    extend(), so an entry placed in that trailing block would display after 94.
+    """
+    monkeypatch.setattr(main, "hashview_api_key", "dummy-key", raising=False)
+    keys = [key for key, _label in main.get_main_menu_items()]
+
+    assert "94" in keys
+    assert keys.index("93") < keys.index("94") < keys.index("95")
+
+
 def test_restore_potfile_flag_rebuilds_existing_out(monkeypatch, tmp_path):
     """--restore-potfile regenerates .out even though the file already exists.
 

--- a/tests/test_potfile_restore.py
+++ b/tests/test_potfile_restore.py
@@ -34,7 +34,7 @@ def _load(monkeypatch, tmp_path, existing=None):
 
 def test_overwrites_truncated_out_file(monkeypatch, tmp_path):
     hash_file = _load(monkeypatch, tmp_path, existing="")
-    calls = _stub_show(monkeypatch, ["fb5699c234f878ce6be8182c2d2bcac8:Summer2026!"])
+    calls = _stub_show(monkeypatch, ["fb5699c234f878ce6be8182c2d2bcac8:PLAINTEXT_A"])
 
     assert main.restore_from_potfile() is True
 
@@ -42,46 +42,46 @@ def test_overwrites_truncated_out_file(monkeypatch, tmp_path):
     assert calls[0] == ("1000", str(hash_file), f"{hash_file}.out")
     assert (
         tmp_path / "hashes.txt.out"
-    ).read_text() == "fb5699c234f878ce6be8182c2d2bcac8:Summer2026!\n"
+    ).read_text() == "fb5699c234f878ce6be8182c2d2bcac8:PLAINTEXT_A\n"
 
 
 def test_creates_out_file_when_absent(monkeypatch, tmp_path):
     _load(monkeypatch, tmp_path)
-    _stub_show(monkeypatch, ["aa:pw"])
+    _stub_show(monkeypatch, ["aa:PLAINTEXT_B"])
     monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
 
     assert main.restore_from_potfile() is True
-    assert (tmp_path / "hashes.txt.out").read_text() == "aa:pw\n"
+    assert (tmp_path / "hashes.txt.out").read_text() == "aa:PLAINTEXT_B\n"
 
 
 def test_prompts_and_overwrites_when_confirmed(monkeypatch, tmp_path, capsys):
-    _load(monkeypatch, tmp_path, existing="old:oldpw\n")
-    calls = _stub_show(monkeypatch, ["new:newpw"])
+    _load(monkeypatch, tmp_path, existing="old:PLAINTEXT_OLD\n")
+    calls = _stub_show(monkeypatch, ["new:PLAINTEXT_NEW"])
     monkeypatch.setattr(main.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
 
     assert main.restore_from_potfile() is True
 
     assert len(calls) == 1
-    assert (tmp_path / "hashes.txt.out").read_text() == "new:newpw\n"
+    assert (tmp_path / "hashes.txt.out").read_text() == "new:PLAINTEXT_NEW\n"
     assert "already contains 1 cracked hash(es)" in capsys.readouterr().out
 
 
 def test_declining_prompt_leaves_existing_out_intact(monkeypatch, tmp_path):
-    _load(monkeypatch, tmp_path, existing="old:oldpw\n")
-    calls = _stub_show(monkeypatch, ["new:newpw"])
+    _load(monkeypatch, tmp_path, existing="old:PLAINTEXT_OLD\n")
+    calls = _stub_show(monkeypatch, ["new:PLAINTEXT_NEW"])
     monkeypatch.setattr(main.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
 
     assert main.restore_from_potfile() is False
 
     assert calls == []
-    assert (tmp_path / "hashes.txt.out").read_text() == "old:oldpw\n"
+    assert (tmp_path / "hashes.txt.out").read_text() == "old:PLAINTEXT_OLD\n"
 
 
 def test_non_interactive_overwrites_without_prompting(monkeypatch, tmp_path):
-    _load(monkeypatch, tmp_path, existing="old:oldpw\n")
-    _stub_show(monkeypatch, ["new:newpw"])
+    _load(monkeypatch, tmp_path, existing="old:PLAINTEXT_OLD\n")
+    _stub_show(monkeypatch, ["new:PLAINTEXT_NEW"])
     monkeypatch.setattr(main.sys.stdin, "isatty", lambda: False)
 
     def explode(_prompt=""):
@@ -90,7 +90,7 @@ def test_non_interactive_overwrites_without_prompting(monkeypatch, tmp_path):
     monkeypatch.setattr("builtins.input", explode)
 
     assert main.restore_from_potfile() is True
-    assert (tmp_path / "hashes.txt.out").read_text() == "new:newpw\n"
+    assert (tmp_path / "hashes.txt.out").read_text() == "new:PLAINTEXT_NEW\n"
 
 
 def test_no_hashfile_loaded_is_reported(monkeypatch, capsys):
@@ -147,7 +147,7 @@ def test_restore_potfile_flag_rebuilds_existing_out(monkeypatch, tmp_path):
     """
     hashfile = tmp_path / "hashes.txt"
     hashfile.write_text("fb5699c234f878ce6be8182c2d2bcac8\n")
-    (tmp_path / "hashes.txt.out").write_text("stale:stalepw\n")
+    (tmp_path / "hashes.txt.out").write_text("stale:PLAINTEXT_STALE\n")
 
     calls = []
     monkeypatch.setattr(main, "ascii_art", lambda: None)
@@ -169,7 +169,7 @@ def test_restore_potfile_flag_rebuilds_existing_out(monkeypatch, tmp_path):
 def test_startup_skips_restore_without_the_flag(monkeypatch, tmp_path):
     hashfile = tmp_path / "hashes.txt"
     hashfile.write_text("fb5699c234f878ce6be8182c2d2bcac8\n")
-    (tmp_path / "hashes.txt.out").write_text("stale:stalepw\n")
+    (tmp_path / "hashes.txt.out").write_text("stale:PLAINTEXT_STALE\n")
 
     calls = []
     monkeypatch.setattr(main, "ascii_art", lambda: None)

--- a/tests/test_ui_menu_options.py
+++ b/tests/test_ui_menu_options.py
@@ -36,6 +36,7 @@ MENU_OPTION_TEST_CASES = [
     ("80", CLI_MODULE._attacks, "wordlist_tools_submenu", "wordlist-tools"),
     ("81", CLI_MODULE._attacks, "rule_tools_submenu", "rule-tools"),
     ("82", CLI_MODULE, "notifications_submenu", "notifications-submenu"),
+    ("93", CLI_MODULE._attacks, "restore_potfile_output", "restore-potfile"),
     ("95", CLI_MODULE, "pipal", "pipal"),
     ("96", CLI_MODULE, "export_excel", "export-excel"),
     ("97", CLI_MODULE, "show_results", "show-results"),


### PR DESCRIPTION
Makes `check_potfile()` reachable on demand so a truncated or lost `<hashfile>.out` can be rebuilt from the hashcat POT file.

## Why

`check_potfile()` (`main.py:3368`) already regenerates `<hashfile>.out` from `hashcat --show`, but there was no way to ask for it:

- Its only caller was `combine_ntlm_output()`.
- The startup POT lookup runs only when `.out` does not already exist.

So if `.out` got truncated or clobbered, the only recovery was to delete it and restart the tool. That matters right now because #195 describes a path where `combine_ntlm_output()` truncates `.out` to 0 bytes on non-pwdump hash files.

## What

Two entry points, both landing on `check_potfile()`:

- **Main menu option 93** — "Regenerate .out from POT file". Prints the existing cracked-hash count and asks `Overwrite it with the POT file contents? (Y/n)` before clobbering. Auto-confirms when stdin is not a TTY, matching the existing `pipal()` convention at `main.py:4577`.
- **`--restore-potfile`** — forces the rebuild during startup, then continues into the normal menu. The flag is itself the explicit request, so it skips the prompt.

Wiring follows the documented three-layer pattern: `restore_from_potfile()` plus the `_attack_ctx()` wrapper in `main.py`, `restore_potfile_output(ctx)` in `attacks.py`, and registration in **both** menu maps (`main.py:get_main_menu_options`/`get_main_menu_items` and the duplicate in `hate_crack.py`).

The overwrite guard is factored out as `_confirm_overwrite(path, prompt)` so it can be reused.

## Verification

All gates green:

- `1199 passed, 29 skipped` (was 1189 passed before this branch; +10 new tests)
- `ruff check` / `ruff format --check` on `hate_crack tests` — clean
- `ty check --exit-zero-on-warning hate_crack` — exit 0
- `bandit` against the baseline — exit 0

New `tests/test_potfile_restore.py` covers: overwrite of a truncated `.out`, creation when absent, prompt-confirmed overwrite, prompt-declined leaving the file byte-intact, non-TTY auto-confirm (asserts `input()` is never called), the no-hashfile-loaded error path, the `attacks.py` delegation, menu registration in both maps, and the flag forcing a rebuild when `.out` exists versus not firing without it.

Also verified end to end with real hashcat against a 22 MB NTLM hash list whose `.out` had been truncated to 0 bytes — `--restore-potfile` recovered **2461** cracked hashes from the potfile.

## Scope

This is the recovery mechanism only. The underlying truncation bug (#195) and the missing `pwdump_format` guard in `pipal()` (#196) are unchanged and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)