### PR TITLE
Remove orphaned combinator wrappers

### DIFF
--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -540,21 +540,6 @@ def _prompt_wordlist_paths(ctx, max_count: int) -> list[str]:
     return collected
 
 
-def combinator3_crack(ctx: Any) -> None:
-    """3-way combinator attack (delegates to unified combinator_crack)."""
-    combinator_crack(ctx)
-
-
-def combinatorX_crack(ctx: Any) -> None:
-    """N-way combinator attack (delegates to unified combinator_crack)."""
-    combinator_crack(ctx)
-
-
-def combinator_3plus_crack(ctx: Any) -> None:
-    """3+ wordlist combinator (delegates to unified combinator_crack)."""
-    combinator_crack(ctx)
-
-
 def bandrel_method(ctx: Any) -> None:
     _notify.prompt_notify_for_attack("Bandrel")
     ctx.hcatBandrel(ctx.hcatHashType, ctx.hcatHashFile)

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -4262,18 +4262,6 @@ def middle_combinator():
     return _attacks.middle_combinator(_attack_ctx())
 
 
-def combinator3_crack():
-    return _attacks.combinator3_crack(_attack_ctx())
-
-
-def combinatorX_crack():
-    return _attacks.combinatorX_crack(_attack_ctx())
-
-
-def combinator_3plus_crack():
-    return _attacks.combinator_3plus_crack(_attack_ctx())
-
-
 def ngram_attack():
     return _attacks.ngram_attack(_attack_ctx())
 


### PR DESCRIPTION
## Summary

Closes #208.

Remove the three orphaned combinator delegation shims from `attacks.py` and
their matching proxies from `main.py`. The unified `combinator_crack` handler
is already the only path exposed by the menu.

The duplicate pattern branch referenced in the issue is already absent from
the current `main` branch, so no additional change is needed for that part.

## Test plan

- `uv run pytest -q tests/test_combinator3_combinatorX.py tests/test_llm.py`
  (33 passed)
- `uv run ruff check hate_crack/attacks.py hate_crack/main.py`
- `git diff --check`

This PR was prepared with AI assistance and validated with the checks above.
