### PR TITLE
feat(release): make the patch component the nightly counter

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,7 +1,18 @@
 name: Auto Tag
 
-# Runs only after the CI workflow finishes successfully on main, so a broken
-# commit never gets tagged or released.
+# Cuts a stable release on main after CI passes, so a broken commit never gets
+# tagged or released.
+#
+# Stable releases always carry patch 0: merging nightly-dev down is the release
+# event, and it cuts X.(Y+1).0 (or (X+1).0.0 for a breaking change). The patch
+# component belongs to nightly-dev, which counts X.Y.1, X.Y.2, … between
+# releases. The policy itself lives in tools/next_version.py, shared with
+# nightly-tag.yml and tested in tests/test_next_version.py.
+#
+# Note this fires on ANY push to main that passes CI, not only a nightly-dev
+# merge. A commit pushed straight to main therefore also cuts a minor release,
+# because this scheme leaves no patch slot for a hotfix on main. Route fixes
+# through nightly-dev unless you intend to ship a release.
 on:
   workflow_run:
     workflows: ["CI"]
@@ -39,81 +50,16 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - name: Determine version bump
+      - name: Determine release version
         id: bump
         run: |
-          # Get the latest semver tag. The `|| true` keeps `set -o pipefail`
-          # from aborting the step when there are no matching tags yet.
-          latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-          if [ -z "$latest_tag" ]; then
-            echo "No semver tag found, starting at v0.1.0"
-            echo "new_tag=v0.1.0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Latest tag: $latest_tag"
-
-          # Commit SHAs since the last tag. We iterate SHAs rather than reading
-          # subjects line-by-line so that commit *bodies* (and therefore
-          # BREAKING CHANGE footers) are visible.
-          shas=$(git log "$latest_tag"..HEAD --format=%H)
-
-          if [ -z "$shas" ]; then
-            echo "No new commits since $latest_tag"
+          new_tag=$(python3 tools/next_version.py --channel stable)
+          if [ -z "$new_tag" ]; then
+            echo "Nothing to tag"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          # Parse current version
-          version="${latest_tag#v}"
-          major=$(echo "$version" | cut -d. -f1)
-          minor=$(echo "$version" | cut -d. -f2)
-          patch=$(echo "$version" | cut -d. -f3)
-
-          # Determine bump type. Precedence: major > minor > patch.
-          bump="none"
-          while IFS= read -r sha; do
-            [ -n "$sha" ] || continue
-            body=$(git log -1 --format=%B "$sha")
-            subject=${body%%$'\n'*}
-
-            # Note: matches are done with bash [[ =~ ]] / here-strings rather
-            # than pipelines, so `set -o pipefail` cannot turn an early-exiting
-            # `grep -q` (SIGPIPE, status 141) into a false negative.
-            if [[ "$subject" =~ ^[a-zA-Z]+(\(.+\))?!: ]]; then
-              # e.g. "feat!: ..." / "refactor(api)!: ..."
-              bump="major"
-            elif grep -qE '^(BREAKING CHANGE|BREAKING-CHANGE):' <<<"$body"; then
-              # Conventional Commits breaking-change footer in the body.
-              bump="major"
-            elif [[ "$subject" =~ ^feat(\(.+\))?: ]] && [ "$bump" != "major" ]; then
-              bump="minor"
-            elif [[ "$subject" =~ ^(fix|perf)(\(.+\))?: ]] && [ "$bump" = "none" ]; then
-              bump="patch"
-            fi
-          done <<EOF
-          $shas
-          EOF
-
-          if [ "$bump" = "none" ]; then
-            echo "No feat/fix/perf/breaking commits, skipping tag"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$bump" = "major" ]; then
-            major=$((major + 1))
-            minor=0
-            patch=0
-          elif [ "$bump" = "minor" ]; then
-            minor=$((minor + 1))
-            patch=0
-          else
-            patch=$((patch + 1))
-          fi
-
-          new_tag="v${major}.${minor}.${patch}"
-          echo "Bump: $bump -> $new_tag"
+          echo "Next stable release: $new_tag"
           echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
 
       - name: Create tag
@@ -132,6 +78,12 @@ jobs:
       # GITHUB_TOKEN, so release.yml will not fire for the tag above. Create the
       # release here instead. release.yml remains the path for tags pushed
       # manually by a human.
+      #
+      # Creating the release here is also what keeps nightly versions out of an
+      # operator's upgrade path. Nightly tags are ordinary final versions now, so
+      # the only thing marking a version as released is that a GitHub release
+      # exists for it, and the startup check reads the releases endpoint. Never
+      # create releases from nightly-tag.yml.
       - name: Create GitHub release
         if: steps.bump.outputs.skip != 'true'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      # tools/next_version.py and packaging/ are listed individually rather than
