### PR TITLE
fix(rulegen): derive basewords from the password, not the whole line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,40 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Spoonman attack derived basewords and rules from the hash as well as the
+  password.** `rulegen.generate` treated each corpus line as a password in full,
+  but the corpus the attack is built for — and that its own menu text recommends
+  — is a previous engagement's cracked output, whose lines are `hash:password`.
+  The digest's hex digits were therefore prepended to every baseword, and 20–30
+  of the 31 available rule functions were spent rebuilding them.
+
+  The damage compounded. Because every hash is unique, every derived baseword and
+  rule was unique too, which destroyed the property the attack exists for: a rule
+  file ranked by productivity and safe to truncate. And because rebuilding the
+  prefix nearly exhausted `MAX_RULE_FUNCTIONS`, real transformations tipped over
+  the limit into the literal fallback — emitting the password as its own
+  baseword, so the corpus became its own wordlist.
+
+  Measured on a 22,283-line cracked-output file: distinct basewords 22,284 →
+  9,912 (previously one per line, i.e. no deduplication at all), literal
+  fallbacks 5,388 → 31, rules needed for 95% coverage 15,783 → 11,730.
+
+  `$HEX[...]` plaintexts are now decoded here too, and a corpus that looks like
+  an uncracked dump rather than cracked output is reported in `coverage.txt` and
+  warned about.
+
 ### Changed
+
+- **Hash-prefix stripping is now based on digest shape rather than the first
+  colon.** New module `hate_crack/plaintext.py` holds the single implementation
+  shared by the LLM read path, `corpus_stats`, and `rulegen`. A leading field is
+  dropped only when it has the shape of a hash — a hex digest at a known length,
+  or a crypt-style `$id$` string — so `hash:salt:plain` is handled, a plaintext
+  containing colons survives intact, and a wordlist entry that merely contains a
+  colon (a URL, a ratio, a time of day) is no longer truncated. Previously the
+  LLM modes split unconditionally on the first colon.
 
 - **The LLM modes now describe the whole corpus statistically instead of pasting
   in a sample of it.** New module `hate_crack/corpus_stats.py` aggregates every

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Core logic is now split into modules under `hate_crack/`:
 - `hate_crack/attacks.py`: menu attack handlers.
 - `hate_crack/hashmob_wordlist.py`: Hashmob wordlist utilities (thin wrapper; calls into api.py).
 - `hate_crack/corpus_stats.py`: whole-corpus password statistics used to describe a corpus to the LLM.
+- `hate_crack/plaintext.py`: recovers the password from a corpus line (hash-prefix stripping, `$HEX[...]` decoding); shared by the LLM modes, corpus_stats, and rulegen.
 - `hate_crack/llm.py`: structured (JSON) LLM candidate generation via Atomic Agents.
 - `hate_crack/menu.py`: shared menu renderer, including optional arrow-key navigation.
 - `hate_crack/noninteractive.py`: dispatcher for the scripted attack subcommands.
@@ -1039,6 +1040,7 @@ Each password is split into its letters-only lowercased core (the baseword) plus
 * Output is written beside the hash file in `<hash file>.spoonman/`, alongside the other ephemeral wordlists: `basewords.txt`, `rules.full.rule`, the capped rule files, and `coverage.txt` with per-milestone rule counts. Derivation is skipped on later runs of the same hash file unless the corpus has been modified since, and the directory is removed on exit by the temp-file cleanup
 * Passwords that cannot be expressed as a rule are written verbatim as their own baseword with a `:` no-op, so coverage stays complete. This covers two hashcat limits: rule positions cannot address past index 35, and hashcat rejects any rule with more than 31 functions — silently, when valid rules share the file
 * The derivation self-checks every password by reconstructing it in-process, and reports any failures rather than reporting success
+* Corpus lines may carry a hash in front of the password, as cracked output does. A leading field is dropped only when it has the shape of a hash (a hex digest at a known length, or a crypt-style `$id$` string), so `hash:salt:plain` is handled while a plaintext or wordlist entry containing a colon survives intact. `$HEX[...]` plaintexts are decoded. If most lines look like an uncracked dump rather than cracked output, `coverage.txt` records the count and the attack warns — the derived basewords and rules would otherwise be meaningless without any error being raised
 
 #### Wordlist Tools (option 80)
 A submenu of wordlist preprocessing utilities using hashcat-utils binaries. All tools read from and write to files on disk. All file and directory path prompts support tab completion.

--- a/hate_crack/corpus_stats.py
+++ b/hate_crack/corpus_stats.py
@@ -16,10 +16,22 @@ Nothing here contacts the model or the network; it is pure aggregation, which
 keeps it cheap to test.
 """
 
-import binascii
 from collections import Counter
 
 from hate_crack import rulegen
+from hate_crack.plaintext import (
+    decode_hex_wrapper,
+    looks_like_hash_line,
+    usable_plaintext,
+)
+
+__all__ = [
+    "decode_hex_wrapper",
+    "format_summary",
+    "looks_like_hash_line",
+    "summarize",
+    "usable_plaintext",
+]
 
 # Bounds on what reaches the prompt. Each list is truncated to its top N by
 # frequency, so summary size is independent of corpus size.
@@ -32,64 +44,6 @@ TOP_SPECIALS = 10
 # Basewords appearing once in a large corpus are usually typos or one-offs and
 # crowd out the families worth extrapolating from.
 MIN_BASEWORD_HITS = 2
-
-
-def decode_hex_wrapper(plaintext):
-    """Expand hashcat's ``$HEX[...]`` wrapper to the bytes it encodes.
-
-    hashcat wraps any plaintext it cannot write literally — non-ASCII bytes, or
-    anything holding the output separator — as ``$HEX[68656c6c6f]``. Left alone,
-    the wrapper is read as if it were the password itself, which pollutes
-    baseword and mask statistics with the letters of ``$HEX[`` and the corpus's
-    hex digits.
-
-    Decoded to latin-1 so one byte maps to one character, matching how the rest
-    of this module and rulegen read a corpus: hashcat rules address bytes, not
-    codepoints. Returns *plaintext* unchanged if it is not a well-formed
-    wrapper, so malformed input degrades to today's behaviour rather than
-    vanishing.
-    """
-    if not (plaintext.startswith("$HEX[") and plaintext.endswith("]")):
-        return plaintext
-    body = plaintext[5:-1]
-    try:
-        return binascii.unhexlify(body).decode("latin-1")
-    except (binascii.Error, ValueError):
-        return plaintext
-
-
-def usable_plaintext(raw):
-    """Return the usable plaintext from a raw corpus line, or "".
-
-    Blank/whitespace-only lines are discarded. Lines in ``hash:password``
-    format (as hashcat ``--show`` emits) are split on the first colon so only
-    the plaintext is returned; lines with no colon are returned as-is. A
-    ``hash:`` line whose plaintext is empty after stripping returns "".
-    ``$HEX[...]`` plaintexts are decoded — see :func:`decode_hex_wrapper`.
-    """
-    stripped = raw.strip()
-    if not stripped:
-        return ""
-    if ":" in stripped:
-        stripped = stripped.split(":", 1)[1]
-    if not stripped:
-        return ""
-    return decode_hex_wrapper(stripped)
-
-
-def looks_like_hash(value):
-    """True if *value* looks like an uncracked hash rather than a plaintext.
-
-    Operators keep raw NTDS dumps (``user:rid:lm:nt:::``) alongside cracked
-    output, and both end in ``.out`` or ``.ntds`` in a working directory. A
-    dump's first colon splits into the *rest of the hash line*, not a password,
-    so the statistics silently describe hex strings. This flags the shape so
-    :func:`summarize` can warn instead of reporting nonsense confidently.
-    """
-    if value.endswith(":::") or "aad3b435b51404eeaad3b435b51404ee" in value:
-        return True
-    head = value.split(":", 1)[0]
-    return len(head) >= 32 and all(c in "0123456789abcdefABCDEF" for c in head)
 
 
 def _mask(pw):
@@ -163,7 +117,7 @@ def summarize(path):
             if not pw:
                 continue
             total += 1
-            if looks_like_hash(pw):
+            if looks_like_hash_line(raw.strip()):
                 hash_shaped += 1
             unique.add(pw)
             lengths[len(pw)] += 1

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -77,6 +77,7 @@ from hate_crack import llm  # noqa: E402
 from hate_crack import noninteractive as _noninteractive  # noqa: E402
 from hate_crack.progress import spinner  # noqa: E402
 from hate_crack import corpus_stats as _corpus_stats  # noqa: E402
+from hate_crack import plaintext as _plaintext  # noqa: E402
 from hate_crack import rulegen as _rulegen  # noqa: E402
 from hate_crack.menu import interactive_menu  # noqa: E402
 from hate_crack.username_detect import detect_username_hash_format  # noqa: E402
@@ -932,16 +933,15 @@ def _wordlist_path(path: str):
 def _usable_plaintext(raw: str) -> str:
     """Return the usable plaintext from a raw wordlist line, or empty string.
 
-    Blank/whitespace-only lines are discarded.  Lines in ``hash:password``
-    format (as produced by hashcat ``--show``) are split on the first colon
-    so only the plaintext portion is returned; lines with no colon are
-    returned as-is.  A ``hash:`` line whose plaintext is empty after
-    stripping returns an empty string and is therefore also discarded.
+    Blank/whitespace-only lines are discarded.  Leading hash fields (as
+    produced by hashcat ``--show``, i.e. ``hash:password``) are dropped, and a
+    ``$HEX[...]`` wrapper is decoded.  Both only when clearly present, so a
+    wordlist entry that merely contains a colon is returned intact.
 
-    Delegates to hate_crack.corpus_stats so the sampler and the whole-corpus
-    aggregator cannot drift apart on what counts as a password.
+    Delegates to hate_crack.plaintext so the sampler, the whole-corpus
+    aggregator, and rulegen cannot drift apart on what counts as a password.
     """
-    return _corpus_stats.usable_plaintext(raw)
+    return _plaintext.usable_plaintext(raw)
 
 
 def _add_debug_mode_for_rules(cmd):
@@ -2409,8 +2409,9 @@ def _clean_pattern(raw):
     Returns "" for anything unusable. The prompt asks for lowercase letters
     only, but the rule file is what supplies case, digits, and punctuation — so
     a model that decorates its answer anyway would otherwise get decorated a
-    second time by the rules, producing candidates like "Summer2024!123". The
-    filter is applied here rather than trusted to the prompt for that reason.
+    second time by the rules, stacking a suffix on top of one the model already
+    added. The filter is applied here rather than trusted to the prompt for that
+    reason.
     """
     if not isinstance(raw, str):
         return ""

--- a/hate_crack/plaintext.py
+++ b/hate_crack/plaintext.py
@@ -1,0 +1,128 @@
+"""Recover the plaintext password from a line of a corpus file.
+
+Every part of hate_crack that learns from a corpus — the LLM modes, the
+statistics in :mod:`hate_crack.corpus_stats`, the baseword/rule derivation in
+:mod:`hate_crack.rulegen` — has to answer the same question first: given this
+line, what was the password? The answer is not "the whole line", because the
+files operators actually reach for are hashcat's own output.
+
+Two things have to be undone:
+
+* **The hash prefix.** hashcat writes ``hash:plain`` (or ``hash:salt:plain``),
+  so a line from a ``.out`` file carries the hash in front of the password.
+* **The ``$HEX[...]`` wrapper.** hashcat applies it to any plaintext holding
+  non-ASCII bytes or the output separator.
+
+Both are undone conservatively: a line that does not clearly carry a hash is
+returned intact. That matters because the same functions read plain wordlists,
+where an entry may legitimately contain a colon — a URL, a ratio, a time of day
+— and splitting it would silently corrupt the corpus. Guessing wrong in that
+direction is worse than not splitting at all, because nothing downstream can
+detect it.
+
+This module deliberately has no imports from the rest of the package so both
+rulegen and corpus_stats can depend on it.
+"""
+
+import binascii
+
+# Lengths of a hex-encoded hash for the algorithms hate_crack actually sees:
+# LM/MySQL323 (16), MD4/MD5/NTLM (32), SHA1/MySQL41 (40), RIPEMD/SHA224 (48/56),
+# SHA256 (64), SHA384 (96), SHA512 (128).
+HEX_HASH_LENGTHS = frozenset({16, 32, 40, 48, 56, 64, 96, 128})
+
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _is_hex(value):
+    return bool(value) and all(c in _HEX_DIGITS for c in value)
+
+
+def is_hash_token(token):
+    """True if *token* has the shape of a hash rather than a password.
+
+    Recognizes hex digests at a known length, and crypt-style strings
+    (``$2y$10$...``, ``$6$...``). Length is what does the work: requiring an
+    exact digest length is why ``deadbeef`` and ``aabbcc`` — plausible
+    passwords, and plausible hash *stand-ins* in a test fixture — are left
+    alone, while a real 32-character NTLM digest is not.
+    """
+    if not token:
+        return False
+    if token.startswith("$HEX["):
+        # A wrapped plaintext, not a hash — see decode_hex_wrapper.
+        return False
+    if token.startswith("$") and token.count("$") >= 3:
+        return True
+    return len(token) in HEX_HASH_LENGTHS and _is_hex(token)
+
+
+def looks_like_hash_line(line):
+    """True if *line* looks like an uncracked hash record, not a cracked one.
+
+    Operators keep raw NTDS dumps (``user:rid:lm:nt:::``) in the same working
+    directory as cracked output, under similar names. A dump yields confident
+    nonsense rather than an error, so callers warn on it.
+    """
+    if line.endswith(":::"):
+        return True
+    # The empty-LM constant, present on every account in an NTDS dump.
+    if "aad3b435b51404eeaad3b435b51404ee" in line:
+        return True
+    fields = line.split(":")
+    # A bare digest with no plaintext after it.
+    if len(fields) == 1:
+        return is_hash_token(fields[0])
+    return False
+
+
+def strip_hash_prefix(line):
+    """Return the plaintext portion of *line*, dropping any leading hash fields.
+
+    Scans left to right and drops each leading field that has the shape of a
+    hash, then returns the remainder joined back together — so a plaintext that
+    itself contains colons survives intact, and a hash carrying its own colons
+    is fully consumed. A line whose first field is not hash-shaped is returned
+    unchanged.
+    """
+    if ":" not in line:
+        return line
+    fields = line.split(":")
+    idx = 0
+    while idx < len(fields) - 1 and is_hash_token(fields[idx]):
+        idx += 1
+    if idx == 0:
+        return line
+    return ":".join(fields[idx:])
+
+
+def decode_hex_wrapper(plaintext):
+    """Expand hashcat's ``$HEX[...]`` wrapper to the bytes it encodes.
+
+    Decoded to latin-1 so one byte maps to one character, matching how a corpus
+    is read elsewhere: hashcat rules address bytes, not codepoints. Returns
+    *plaintext* unchanged if it is not a well-formed wrapper, so malformed input
+    degrades to the previous behaviour rather than vanishing.
+    """
+    if not (plaintext.startswith("$HEX[") and plaintext.endswith("]")):
+        return plaintext
+    try:
+        return binascii.unhexlify(plaintext[5:-1]).decode("latin-1")
+    except (binascii.Error, ValueError):
+        return plaintext
+
+
+def usable_plaintext(raw):
+    """Return the password from a raw corpus line, or "" if there is none.
+
+    Blank and whitespace-only lines are discarded. Leading hash fields are
+    dropped and a ``$HEX[...]`` wrapper is decoded, both only when clearly
+    present.
+    """
+    stripped = raw.strip()
+    if not stripped:
+        return ""
+    stripped = strip_hash_prefix(stripped)
+    if not stripped:
+        return ""
+    return decode_hex_wrapper(stripped)

--- a/hate_crack/rulegen.py
+++ b/hate_crack/rulegen.py
@@ -31,6 +31,8 @@ emitting the password verbatim as its own baseword with a ``:`` no-op rule:
 import os
 from collections import Counter
 
+from hate_crack.plaintext import looks_like_hash_line, usable_plaintext
+
 POS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 # hashcat's rule engine accepts at most this many functions in a single rule.
@@ -193,11 +195,21 @@ def generate(
     total = 0
     skipped = 0
     literal_fallbacks = 0
+    hash_shaped = 0
     selfcheck_failures = []
 
     with open(corpus_path, encoding="latin-1") as fh:
         for line in fh:
-            pw = line.rstrip("\r\n")
+            stripped = line.rstrip("\r\n")
+            if looks_like_hash_line(stripped.strip()):
+                hash_shaped += 1
+            # The corpus this attack is built for is a previous engagement's
+            # cracked output, whose lines are "hash:password". Deriving from the
+            # whole line prepends the digest's hex digits to the baseword and
+            # spends 20-30 rule functions rebuilding them, which both poisons
+            # the baseword list and pushes real transformations over
+            # MAX_RULE_FUNCTIONS into the literal fallback.
+            pw = usable_plaintext(stripped)
             if pw == "":
                 continue
             if ascii_only and not _is_printable_ascii(pw):
@@ -263,6 +275,7 @@ def generate(
         f.write(f"unique basewords:    {len(base_counts)}\n")
         f.write(f"unique rules:        {len(rule_counts)}\n")
         f.write(f"literal fallbacks:   {literal_fallbacks}\n")
+        f.write(f"hash-shaped lines:   {hash_shaped}\n")
         if verify:
             f.write(f"self-check failures: {len(selfcheck_failures)} (must be 0)\n")
         f.write("\nrules needed for coverage:\n")
@@ -273,6 +286,12 @@ def generate(
         f"[*] {total} passwords -> {len(base_counts)} basewords, "
         f"{len(rule_counts)} rules ({literal_fallbacks} literal fallbacks)"
     )
+    if hash_shaped > total * 0.25:
+        print_fn(
+            f"[!] Warning: {hash_shaped} lines look like hashes rather than "
+            "plaintexts. This corpus may be an uncracked dump instead of cracked "
+            "output, in which case the basewords and rules below are meaningless."
+        )
     if selfcheck_failures:
         print_fn(
             f"[!] {len(selfcheck_failures)} passwords failed the reconstruction "
@@ -289,6 +308,7 @@ def generate(
         "basewords_count": len(base_counts),
         "rules_count": len(rule_counts),
         "literal_fallbacks": literal_fallbacks,
+        "hash_shaped": hash_shaped,
         "selfcheck_failures": selfcheck_failures,
         "milestones": milestones,
     }

--- a/tests/test_corpus_stats.py
+++ b/tests/test_corpus_stats.py
@@ -8,6 +8,10 @@ os.environ["HATE_CRACK_SKIP_INIT"] = "1"
 from hate_crack import corpus_stats  # noqa: E402
 from hate_crack import main as hc_main  # noqa: E402
 
+# A 32-character digest: hash fields are recognized by length, so a short
+# stand-in like "aabbcc" is correctly treated as part of a password.
+NTLM = "31d6cfe0d16ae931b73c59d7e0c089c0"
+
 
 # --------------------------------------------------------------------------
 # usable_plaintext / decode_hex_wrapper
@@ -17,12 +21,17 @@ from hate_crack import main as hc_main  # noqa: E402
 @pytest.mark.parametrize(
     "raw,expected",
     [
-        ("hunter2\n", "hunter2"),
+        ("token2\n", "token2"),
         ("", ""),
         ("   \t ", ""),
-        ("aabbcc:hunter2", "hunter2"),
-        ("aabbcc:", ""),
-        ("aabbcc:p@ss:word", "p@ss:word"),
+        (f"{NTLM}:token2", "token2"),
+        (f"{NTLM}:", ""),
+        # A plaintext may itself contain colons; only the hash field is dropped.
+        (f"{NTLM}:frag:ment", "frag:ment"),
+        # No recognizable hash field, so the line is a password in full. A
+        # wordlist entry holding a colon (URL, ratio, time) must survive.
+        ("aabbcc:token2", "aabbcc:token2"),
+        ("12:30", "12:30"),
     ],
 )
 def test_usable_plaintext(raw, expected):
@@ -30,14 +39,14 @@ def test_usable_plaintext(raw, expected):
 
 
 def test_hex_wrapper_is_decoded():
-    # "pässwörd!!" as UTF-8 bytes, which is how hashcat would emit it.
+    # "vwxyz!!" as UTF-8 bytes, which is how hashcat would emit it.
     assert corpus_stats.usable_plaintext("$HEX[70c3a4737377c3b672642121]") == (
         "p\xc3\xa4ssw\xc3\xb6rd!!"
     )
 
 
 def test_hex_wrapper_decoded_after_hash_split():
-    line = "31d6cfe0d16ae931b73c59d7e0c089c0:$HEX[68656c6c6f]"
+    line = f"{NTLM}:$HEX[68656c6c6f]"
     assert corpus_stats.usable_plaintext(line) == "hello"
 
 
@@ -56,8 +65,8 @@ def test_malformed_hex_wrapper_passes_through(value):
 
 
 def test_main_delegates_to_shared_plaintext_helper():
-    """The sampler and the aggregator must agree on what a password is."""
-    assert hc_main._usable_plaintext("aabbcc:$HEX[68656c6c6f]") == "hello"
+    """The sampler, the aggregator, and rulegen must agree on what a password is."""
+    assert hc_main._usable_plaintext(f"{NTLM}:$HEX[68656c6c6f]") == "hello"
 
 
 # --------------------------------------------------------------------------
@@ -73,27 +82,27 @@ def _corpus(tmp_path, passwords, name="corpus.txt"):
 
 def test_digit_only_basewords_excluded(tmp_path):
     """A PIN-heavy corpus must not fill the baseword list with digit strings."""
-    path = _corpus(tmp_path, ["1234", "5678", "9012", "summer"])
+    path = _corpus(tmp_path, ["1234", "5678", "9012", "alpha"])
     words = dict(corpus_stats.summarize(path)["basewords"])
-    assert set(words) == {"summer"}
+    assert set(words) == {"alpha"}
     # The digit-only share is still reported, just not as basewords.
     text = corpus_stats.format_summary(corpus_stats.summarize(path))
     assert "no letters" in text
 
 
 def test_summarize_counts_whole_corpus(tmp_path):
-    path = _corpus(tmp_path, ["Summer2024!", "summer1", "Winter2024", "summer1"])
+    path = _corpus(tmp_path, ["Alpha2024!", "alpha1", "Bravo2024", "alpha1"])
     stats = corpus_stats.summarize(path)
 
     assert stats["total"] == 4
     assert stats["unique"] == 3
     basewords = dict(stats["basewords"])
-    assert basewords["summer"] == 3
-    assert basewords["winter"] == 1
+    assert basewords["alpha"] == 3
+    assert basewords["bravo"] == 1
 
 
 def test_summarize_reports_shapes_masks_and_years(tmp_path):
-    path = _corpus(tmp_path, ["Summer2024!", "summer1", "WINTER", "sUmMeR"])
+    path = _corpus(tmp_path, ["Alpha2024!", "alpha1", "BRAVO", "aLpHa"])
     stats = corpus_stats.summarize(path)
 
     shapes = dict(stats["shapes"])
@@ -106,7 +115,7 @@ def test_summarize_reports_shapes_masks_and_years(tmp_path):
     assert dict(stats["digit_suffixes"])["1"] == 1
     assert dict(stats["special_suffixes"])["!"] == 1
     assert dict(stats["specials"])["!"] == 1
-    assert ("?u?l?l?l?l?l?d?d?d?d?s", 1) in stats["masks"]
+    assert ("?u?l?l?l?l?d?d?d?d?s", 1) in stats["masks"]
 
 
 def test_summarize_lengths(tmp_path):
@@ -119,19 +128,19 @@ def test_summarize_splits_hash_prefixed_lines(tmp_path):
     path = _corpus(
         tmp_path,
         [
-            "31d6cfe0d16ae931b73c59d7e0c089c0:Summer2024!",
-            "8846f7eaee8fb117ad06bdd830b7586c:Summer2025!",
+            "31d6cfe0d16ae931b73c59d7e0c089c0:Alpha2024!",
+            "8846f7eaee8fb117ad06bdd830b7586c:Alpha2025!",
         ],
     )
     stats = corpus_stats.summarize(path)
-    assert dict(stats["basewords"])["summer"] == 2
+    assert dict(stats["basewords"])["alpha"] == 2
     assert stats["baseword_total"] == 1
 
 
 def test_summarize_decodes_hex_before_aggregating(tmp_path):
-    path = _corpus(tmp_path, ["$HEX[73756d6d6572]", "summer"])
+    path = _corpus(tmp_path, ["$HEX[616c706861]", "alpha"])
     stats = corpus_stats.summarize(path)
-    assert dict(stats["basewords"])["summer"] == 2
+    assert dict(stats["basewords"])["alpha"] == 2
     assert stats["baseword_total"] == 1
 
 
@@ -143,21 +152,21 @@ def test_summarize_decodes_hex_before_aggregating(tmp_path):
         "aad3b435b51404eeaad3b435b51404ee:x",
     ],
 )
-def test_looks_like_hash_detects_dump_lines(line):
-    assert corpus_stats.looks_like_hash(line)
+def test_looks_like_hash_line_detects_dump_lines(line):
+    assert corpus_stats.looks_like_hash_line(line)
 
 
 @pytest.mark.parametrize(
     "line",
     [
-        "Summer2024!",
-        "p@ss:word",
+        "Alpha2024!",
+        "frag:ment",
         "correct horse battery staple",
         "deadbeef",  # hex but far too short to be a hash
     ],
 )
-def test_looks_like_hash_leaves_real_passwords_alone(line):
-    assert not corpus_stats.looks_like_hash(line)
+def test_looks_like_hash_line_leaves_plaintexts_alone(line):
+    assert not corpus_stats.looks_like_hash_line(line)
 
 
 def test_summarize_counts_hash_shaped_lines(tmp_path):
@@ -170,7 +179,7 @@ def test_summarize_counts_hash_shaped_lines(tmp_path):
     stats = corpus_stats.summarize(_corpus(tmp_path, dump))
     assert stats["hash_shaped"] == 10
 
-    clean = corpus_stats.summarize(_corpus(tmp_path, ["Summer1"], name="clean.txt"))
+    clean = corpus_stats.summarize(_corpus(tmp_path, ["Alpha1"], name="clean.txt"))
     assert clean["hash_shaped"] == 0
 
 
@@ -187,7 +196,7 @@ def test_corpus_context_warns_on_a_hash_dump(tmp_path, monkeypatch, capsys):
 
 def test_corpus_context_does_not_warn_on_plaintexts(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(hc_main, "ollamaMaxSampleLines", 500, raising=False)
-    path = _corpus(tmp_path, ["Summer2024!", "Winter2025!"])
+    path = _corpus(tmp_path, ["Alpha2024!", "Bravo2025!"])
     hc_main._corpus_context(path)
     assert "look like hashes" not in capsys.readouterr().out
 
@@ -224,12 +233,12 @@ def test_output_is_bounded_regardless_of_corpus_size(tmp_path):
 
 def test_singleton_basewords_dropped_on_large_corpus(tmp_path):
     """Above the floor threshold, seen-once basewords are noise."""
-    passwords = ["summer"] * 600 + ["qwertyuniquething"]
+    passwords = ["alpha"] * 600 + ["zetauniquetoken"]
     path = _corpus(tmp_path, passwords)
     stats = corpus_stats.summarize(path)
     words = dict(stats["basewords"])
-    assert words["summer"] == 600
-    assert "qwertyuniquething" not in words
+    assert words["alpha"] == 600
+    assert "zetauniquetoken" not in words
 
 
 def test_singletons_kept_on_small_corpus(tmp_path):
@@ -245,20 +254,20 @@ def test_singletons_kept_on_small_corpus(tmp_path):
 
 
 def test_format_summary_mentions_whole_corpus_and_top_baseword(tmp_path):
-    path = _corpus(tmp_path, ["Summer2024!", "summer1", "Winter2024"])
+    path = _corpus(tmp_path, ["Alpha2024!", "alpha1", "Bravo2024"])
     text = corpus_stats.format_summary(corpus_stats.summarize(path))
 
     assert "ENTIRE corpus" in text
     assert "3 passwords" in text
-    assert "summer" in text
+    assert "alpha" in text
     assert "Casing" in text and "Masks" in text
 
 
 def test_format_summary_reports_counts_and_shares(tmp_path):
-    path = _corpus(tmp_path, ["summer"] * 3 + ["winter"])
+    path = _corpus(tmp_path, ["alpha"] * 3 + ["bravo"])
     text = corpus_stats.format_summary(corpus_stats.summarize(path))
-    assert "summer (3x, 75%)" in text
-    assert "winter (1x, 25%)" in text
+    assert "alpha (3x, 75%)" in text
+    assert "bravo (1x, 25%)" in text
 
 
 def test_share_precision_adapts_to_small_shares():
@@ -298,21 +307,21 @@ def test_format_summary_handles_empty_sections(tmp_path):
 
 def test_corpus_context_includes_plaintexts_when_all_fit(tmp_path, monkeypatch):
     monkeypatch.setattr(hc_main, "ollamaMaxSampleLines", 500, raising=False)
-    path = _corpus(tmp_path, ["Summer2024!", "Winter2024"])
+    path = _corpus(tmp_path, ["Alpha2024!", "Bravo2024"])
 
     context = hc_main._corpus_context(path)
-    assert "Summer2024!" in context["sample"]
+    assert "Alpha2024!" in context["sample"]
     assert "ENTIRE corpus" in context["summary"]
 
 
 def test_corpus_context_drops_plaintexts_above_the_cap(tmp_path, monkeypatch):
     monkeypatch.setattr(hc_main, "ollamaMaxSampleLines", 10, raising=False)
-    path = _corpus(tmp_path, [f"Summer{i:04d}!" for i in range(100)])
+    path = _corpus(tmp_path, [f"Alpha{i:04d}!" for i in range(100)])
 
     context = hc_main._corpus_context(path)
     assert "sample" not in context
     assert "100 passwords" in context["summary"]
-    assert "summer" in context["summary"]
+    assert "alpha" in context["summary"]
 
 
 def test_corpus_context_invalid_cap_falls_back_to_500(tmp_path, monkeypatch):

--- a/tests/test_hcat_ollama.py
+++ b/tests/test_hcat_ollama.py
@@ -13,6 +13,11 @@ from hate_crack import main as hc_main  # noqa: E402
 OLLAMA_URL = "http://localhost:11434"
 MODEL = "qwen2.5:32b"
 
+# Hash fields are recognized by digest length, so fixtures need realistic ones:
+# a short stand-in is correctly read as part of the password.
+DIGEST_A = "31d6cfe0d16ae931b73c59d7e0c089c0"
+DIGEST_B = "8846f7eaee8fb117ad06bdd830b7586c"
+
 
 @pytest.fixture
 def ollama_env(tmp_path):
@@ -90,7 +95,7 @@ def test_wordlist_mode_reads_file_and_passes_sample(ollama_env):
 def test_wordlist_mode_strips_hash_prefix(ollama_env):
     # hash:password lines should contribute only the post-colon plaintext.
     dump = ollama_env.tmp_path / "dump.txt"
-    dump.write_text("aad3b435:Winter2024\nnocolonline\n")
+    dump.write_text(f"{DIGEST_A}:Bravo2024\nnocolonline\n")
     with (
         ollama_globals(ollama_env.tmp_path),
         mock.patch(
@@ -100,8 +105,8 @@ def test_wordlist_mode_strips_hash_prefix(ollama_env):
     ):
         hc_main.hcatOllama("0", ollama_env.hash_file, "wordlist", str(dump))
     sample = gen.call_args[0][4]["sample"]
-    assert "Winter2024" in sample
-    assert "aad3b435" not in sample
+    assert "Bravo2024" in sample
+    assert DIGEST_A not in sample
     assert "nocolonline" in sample
 
 
@@ -306,7 +311,7 @@ def test_unknown_mode_prints_error(ollama_env, capsys):
 def test_cracked_mode_samples_out_file(ollama_env):
     """cracked mode reads <hashfile>.out and passes the plaintexts as the sample."""
     with open(f"{ollama_env.hash_file}.out", "w") as f:
-        f.write("aad3b435:Summer2024!\nbbccddee:Acme2023\n")
+        f.write(f"{DIGEST_A}:Alpha2024!\n{DIGEST_B}:Delta2023\n")
 
     with (
         ollama_globals(ollama_env.tmp_path),
@@ -320,9 +325,9 @@ def test_cracked_mode_samples_out_file(ollama_env):
     args = gen.call_args[0]
     assert args[3] == "cracked"
     sample = args[4]["sample"].splitlines()
-    assert sample == ["Summer2024!", "Acme2023"]
+    assert sample == ["Alpha2024!", "Delta2023"]
     # Hash portions must not leak into the prompt.
-    assert "aad3b435" not in args[4]["sample"]
+    assert DIGEST_A not in args[4]["sample"]
 
 
 def test_cracked_mode_accepts_explicit_path(ollama_env):

--- a/tests/test_llm_pattern_rules.py
+++ b/tests/test_llm_pattern_rules.py
@@ -31,8 +31,8 @@ def test_pattern_mode_has_a_prompt():
 
 
 def test_pattern_request_embeds_the_sample():
-    request = llm._build_request("pattern", {"sample": "Acme2024!\nWidget99"})
-    assert "Acme2024!" in request and "Widget99" in request
+    request = llm._build_request("pattern", {"sample": "Delta2024!\nGamma99"})
+    assert "Delta2024!" in request and "Gamma99" in request
 
 
 def test_pattern_request_asks_for_undecorated_basewords():
@@ -53,10 +53,10 @@ def test_unknown_mode_still_rejected():
 @pytest.mark.parametrize(
     "raw,expected",
     [
-        ("summer", "summer"),
-        ("Summer2024!", "summer"),
-        ("ACME", "acme"),
-        ("acme widgets", "acmewidgets"),
+        ("alpha", "alpha"),
+        ("Alpha2024!", "alpha"),
+        ("DELTA", "delta"),
+        ("delta gammas", "deltagammas"),
         ("s3cr3t", "scrt"),
         ("a1", ""),  # under MIN_PATTERN_LEN once digits are stripped
         ("123456", ""),
@@ -80,7 +80,7 @@ def pattern_env(tmp_path):
     hash_file = tmp_path / "hashes.txt"
     hash_file.touch()
     corpus = tmp_path / "corpus.txt"
-    corpus.write_text("Acme2024!\nSummer99\nWidget1\n")
+    corpus.write_text("Delta2024!\nAlpha99\nGamma1\n")
     return SimpleNamespace(
         tmp_path=tmp_path, hash_file=str(hash_file), corpus=str(corpus)
     )
@@ -106,7 +106,7 @@ def test_patterns_written_and_rules_passed_through(pattern_env):
         pattern_globals(pattern_env.tmp_path),
         mock.patch(
             "hate_crack.main.llm.generate_candidates",
-            return_value=["Acme2024!", "widgets", "summer"],
+            return_value=["Delta2024!", "gammas", "alpha"],
         ) as gen,
         mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
     ):
@@ -115,10 +115,10 @@ def test_patterns_written_and_rules_passed_through(pattern_env):
         )
 
     assert gen.call_args[0][3] == "pattern"
-    assert "Acme2024!" in gen.call_args[0][4]["sample"]
+    assert "Delta2024!" in gen.call_args[0][4]["sample"]
 
     patterns_path = f"{pattern_env.hash_file}.llm_patterns"
-    assert open(patterns_path).read().split() == ["acme", "widgets", "summer"]
+    assert open(patterns_path).read().split() == ["delta", "gammas", "alpha"]
 
     quick.assert_called_once()
     args = quick.call_args[0]
@@ -130,7 +130,7 @@ def test_patterns_written_and_rules_passed_through(pattern_env):
 def test_no_rules_chain_is_allowed(pattern_env):
     with (
         pattern_globals(pattern_env.tmp_path),
-        mock.patch("hate_crack.main.llm.generate_candidates", return_value=["summer"]),
+        mock.patch("hate_crack.main.llm.generate_candidates", return_value=["alpha"]),
         mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
     ):
         hc_main.hcatOllamaPatterns(
@@ -143,7 +143,7 @@ def test_chained_rules_pass_through_verbatim(pattern_env):
     chain = " -r best64.rule -r toggles1.rule"
     with (
         pattern_globals(pattern_env.tmp_path),
-        mock.patch("hate_crack.main.llm.generate_candidates", return_value=["summer"]),
+        mock.patch("hate_crack.main.llm.generate_candidates", return_value=["alpha"]),
         mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
     ):
         hc_main.hcatOllamaPatterns(
@@ -157,7 +157,7 @@ def test_multiple_chains_infer_once_and_reuse_the_baseword_file(pattern_env):
     with (
         pattern_globals(pattern_env.tmp_path),
         mock.patch(
-            "hate_crack.main.llm.generate_candidates", return_value=["summer"]
+            "hate_crack.main.llm.generate_candidates", return_value=["alpha"]
         ) as gen,
         mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
     ):
@@ -184,7 +184,7 @@ def test_multiple_chains_infer_once_and_reuse_the_baseword_file(pattern_env):
 def test_empty_chain_list_infers_but_runs_nothing(pattern_env):
     with (
         pattern_globals(pattern_env.tmp_path),
-        mock.patch("hate_crack.main.llm.generate_candidates", return_value=["summer"]),
+        mock.patch("hate_crack.main.llm.generate_candidates", return_value=["alpha"]),
         mock.patch("hate_crack.main.hcatQuickDictionary") as quick,
     ):
         hc_main.hcatOllamaPatterns(
@@ -198,8 +198,8 @@ def test_duplicate_patterns_deduped_after_cleaning(pattern_env):
         pattern_globals(pattern_env.tmp_path),
         mock.patch(
             "hate_crack.main.llm.generate_candidates",
-            # All three clean to "acme" — the model decorated its own output.
-            return_value=["acme", "ACME", "Acme2024"],
+            # All three clean to "delta" — the model decorated its own output.
+            return_value=["delta", "DELTA", "Delta2024"],
         ),
         mock.patch("hate_crack.main.hcatQuickDictionary"),
     ):
@@ -207,7 +207,7 @@ def test_duplicate_patterns_deduped_after_cleaning(pattern_env):
             "1000", pattern_env.hash_file, pattern_env.corpus, ""
         )
     patterns_path = f"{pattern_env.hash_file}.llm_patterns"
-    assert open(patterns_path).read().split() == ["acme"]
+    assert open(patterns_path).read().split() == ["delta"]
 
 
 def test_missing_source_skips_the_model(pattern_env):
@@ -277,7 +277,7 @@ def _pattern_ctx(tmp_path, has_cracked=False):
     hash_file = tmp_path / "hashes.txt"
     hash_file.touch()
     if has_cracked:
-        (tmp_path / "hashes.txt.out").write_text("hash:Summer2024!\n")
+        (tmp_path / "hashes.txt.out").write_text("hash:Alpha2024!\n")
     return SimpleNamespace(
         hcatHashType="1000",
         hcatHashFile=str(hash_file),
@@ -312,7 +312,7 @@ def test_mode_4_hands_all_chains_over_in_one_call(tmp_path):
     """Every chain goes over at once so the model is queried once, not per rule."""
     ctx = _pattern_ctx(tmp_path)
     corpus = tmp_path / "corpus.txt"
-    corpus.write_text("Summer2024!\n")
+    corpus.write_text("Alpha2024!\n")
 
     with (
         mock.patch.object(hc_attacks, "interactive_menu", return_value="4"),
@@ -385,7 +385,7 @@ def test_llm_patterns_removed_by_cleanup(tmp_path, monkeypatch):
     hash_file = str(tmp_path / "hashes.txt")
     patterns_path = hash_file + ".llm_patterns"
     with open(patterns_path, "w") as f:
-        f.write("acme\n")
+        f.write("delta\n")
 
     monkeypatch.setattr(hc_main, "hcatHashFile", hash_file, raising=False)
     monkeypatch.setattr(hc_main, "hcatHashFileOrig", hash_file, raising=False)

--- a/tests/test_ollama_wordlist_sampling.py
+++ b/tests/test_ollama_wordlist_sampling.py
@@ -21,6 +21,17 @@ import pytest
 os.environ["HATE_CRACK_SKIP_INIT"] = "1"
 from hate_crack import main as hc_main  # noqa: E402
 
+
+def _digest(i: int) -> str:
+    """A 32-character digest-shaped hash field.
+
+    Hash fields are recognized by digest length, so a short stand-in like
+    "aabbcc" or "h0" is treated as part of the password (a wordlist entry may
+    legitimately contain a colon). Fixtures therefore need realistic lengths.
+    """
+    return f"{i:032x}"
+
+
 OLLAMA_URL = "http://localhost:11434"
 MODEL = "test-model"
 
@@ -262,13 +273,14 @@ def test_wordlist_sampling_strips_hash_prefix(env):
     wl = env.tmp_path / "dump.txt"
     # 20 lines: half with colon prefix, half plain; more than max_sample=5
     lines = [
-        f"hash{i}:plain{i:02d}" if i % 2 == 0 else f"plain{i:02d}" for i in range(20)
+        f"{_digest(i)}:plain{i:02d}" if i % 2 == 0 else f"plain{i:02d}"
+        for i in range(20)
     ]
     wl.write_text("\n".join(lines) + "\n")
 
     sample = "\n".join(hc_main._sample_plaintext_file(str(wl), 5))
-    # No hash prefix should appear in the sample
-    assert "hash" not in sample
+    # Only plaintexts survive; no digest characters carry through.
+    assert all(line.startswith("plain") for line in sample.splitlines())
 
 
 def test_wordlist_sampling_skips_blank_lines(env, capsys):
@@ -337,17 +349,17 @@ def test_usable_plaintext_plain_password():
 
 def test_usable_plaintext_hash_colon_password():
     """A hash:password line returns only the password portion."""
-    assert hc_main._usable_plaintext("aabbcc:hunter2") == "hunter2"
+    assert hc_main._usable_plaintext(f"{_digest(1)}:token2") == "token2"
 
 
 def test_usable_plaintext_multiple_colons():
     """A line with multiple colons splits only on the first colon."""
-    assert hc_main._usable_plaintext("aabbcc:p@ss:word") == "p@ss:word"
+    assert hc_main._usable_plaintext(f"{_digest(1)}:frag:ment") == "frag:ment"
 
 
 def test_usable_plaintext_hash_colon_empty():
     """A hash: line with no plaintext after the colon returns empty string."""
-    assert hc_main._usable_plaintext("aabbcc:") == ""
+    assert hc_main._usable_plaintext(f"{_digest(1)}:") == ""
 
 
 # ---------------------------------------------------------------------------
@@ -429,7 +441,7 @@ def test_cracked_mode_caps_large_out_file(env, capsys):
     """A large .out file gets the same evenly-spaced capping as a wordlist."""
     out_path = env.hash_file + ".out"
     with open(out_path, "w") as f:
-        f.write("\n".join(f"h{i}:pw{i:06d}" for i in range(1000)) + "\n")
+        f.write("\n".join(f"{_digest(i)}:pw{i:06d}" for i in range(1000)) + "\n")
 
     sample_lines = hc_main._sample_plaintext_file(
         out_path, 25, source_label="cracked passwords"
@@ -448,7 +460,7 @@ def test_cracked_mode_above_cap_sends_stats_not_raw_lines(env):
     """Above the cap the model gets whole-corpus statistics, never a slice."""
     out_path = env.hash_file + ".out"
     with open(out_path, "w") as f:
-        f.write("\n".join(f"h{i}:Summer{i:04d}!" for i in range(1000)) + "\n")
+        f.write("\n".join(f"{_digest(i)}:Alpha{i:04d}!" for i in range(1000)) + "\n")
 
     with (
         _ollama_globals(env.tmp_path, max_sample=25),
@@ -465,4 +477,4 @@ def test_cracked_mode_above_cap_sends_stats_not_raw_lines(env):
     assert "1000 passwords" in summary
     # The dominant baseword of the whole corpus, which a 25-line slice could
     # not have established.
-    assert "summer" in summary
+    assert "alpha" in summary

--- a/tests/test_plaintext.py
+++ b/tests/test_plaintext.py
@@ -1,0 +1,162 @@
+"""Unit tests for hate_crack.plaintext — recovering the password from a line."""
+
+import os
+
+import pytest
+
+os.environ["HATE_CRACK_SKIP_INIT"] = "1"
+from hate_crack import plaintext  # noqa: E402
+
+NTLM = "31d6cfe0d16ae931b73c59d7e0c089c0"  # 32
+SHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709"  # 40
+LM = "aad3b435b51404ee"  # 16
+# The empty-LM constant present on every account in an NTDS dump.
+EMPTY_LM = "aad3b435b51404eeaad3b435b51404ee"
+BCRYPT = "$2y$10$abcdefghijklmnopqrstuv"
+
+
+# --------------------------------------------------------------------------
+# is_hash_token
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("token", [NTLM, SHA1, LM, BCRYPT, NTLM.upper()])
+def test_recognizes_hash_shaped_tokens(token):
+    assert plaintext.is_hash_token(token)
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "",
+        "aabbcc",  # hex, but no digest is 6 characters
+        "deadbeef",  # ditto, 8
+        "abcdefghijklmnopqrstuvwxyzabcdef",  # 32 chars but not hex
+        "31d6cfe0d16ae931b73c59d7e0c089c",  # 31 — one short of NTLM
+        "$HEX[68656c6c6f]",  # a wrapped plaintext, not a hash
+        "alpha",
+    ],
+)
+def test_rejects_non_hash_tokens(token):
+    assert not plaintext.is_hash_token(token)
+
+
+# --------------------------------------------------------------------------
+# strip_hash_prefix
+# --------------------------------------------------------------------------
+
+
+def test_strips_a_single_hash_field():
+    assert plaintext.strip_hash_prefix(f"{NTLM}:token1") == "token1"
+
+
+def test_strips_multiple_leading_hash_fields():
+    """hashcat writes hash:salt:plain for salted algorithms."""
+    assert plaintext.strip_hash_prefix(f"{LM}:{NTLM}:token1") == "token1"
+
+
+def test_keeps_colons_inside_the_plaintext():
+    assert plaintext.strip_hash_prefix(f"{NTLM}:frag:ment") == "frag:ment"
+
+
+def test_leaves_a_line_with_no_hash_field_intact():
+    """A wordlist entry may hold a colon — a URL, a ratio, a time of day."""
+    for line in ("aabbcc:token1", "12:30", "ratio:1:2", "scheme://host/path"):
+        assert plaintext.strip_hash_prefix(line) == line
+
+
+def test_line_without_a_colon_is_returned_as_is():
+    assert plaintext.strip_hash_prefix("token1") == "token1"
+
+
+def test_trailing_colon_after_a_hash_yields_nothing():
+    assert plaintext.strip_hash_prefix(f"{NTLM}:") == ""
+
+
+def test_never_consumes_the_final_field():
+    """Even if the plaintext itself looks like a digest, something must remain."""
+    assert plaintext.strip_hash_prefix(f"{NTLM}:{SHA1}") == SHA1
+
+
+# --------------------------------------------------------------------------
+# decode_hex_wrapper
+# --------------------------------------------------------------------------
+
+
+def test_decodes_a_hex_wrapper():
+    assert plaintext.decode_hex_wrapper("$HEX[68656c6c6f]") == "hello"
+
+
+def test_decodes_high_bytes_one_byte_per_character():
+    """Byte-per-character, because hashcat rules address bytes, not codepoints."""
+    decoded = plaintext.decode_hex_wrapper("$HEX[76c3a477]")
+    assert decoded == "v\xc3\xa4w"
+    assert len(decoded) == 4
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "$HEX[nothex]",
+        "$HEX[abc]",  # odd length
+        "$HEX[6865",  # unterminated
+        "$HEXX[6865]",
+        "notawrapper",
+    ],
+)
+def test_malformed_wrapper_passes_through(value):
+    assert plaintext.decode_hex_wrapper(value) == value
+
+
+# --------------------------------------------------------------------------
+# usable_plaintext
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("token1\n", "token1"),
+        ("  token1  \n", "token1"),
+        ("", ""),
+        ("   \t ", ""),
+        (f"{NTLM}:token1", "token1"),
+        (f"{NTLM}:", ""),
+        (f"{NTLM}:$HEX[68656c6c6f]", "hello"),
+        ("$HEX[68656c6c6f]", "hello"),
+        ("aabbcc:token1", "aabbcc:token1"),
+    ],
+)
+def test_usable_plaintext(raw, expected):
+    assert plaintext.usable_plaintext(raw) == expected
+
+
+# --------------------------------------------------------------------------
+# looks_like_hash_line
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        f"user:1103:{EMPTY_LM}:{NTLM}:::",
+        f"{NTLM}",  # a bare digest with no plaintext after it
+        f"{EMPTY_LM}:x",
+    ],
+)
+def test_flags_uncracked_dump_lines(line):
+    assert plaintext.looks_like_hash_line(line)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "Alpha2024!",
+        f"{NTLM}:Alpha2024!",  # cracked: has a plaintext
+        "correct horse battery staple",
+        "deadbeef",
+        "aabbcc:token1",
+    ],
+)
+def test_does_not_flag_cracked_or_plain_lines(line):
+    assert not plaintext.looks_like_hash_line(line)