+      # by directory: the rest of tools/ predates linting and does not pass yet,
+      # and reformatting it here would bury this change in unrelated churn.
       - name: Ruff (lint)
-        run: uv run ruff check hate_crack tests
+        run: uv run ruff check hate_crack tests tools/next_version.py packaging
 
       - name: Ruff (format)
-        run: uv run ruff format --check hate_crack tests
+        run: uv run ruff format --check hate_crack tests tools/next_version.py packaging
 
       - name: Ty
         # ty 0.0.63 fails CI on warning-level diagnostics by default;

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -1,17 +1,23 @@
 name: Nightly Tag
 
-# Tags nightly-dev with a PEP 440 pre-release (e.g. v2.17.0-rc.3) after CI
-# passes. Full releases are cut only by auto-tag.yml, and only on main, when
-# nightly-dev is merged down at the batch integration.
+# Tags nightly-dev after CI passes. The patch component is the nightly counter:
+# with 2.19.0 released, merges into nightly-dev cut v2.19.1, v2.19.2, … and the
+# batch merge down to main cuts v2.20.0. So a nightly version always sorts after
+# the current release and before the next one.
 #
-# The tag names the version the batch merge will cut, so v2.17.0-rc.3 means
-# "third validated nightly build heading for 2.17.0". setuptools-scm resolves it
-# to 2.17.0rc3, which PEP 440 orders after 2.16.0 and before 2.17.0.
+# These are ordinary final versions, not pre-releases. The previous scheme tagged
+# v2.19.0-rc.N, which sorted *below* the 2.19.0 it was heading for, so a nightly
+# build always looked older than the release it preceded. Counting upward from the
+# last release fixes the ordering, and also removes the setuptools-scm constraint
+# that forced -rc over -dev in the first place.
 #
-# -rc is used rather than -dev because setuptools-scm rejects any tag ending in
-# .devN for N>0 ("create a new supported one ending in .dev0"), reserving the
-# dev segment for its own commit-distance counting. That rules out an
-# incrementing dev scheme.
+# Nothing in the version string marks a build as nightly. What keeps nightly
+# versions out of an operator's upgrade path is that only auto-tag.yml creates
+# GitHub releases, and the startup check reads the releases endpoint. Do not add
+# a release step here.
+#
+# The policy lives in tools/next_version.py, shared with auto-tag.yml and tested
+# in tests/test_next_version.py.
 #
 # This file MUST live on the default branch (main). GitHub only dispatches
 # workflow_run for workflows present on the default branch, so a copy that
@@ -28,9 +34,9 @@ on:
 permissions:
   contents: write
 
-# Two merges landing back-to-back would otherwise both compute the same rc
-# counter and the second push would fail. Serialize instead of cancelling so no
-# merge gets skipped.
+# Two merges landing back-to-back would otherwise both compute the same counter
+# and the second push would fail. Serialize instead of cancelling so no merge
+# gets skipped.
 concurrency:
   group: nightly-tag
   cancel-in-progress: false
@@ -47,6 +53,9 @@ jobs:
           # workflow_run defaults to the tip of the default branch, which is not
           # the commit CI validated.
           ref: ${{ github.event.workflow_run.head_sha }}
+          # Full history and all tags: the counter is computed from the tags in
+          # the repository, including the release tag sitting on main's merge
+          # commit, which this branch does not contain.
           fetch-depth: 0
 
       - name: Configure git identity
@@ -54,84 +63,19 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - name: Determine pre-release tag
+      - name: Determine nightly version
         id: bump
         run: |