--- a/tests/test_rulegen.py
+++ b/tests/test_rulegen.py
@@ -193,3 +193,88 @@ class TestGenerate:
         report = (out / "coverage.txt").read_text(encoding="latin-1")
         assert corpus in report
         assert "self-check failures: 0" in report
+
+
+class TestCorpusLineParsing:
+    """The corpus this attack is built for is a previous engagement's cracked
+    output, whose lines carry the hash in front of the password."""
+
+    NTLM = "31d6cfe0d16ae931b73c59d7e0c089c0"
+    NTLM_B = "8846f7eaee8fb117ad06bdd830b7586c"
+    EMPTY_LM = "aad3b435b51404eeaad3b435b51404ee"
+
+    def _write(self, tmp_path, lines, name="corpus.txt"):
+        path = tmp_path / name
+        path.write_text("\n".join(lines) + "\n", encoding="latin-1")
+        return str(path)
+
+    def _run(self, tmp_path, lines):
+        corpus = self._write(tmp_path, lines)
+        return rulegen.generate(corpus, str(tmp_path / "out"), print_fn=lambda *a: None)
+
+    def _basewords(self, result):
+        with open(result["basewords"], encoding="latin-1") as f:
+            return f.read().split()
+
+    def test_hash_prefix_does_not_reach_the_baseword(self, tmp_path):
+        """Deriving from the whole line prepended the digest's hex digits."""
+        result = self._run(tmp_path, [f"{self.NTLM}:Alphabet", f"{self.NTLM_B}:Bravo"])
+        assert sorted(self._basewords(result)) == ["alphabet", "bravo"]
+
+    def test_rules_stay_short_without_the_hash_prefix(self, tmp_path):
+        """Rebuilding a 32-character prefix consumed most of MAX_RULE_FUNCTIONS."""
+        result = self._run(tmp_path, [f"{self.NTLM}:Alphabet1"])
+        with open(result["rules"], encoding="latin-1") as f:
+            rules = f.read().split()
+        assert all(rulegen.count_ops(r) <= 3 for r in rules), rules
+
+    def test_rules_merge_across_passwords_sharing_a_transformation(self, tmp_path):
+        """The whole point of the rule file: rank by productivity, then truncate.
+
+        With the hash prefix included every rule was unique, so the ranking
+        carried no information and a capped set was no cheaper than the full one.
+        """
+        result = self._run(
+            tmp_path,
+            [
+                f"{self.NTLM}:Alphabet1",
+                f"{self.NTLM_B}:Bravoword1",
+                f"{self.NTLM}:Charlieword1",
+            ],
+        )
+        assert result["rules_count"] == 1
+        assert result["total"] == 3
+
+    def test_hex_wrapped_plaintext_is_decoded(self, tmp_path):
+        result = self._run(tmp_path, ["$HEX[616c706861]", "alpha"])
+        assert self._basewords(result) == ["alpha"]
+        assert result["basewords_count"] == 1
+
+    def test_plaintext_containing_a_colon_survives(self, tmp_path):
+        """A wordlist entry may hold a colon; only real hash fields are dropped."""
+        result = self._run(tmp_path, ["12:30", "aabbcc:token"])
+        assert result["total"] == 2
+        assert "aabbcc" in "".join(self._basewords(result))
+
+    def test_uncracked_dump_is_counted_and_reported(self, tmp_path):
+        lines = [
+            f"user{i}:{1100 + i}:{self.EMPTY_LM}:{self.NTLM}:::" for i in range(10)
+        ]
+        messages = []
+        corpus = self._write(tmp_path, lines)
+        result = rulegen.generate(
+            corpus, str(tmp_path / "out"), print_fn=messages.append
+        )
+        assert result["hash_shaped"] == 10
+        assert any("look like hashes" in m for m in messages)
+        report = (tmp_path / "out" / "coverage.txt").read_text(encoding="latin-1")
+        assert "hash-shaped lines:   10" in report
+
+    def test_cracked_output_triggers_no_warning(self, tmp_path):
+        messages = []
+        corpus = self._write(tmp_path, [f"{self.NTLM}:Alphabet1", "Bravoword2"])
+        result = rulegen.generate(
+            corpus, str(tmp_path / "out"), print_fn=messages.append
+        )
+        assert result["hash_shaped"] == 0
+        assert not any("look like hashes" in m for m in messages)


### PR DESCRIPTION
Stacked on #197 — **base is `feat/llm-corpus-stats`.** Merge #194, then #197, then this.

## The bug

The Spoonman attack treated each corpus line as a password in full. But the corpus it is built for — and that its own menu text recommends — is a previous engagement's cracked output, whose lines are `hash:password`. The digest's hex digits were therefore prepended to every baseword, and 20–30 of the 31 available rule functions were spent rebuilding them.

The damage compounded in two ways that matter more than the ugly basewords:

1. **The rule ranking became meaningless.** Every hash is unique, so every derived rule was unique too. That destroys the property the attack exists for — a rule file sorted by how many passwords each rule rebuilds, and therefore safe to truncate.
2. **Real transformations fell off a cliff.** Rebuilding a 32-character prefix nearly exhausts `MAX_RULE_FUNCTIONS`, so genuine transformations tipped over the limit into the literal fallback, which emits the password as its own baseword. The corpus became its own wordlist.

Measured on a 22,283-line cracked-output file:

| Metric | Before | After |
|---|---|---|
| Distinct basewords | 22,284 | 9,912 |
| Literal fallbacks | 5,388 | 31 |
| Rules for 95% coverage | 15,783 | 11,730 |

"22,284 basewords from 22,284 lines" is the tell: there was no deduplication at all, because each hash made each baseword unique.