-          # Latest FULL release tag. The anchored pattern deliberately excludes
-          # pre-release tags, so this matches auto-tag.yml's baseline exactly.
-          latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-          if [ -z "$latest_tag" ]; then
-            base_version="0.1.0"
-            shas=$(git log --format=%H)
-          else
-            echo "Latest release tag: $latest_tag"
-            base_version="${latest_tag#v}"
-            shas=$(git log "$latest_tag"..HEAD --format=%H)
-          fi
-
-          if [ -z "$shas" ]; then
-            echo "No new commits since $latest_tag"
+          new_tag=$(python3 tools/next_version.py --channel nightly)
+          if [ -z "$new_tag" ]; then
+            echo "Nothing to tag"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          major=$(echo "$base_version" | cut -d. -f1)
-          minor=$(echo "$base_version" | cut -d. -f2)
-          patch=$(echo "$base_version" | cut -d. -f3)
-
-          # Same bump precedence as auto-tag.yml (major > minor > patch), so the
-          # tag names the version the batch merge to main will cut.
-          bump="none"
-          while IFS= read -r sha; do
-            [ -n "$sha" ] || continue
-            body=$(git log -1 --format=%B "$sha")
-            subject=${body%%$'\n'*}
-
-            if [[ "$subject" =~ ^[a-zA-Z]+(\(.+\))?!: ]]; then
-              bump="major"
-            elif grep -qE '^(BREAKING CHANGE|BREAKING-CHANGE):' <<<"$body"; then
-              bump="major"
-            elif [[ "$subject" =~ ^feat(\(.+\))?: ]] && [ "$bump" != "major" ]; then
-              bump="minor"
-            elif [[ "$subject" =~ ^(fix|perf)(\(.+\))?: ]] && [ "$bump" = "none" ]; then
-              bump="patch"
-            fi
-          done <<EOF
-          $shas
-          EOF
-
-          if [ "$bump" = "none" ]; then
-            # Unlike auto-tag.yml, a chore/docs-only nightly still gets a tag so
-            # every validated nightly commit is addressable. It carries the next
-            # patch version, since that is what a release would be.
-            echo "No feat/fix/perf/breaking commits; tagging as a patch pre-release"
-            bump="patch"
-          fi
-
-          if [ "$bump" = "major" ]; then
-            major=$((major + 1)); minor=0; patch=0
-          elif [ "$bump" = "minor" ]; then
-            minor=$((minor + 1)); patch=0
-          else
-            patch=$((patch + 1))
-          fi
-
-          next="${major}.${minor}.${patch}"
-
-          # Increment the rc counter for this target version. Tags for other
-          # versions are irrelevant.
-          last_n=$(git tag --list "v${next}-rc.*" \
-            | sed -E "s/^v${next}-rc\.([0-9]+)$/\1/" \
-            | grep -E '^[0-9]+$' \
-            | sort -n \
-            | tail -1 || true)
-          n=$(( ${last_n:-0} + 1 ))
-
-          new_tag="v${next}-rc.${n}"
-          echo "Bump: $bump -> $new_tag"
+          echo "Next nightly: $new_tag"
           echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
 
-      - name: Create pre-release tag
+      - name: Create nightly tag
         if: steps.bump.outputs.skip != 'true'
         env:
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
@@ -143,6 +87,6 @@ jobs:
             git push origin "refs/tags/$NEW_TAG"
           fi
 
-      # No GitHub release is created. These tags exist to make nightly builds
-      # addressable and to give setuptools-scm a version; releases are cut on
-      # main by auto-tag.yml.
+      # No GitHub release is created, deliberately -- see the header comment.
+      # These tags exist to make nightly builds addressable and to give
+      # setuptools-scm a version to resolve.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,20 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   reached from two wordlists, misranking rules exactly when several logs were
   mined together.
 
+- **Versioning policy: the patch component is now the nightly counter.**
+  Releases on `main` always end in `.0`, and merging `nightly-dev` down cuts
+  `X.(Y+1).0` (or `(X+1).0.0` for a breaking change). Merges into `nightly-dev`
+  now cut ordinary versions `X.Y.1`, `X.Y.2`, … instead of `vX.Y.0-rc.N`
+  pre-release tags. The old rc tags sorted *below* the release they were heading
+  for, so a nightly build always looked older than the release it preceded;
+  counting upward from the last release fixes that ordering. Nightly builds still
+  publish no GitHub release, which is what keeps them out of the startup check's
+  upgrade path. Existing `vX.Y.Z-rc.N` tags are ignored when computing versions.
+- A chore-only or docs-only merge to `main` now cuts a release. The merge is the
+  release event; previously such a merge was left untagged.
+- The tagging policy moved out of duplicated shell in the two tagging workflows
+  into `tools/next_version.py`, covered by `tests/test_next_version.py`.
+
 ### Removed
 
 - **The standalone `wordlist_optimizer.py` script.** Its per-length split and

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Common options:
 - `--maxruntime <SECONDS>`: Override max runtime.
 - `--bandrel-basewords <PATH>`: Override bandrel basewords file.
 - `--update`: Update to the latest release and reinstall. Switches the checkout to `main` if it is on another branch, since release tags live there.