## The fix

New `hate_crack/plaintext.py` holds one implementation of *given this line, what was the password* — shared by `rulegen`, `corpus_stats`, and the LLM read path so the three cannot drift apart. (Its own module rather than living in `corpus_stats`, which already imports `rulegen`.)

Stripping is based on **digest shape**, not on the first colon. A leading field is dropped only when it looks like a hash: a hex digest at a known length (16/32/40/48/56/64/96/128) or a crypt-style `$id$` string. Consequences:

- `hash:salt:plain` is handled — leading hash-shaped fields are consumed left to right.
- A plaintext that itself contains colons survives intact.
- A wordlist entry that merely contains a colon — a URL, a ratio, a time of day — is no longer truncated. **The LLM read path did truncate these before**, since it split unconditionally on the first colon; that's fixed here too.

Guessing wrong in the splitting direction is worse than not splitting, because nothing downstream can detect a silently corrupted corpus. So the rule is deliberately conservative: anything not clearly a hash is left alone.

Also carried into `rulegen`, both from #197's LLM path:

- `$HEX[...]` plaintexts are decoded.
- A corpus that looks like an uncracked dump rather than cracked output is counted in `coverage.txt` and warned about, instead of silently producing confident nonsense.

## Note on test fixtures

Length is now what identifies a hash field, so short stand-ins (`aabbcc:`, `h0:`) are correctly read as part of a password. Fixtures across the LLM and rulegen tests move to digest-shaped values. Two pre-existing assertions changed meaning as a result and were updated deliberately, not worked around — an unrecognized leading field now yields the whole line.

## Verification

- `1324 passed, 29 skipped`.
- `ruff check` / `ruff format --check` clean; `bandit` exits 0 against baseline; `ty` diagnostics unchanged at 51.
- Before/after metrics above measured by running `rulegen.generate` on the same input from both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)