-- `--nightly`: Update to the latest nightly instead, from the `nightly-dev` branch. Nightlies have passed CI but are not part of a cut release. Can also be written `--update --nightly`.
+- `--nightly`: Update to the latest nightly instead, from the `nightly-dev` branch. Nightlies have passed CI but are not part of a cut release; they carry a non-zero patch version such as `2.19.3` (see [Versioning](#versioning)). Can also be written `--update --nightly`.
 - `--no-optimized-kernel` (or `--no-optimize`): Never pass `-O` to hashcat for the whole run. Overrides `optimizedKernelAttacks` in `config.json` and strips any `-O` you put in `hcatTuning`. Nothing is written back to the config, so it applies to this run only. With a subcommand, put it before the subcommand: `./hate_crack.py --no-optimize quick hashes.txt 1000 --wordlist words.txt`.
 - `--debug`: Enable debug logging (writes to stderr).
 
@@ -714,13 +714,15 @@ hate_crack can automatically check GitHub for newer releases on startup. This fe
 
 | Channel | Flag | Source | What you get |
 |---------|------|--------|--------------|
-| Release | `--update` | `main` | The latest cut release. This is the default and what the startup check offers. |
-| Nightly | `--nightly` | `nightly-dev` | Work that has passed CI but has not been released yet. |
+| Release | `--update` | `main` | The latest cut release, always `X.Y.0`. This is the default and what the startup check offers. |
+| Nightly | `--nightly` | `nightly-dev` | Work that has passed CI but has not been released yet, numbered `X.Y.1`, `X.Y.2`, … |
 
 The startup check only ever offers releases. It reads GitHub's "latest release"
-endpoint, which excludes pre-releases, and nightly builds publish no GitHub
-release at all — so enabling `check_for_updates` will never pull you onto a
-nightly.
+endpoint, and nightly builds publish no GitHub release at all — so enabling
+`check_for_updates` will never pull you onto a nightly. Note that a GitHub
+release existing is the *only* thing that distinguishes a release from a
+nightly: nightly tags are ordinary version numbers, not pre-releases (see
+[Versioning](#versioning)).
 
 Either flag switches your checkout to the corresponding branch first (and
 refuses to do so if you have uncommitted changes). If you are running a nightly
@@ -762,6 +764,49 @@ $ ./hate_crack.py <hash file> 1000
        \/      \/          \/_____/      \/            \/     \/     \/
                           Version 2.0
 ```
+
+-------------------------------------------------------------------
+## Versioning
+
+Version numbers are derived from git tags by setuptools-scm and created
+automatically after CI passes. Which component moves depends on the branch:
+
+| Branch | Shape | When it moves |
+|--------|-------|---------------|
+| `main` (stable) | `X.Y.0` | Merging `nightly-dev` down cuts `X.(Y+1).0`. A breaking change cuts `(X+1).0.0`. |
+| `nightly-dev` (rolling) | `X.Y.N` | Every merge that passes CI increments `N`: `2.19.1`, `2.19.2`, … |
+
+**The patch component is the nightly counter.** A release always ends in `.0`,
+and everything between two releases is a nightly. So with 2.19.0 released,
+nightly-dev counts 2.19.1, 2.19.2, 2.19.3, and the merge down to main cuts
+2.20.0. Every nightly version sorts after the release it started from and before
+the release it becomes, which means a nightly build never looks older than the
+release it precedes.
+
+Nightly tags are ordinary final version numbers, not pre-releases. The only thing
+marking a version as released is that a GitHub release exists for it, which is why
+the startup check never offers a nightly.
+
+Two consequences worth knowing:
+
+- **`main` has no patch slot for a hotfix.** Any push to `main` that passes CI
+  cuts a minor release, so route fixes through `nightly-dev` unless you intend to
+  ship one.
+- **A chore-only or docs-only merge to `main` still releases.** The merge itself
+  is the release event; the previous policy skipped tagging when no
+  `feat`/`fix`/`perf` commits were present, which would strand such a merge
+  unreleased.
+
+Breaking changes are detected from Conventional Commits — either a `!` before the
+colon in the subject (`feat!:`) or a `BREAKING CHANGE:` footer in the body.
+
+The policy lives in one place, `tools/next_version.py`, which both
+`.github/workflows/auto-tag.yml` and `.github/workflows/nightly-tag.yml` call.
+`tests/test_next_version.py` covers it, including a real-git test that walks a
+full release → nightlies → release cycle and asserts versions stay monotonic.
+
+Tags of the form `vX.Y.Z-rc.N` are from a retired scheme and are ignored when
+computing the next version.
 
 -------------------------------------------------------------------
 ## Testing

--- a/tests/test_next_version.py
+++ b/tests/test_next_version.py
@@ -1,0 +1,279 @@
+"""Tests for the release versioning policy in tools/next_version.py.
+
+The policy: main carries `X.Y.0` and cuts `X.(Y+1).0` when nightly-dev is merged
+down; nightly-dev uses the patch component as a per-merge counter, so `X.Y.1`,
+`X.Y.2`, … land between releases.
+
+The integration tests build real git repositories and walk a full cycle, because
+the failure this policy is most exposed to is ordering — a nightly version that
+sorts below the stable release it followed would put nightly users behind a
+"downgrade to stable" prompt.
+"""
+
+import importlib.util
+import os
+import subprocess
+
+import pytest
+from packaging.version import parse as parse_version
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT = os.path.join(REPO_ROOT, "tools", "next_version.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("next_version", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+nv = _load()
+
+
+class TestParsing:
+    def test_final_tags_parse(self):
+        assert nv.parse_tag("v2.19.3") == (2, 19, 3)
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "v2.19.0-rc.3",  # retired pre-release scheme
+            "v2.19.0rc3",
+            "2.19.0",  # missing v
+            "v2.19",
+            "vX.Y.Z",
+            "",
+        ],
+    )
+    def test_non_final_tags_rejected(self, tag):
+        assert nv.parse_tag(tag) is None
+
+    def test_latest_release_ignores_pre_release_tags(self):
+        """An rc tag left over from the old scheme must never be a baseline."""
+        tags = ["v2.18.0", "v2.19.0-rc.8", "v2.18.1-rc.3"]
+        assert nv.latest_release(tags) == (2, 18, 0)
+
+    def test_latest_release_compares_numerically(self):
+        assert nv.latest_release(["v2.9.0", "v2.10.0"]) == (2, 10, 0)
+
+    def test_latest_release_with_no_tags(self):
+        assert nv.latest_release([]) == (0, 0, 0)
+
+
+class TestBreakingDetection:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "feat!: drop python 3.12",
+            "refactor(api)!: rename everything",
+            "fix: something\n\nBREAKING CHANGE: config moved\n",
+            "fix: something\n\nBREAKING-CHANGE: config moved\n",
+        ],
+    )
+    def test_breaking_recognised(self, message):
+        assert nv.has_breaking_change([message]) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "feat: add rosetta attack",
+            "fix(cleanup): default pwdump_format",
+            "docs: note the breaking change policy",
+            "chore: bump ruff",
+        ],
+    )
+    def test_non_breaking(self, message):
+        assert nv.has_breaking_change([message]) is False
+
+    def test_breaking_anywhere_in_the_set_wins(self):
+        assert nv.has_breaking_change(["chore: x", "feat!: y", "docs: z"]) is True
+
+
+class TestStableBumps:
+    def test_minor_bump_resets_patch_to_zero(self):
+        """The defining property: a release is always X.Y.0."""
+        assert nv.next_stable((2, 19, 5), breaking=False) == "v2.20.0"
+
+    def test_breaking_bumps_major(self):
+        assert nv.next_stable((2, 19, 5), breaking=True) == "v3.0.0"
+
+    def test_first_release(self):
+        assert nv.next_stable((0, 0, 0), breaking=False) == "v0.1.0"
+
+
+class TestNightlyBumps:
+    def test_counts_up_from_the_release(self):
+        assert nv.next_nightly((2, 19, 0), ["v2.19.0"]) == "v2.19.1"
+
+    def test_counts_up_from_the_previous_nightly(self):
+        tags = ["v2.19.0", "v2.19.1", "v2.19.2"]
+        assert nv.next_nightly((2, 19, 2), tags) == "v2.19.3"
+
+    def test_skips_taken_numbers(self):
+        """A hand-pushed or re-run tag must not stall the counter."""
+        tags = ["v2.19.0", "v2.19.1", "v2.19.2", "v2.19.3"]
+        # Base is behind the tags that exist (a re-run against an older commit),
+        # so it walks up past 2, 3 rather than colliding on them.
+        assert nv.next_nightly((2, 19, 1), tags) == "v2.19.4"
+        assert nv.next_nightly((2, 19, 3), tags) == "v2.19.4"
+
+    def test_never_produces_a_zero_patch(self):
+        """X.Y.0 is reserved for releases, so nightly must never mint one."""
+        for patch in range(0, 5):
+            tag = nv.next_nightly((2, 19, patch), [])
+            assert not tag.endswith(".0")
+
+
+class TestOrdering:
+    def test_nightlies_sort_between_the_releases_that_bracket_them(self):
+        stable = parse_version("2.19.0")
+        following = parse_version("2.20.0")
+        for patch in range(1, 6):
+            nightly = parse_version(f"2.19.{patch}")
+            assert stable < nightly < following
+
+    def test_a_nightly_never_sorts_below_its_starting_release(self):
+        """This is what keeps the startup check from offering a downgrade."""
+        base = (2, 19, 0)
+        tags = ["v2.19.0"]
+        for _ in range(4):
+            tag = nv.next_nightly(base, tags)
+            tags.append(tag)
+            assert parse_version(tag.lstrip("v")) > parse_version("2.19.0")
+            base = nv.parse_tag(tag)
+
+
+def _run_git(repo, *args):
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@e",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@e",
+        },
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    path = tmp_path / "repo"
+    path.mkdir()
+    _run_git(path, "init", "-b", "main")
+    (path / "f").write_text("0\n")
+    _run_git(path, "add", "f")
+    _run_git(path, "commit", "-m", "chore: init")
+    return path
+
+
+def _commit(repo, message, content=None):
+    (repo / "f").write_text(content or message)
+    _run_git(repo, "add", "f")
+    _run_git(repo, "commit", "-m", message)
+
+
+class TestAgainstRealGit:
+    def test_no_new_commits_means_no_tag(self, repo):
+        _run_git(repo, "tag", "v2.19.0")
+        assert nv.compute(nv.STABLE, str(repo)) is None
+        assert nv.compute(nv.NIGHTLY, str(repo)) is None
+
+    def test_chore_only_push_to_main_still_releases(self, repo):
+        """The old policy skipped these, which would strand a chore-only merge."""
+        _run_git(repo, "tag", "v2.19.0")
+        _commit(repo, "docs: fix a typo")
+        assert nv.compute(nv.STABLE, str(repo)) == "v2.20.0"
+
+    def test_breaking_commit_in_the_merged_range_bumps_major(self, repo):
+        _run_git(repo, "tag", "v2.19.0")
+        _commit(repo, "feat!: rework the config")
+        assert nv.compute(nv.STABLE, str(repo)) == "v3.0.0"
+
+    def test_breaking_footer_in_a_commit_body_is_seen(self, repo):
+        """Bodies must be read, not just subjects."""
+        _run_git(repo, "tag", "v2.19.0")
+        (repo / "f").write_text("x")
+        _run_git(repo, "add", "f")
+        _run_git(repo, "commit", "-m", "fix: x", "-m", "BREAKING CHANGE: dropped y")
+        assert nv.compute(nv.STABLE, str(repo)) == "v3.0.0"
+
+    def test_full_cycle_release_then_nightlies_then_release(self, repo):
+        """Walk the documented lifecycle and assert it stays monotonic."""
+        _run_git(repo, "tag", "v2.19.0")
+        _run_git(repo, "checkout", "-b", "nightly-dev")
+
+        seen = ["2.19.0"]
+        for i in range(3):
+            _commit(repo, f"feat: nightly work {i}")
+            tag = nv.compute(nv.NIGHTLY, str(repo))
+            assert tag == f"v2.19.{i + 1}"
+            _run_git(repo, "tag", tag)
+            seen.append(tag.lstrip("v"))
+
+        _run_git(repo, "checkout", "main")
+        _run_git(repo, "merge", "--no-ff", "nightly-dev", "-m", "Merge nightly-dev")
+        release = nv.compute(nv.STABLE, str(repo))
+        assert release == "v2.20.0"
+        _run_git(repo, "tag", release)
+        seen.append(release.lstrip("v"))
+
+        parsed = [parse_version(v) for v in seen]
+        assert parsed == sorted(parsed), f"versions went backwards: {seen}"
+
+    def test_nightly_after_a_release_does_not_regress(self, repo):
+        """The trap this policy is most exposed to.
+
+        The v2.20.0 tag lives on main's merge commit, which nightly-dev does not
+        contain. Computing the next nightly from tags *reachable from HEAD* would
+        yield v2.19.4 — a version below the 2.20.0 release that already shipped,
+        so every nightly user would be told to upgrade to stable.
+        """
+        _run_git(repo, "tag", "v2.19.0")
+        _run_git(repo, "checkout", "-b", "nightly-dev")
+        _commit(repo, "feat: a")
+        _run_git(repo, "tag", "v2.19.1")
+
+        _run_git(repo, "checkout", "main")
+        _run_git(repo, "merge", "--no-ff", "nightly-dev", "-m", "Merge nightly-dev")
+        _run_git(repo, "tag", "v2.20.0")
+
+        _run_git(repo, "checkout", "nightly-dev")
+        _commit(repo, "feat: b")
+        tag = nv.compute(nv.NIGHTLY, str(repo))
+        assert tag == "v2.20.1"
+        assert parse_version(tag.lstrip("v")) > parse_version("2.20.0")
+
+    def test_retired_rc_tags_do_not_become_a_baseline(self, repo):
+        """The live repo still carries v2.19.0-rc.* from the old scheme."""
+        _run_git(repo, "tag", "v2.18.0")
+        _run_git(repo, "tag", "v2.19.0-rc.8")
+        _commit(repo, "feat: next")
+        assert nv.compute(nv.NIGHTLY, str(repo)) == "v2.18.1"
+        assert nv.compute(nv.STABLE, str(repo)) == "v2.19.0"
+
+    def test_cli_prints_the_tag(self, repo):
+        _run_git(repo, "tag", "v2.19.0")
+        _commit(repo, "feat: x")
+        result = subprocess.run(
+            ["python3", SCRIPT, "--channel", "nightly", "--repo-dir", str(repo)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == "v2.19.1"
+
+    def test_cli_prints_nothing_when_there_is_nothing_to_tag(self, repo):
+        _run_git(repo, "tag", "v2.19.0")
+        result = subprocess.run(
+            ["python3", SCRIPT, "--channel", "stable", "--repo-dir", str(repo)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""

--- a/tools/next_version.py
+++ b/tools/next_version.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Compute the next version tag for a branch, per hate_crack's release policy.
+
+The policy has one rule per channel:
+
+* **stable (`main`)** — the patch component is always ``0``. Merging
+  ``nightly-dev`` down is the release event, so it cuts ``X.(Y+1).0``, or
+  ``(X+1).0.0`` when any commit since the last tag is breaking.
+* **nightly (`nightly-dev`)** — the patch component is a counter. Each merge
+  that passes CI cuts ``X.Y.(P+1)``, so ``2.19.1``, ``2.19.2``, … accumulate
+  between releases and sort after the current stable release and before the next
+  one.
+
+Nightly versions are therefore ordinary final versions rather than ``-rc``
+pre-releases. Nothing marks them as nightly in the version string; what keeps
+them out of an operator's upgrade path is that only ``main`` publishes a GitHub
+release, and the startup check reads the releases endpoint.
+
+Baseline is the highest final tag in the repository, deliberately NOT restricted
+to tags reachable from HEAD. A nightly-dev tip does not contain the tag created
+on main's merge commit, so a reachability-restricted lookup would compute the
+next nightly from a stale baseline and hand out a version lower than the stable
+release that already shipped.
+
+Both tagging workflows call this so the policy lives in one place. It is a
+library first and a CLI second: everything above the git boundary is pure and
+unit-tested in tests/test_next_version.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+# Final release tags only. Any pre-release spelling (v2.19.0-rc.3, left over
+# from the retired rc scheme) must not become a baseline.
+TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+BREAKING_SUBJECT_RE = re.compile(r"^[a-zA-Z]+(\(.+\))?!:")
+BREAKING_FOOTER_RE = re.compile(r"^(BREAKING CHANGE|BREAKING-CHANGE):", re.MULTILINE)
+
+STABLE = "stable"
+NIGHTLY = "nightly"
+
+
+def parse_tag(tag: str) -> tuple[int, int, int] | None:
+    """Return (major, minor, patch) for a final release tag, else None."""
+    match = TAG_RE.match(tag.strip())
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def latest_release(tags: list[str]) -> tuple[int, int, int]:
+    """Highest final release version among *tags*, or (0, 0, 0) if there is none.
+
+    Compared as integer tuples rather than strings so 2.9.0 does not outrank
+    2.10.0.
+    """
+    versions = [v for v in (parse_tag(t) for t in tags) if v is not None]
+    return max(versions) if versions else (0, 0, 0)
+
+
+def has_breaking_change(messages: list[str]) -> bool:
+    """True if any commit message declares a breaking change.
+
+    Recognises both Conventional Commits spellings: a ``!`` before the colon in
+    the subject, and a ``BREAKING CHANGE:`` footer in the body.
+    """
+    for message in messages:
+        subject = message.lstrip().split("\n", 1)[0]
+        if BREAKING_SUBJECT_RE.match(subject):
+            return True
+        if BREAKING_FOOTER_RE.search(message):
+            return True
+    return False
+
+
+def next_stable(base: tuple[int, int, int], breaking: bool) -> str:
+    """Next release version for main. Patch is always 0.
+
+    Note there is no "no releasable commits" case: on main, having new commits at
+    all is the release event. The old policy skipped tagging a docs-only or
+    chore-only push, which under this scheme would mean a nightly merge carrying
+    only such commits never got released.
+    """
+    major, minor, _ = base
+    if breaking:
+        return f"v{major + 1}.0.0"
+    return f"v{major}.{minor + 1}.0"
+
+
+def next_nightly(base: tuple[int, int, int], tags: list[str]) -> str:
+    """Next nightly version: the lowest free patch above *base*.
+
+    Skipping past taken numbers rather than failing on a collision keeps a
+    re-run, or a hand-pushed tag, from stalling the counter.
+    """
+    major, minor, patch = base
+    existing = {t.strip() for t in tags}
+    candidate = patch + 1
+    while f"v{major}.{minor}.{candidate}" in existing:
+        candidate += 1
+    return f"v{major}.{minor}.{candidate}"
+
+
+def _git(args: list[str], repo_dir: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def git_tags(repo_dir: str) -> list[str]:
+    return [line for line in _git(["tag"], repo_dir).splitlines() if line.strip()]
+
+
+def commit_messages(repo_dir: str, base: tuple[int, int, int]) -> list[str]:
+    """Commit messages on HEAD since the *base* tag, newest first.
+
+    A (0, 0, 0) base means no release tag exists yet, so the whole history counts.
+    """
+    major, minor, patch = base
+    rev_range = "HEAD" if base == (0, 0, 0) else f"v{major}.{minor}.{patch}..HEAD"
+    out = _git(["log", rev_range, "--format=%B%x00"], repo_dir)
+    return [chunk for chunk in out.split("\0") if chunk.strip()]
+
+
+def compute(channel: str, repo_dir: str) -> str | None:
+    """Next tag for *channel*, or None when there is nothing to tag."""
+    tags = git_tags(repo_dir)
+    base = latest_release(tags)
+    messages = commit_messages(repo_dir, base)
+
+    if not messages:
+        return None
+
+    if channel == NIGHTLY:
+        return next_nightly(base, tags)
+    return next_stable(base, has_breaking_change(messages))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--channel", required=True, choices=[STABLE, NIGHTLY])
+    parser.add_argument("--repo-dir", default=".")
+    args = parser.parse_args(argv)
+
+    tag = compute(args.channel, args.repo_dir)
+    if tag is None:
+        # Empty stdout is the "nothing to do" signal; the workflows test for it.
+        print(
+            f"No new commits since the last release tag ({args.channel})",
+            file=sys.stderr,
+        )
+        return 0
+    print(tag)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Draft on purpose — other integration work is in flight for `nightly-dev`, and there is a sequencing step below that has to happen in the right order.

## What changes

| Branch | Shape | When it moves |
|---|---|---|
| `main` (stable) | `X.Y.0` | Merging `nightly-dev` down cuts `X.(Y+1).0`; a breaking change cuts `(X+1).0.0` |
| `nightly-dev` (rolling) | `X.Y.N` | Every merge that passes CI increments `N` |

With 2.19.0 released, `nightly-dev` counts 2.19.1, 2.19.2, 2.19.3, and the batch merge to main cuts 2.20.0.

## Why, beyond the request

The retired `-rc.N` tags sorted *below* the release they targeted — `2.19.0rc8 < 2.19.0` — so a nightly build always looked older than the release it preceded. Counting upward puts every nightly strictly between the release it started from and the release it becomes. It also drops the setuptools-scm constraint that forced `-rc` over `-dev` in the first place.

## Implementation

The policy moved out of duplicated shell in both tagging workflows into `tools/next_version.py`, which they now both call. Pure above the git boundary, so it is testable: `tests/test_next_version.py` has 37 tests, including real-git tests that walk a full release -> nightlies -> release cycle and assert versions stay monotonic.

The baseline is the highest tag in the repository, **not** the highest reachable from `HEAD`. This is the subtle part and it has a dedicated regression test: the `v2.20.0` tag sits on main's merge commit, which `nightly-dev` does not contain, so a reachability-based lookup computes the next nightly as `v2.19.4` — below the 2.20.0 that already shipped — and every nightly user gets prompted to "upgrade" to stable.

Nightly tags are now ordinary final versions, so nothing in the version string marks a build as nightly. What keeps them out of an operator's upgrade path is that only `auto-tag.yml` creates GitHub releases and the startup check reads the releases endpoint. Both workflows carry a comment saying so, because adding a release step to `nightly-tag.yml` would silently start shipping nightlies to everyone.

## Behaviour changes worth reviewing

- **A chore-only or docs-only merge to `main` now cuts a release.** The merge is the release event; the old "skip unless feat/fix/perf" rule would strand such a merge unreleased.
- **`main` has no patch slot left for a hotfix.** Any push to main that passes CI cuts a minor release. Fixes should route through `nightly-dev`.

## Sequencing — do not merge out of order

`nightly-dev` is at `v2.19.0-rc.8`, so the rc tags have been promising 2.19.0. If this lands and `nightly-dev` is pushed to *before* the batch merge, the next nightly tag is `v2.18.1`, and since setuptools-scm picks the nearest tag a nightly user's reported version goes **down** from 2.19.0rc8 to 2.18.1.

Merge `nightly-dev` -> `main` first, then this. Old `vX.Y.Z-rc.N` tags are ignored by the new logic rather than deleted.

Separately: `nightly-dev` currently carries four `feat(config)!:` / `refactor(config)!:` commits, so the next merge to main cuts **v3.0.0**, not v2.19.0. That is true under the old policy too — this PR does not change it — but it is worth being deliberate about.

## Verification

- Full suite green on this branch: 1935 passed, 30 skipped, twice.
- Ruff lint and format clean; CI now covers `tools/next_version.py` and `packaging/`. The rest of `tools/` predates linting and is deliberately left alone rather than reformatted here.
- Dry-run against real tag history on this branch: `--channel nightly` -> `v2.18.1`, `--channel stable` -> `v3.0.0` (the four breaking config commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)