### PR TITLE
ci: rolling patch versions on nightly-dev, minor-only releases on main

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,5 +1,14 @@
 name: Auto Tag
 
+# Cuts the stable release on main. main is always X.Y.0: merging nightly-dev
+# down is the release event, and it is always a MINOR bump.
+#
+# The version arithmetic is done by commitizen (`cz bump`), configured in
+# pyproject.toml under [tool.commitizen] with version_provider = "scm" and
+# tag_format = "v$version". Nothing here parses or increments a version number;
+# that used to be ~70 lines of `cut -d.` and `$((minor + 1))` duplicated with
+# nightly-tag.yml, and it is deliberately gone. Do not reintroduce it.
+#
 # Runs only after the CI workflow finishes successfully on main, so a broken
 # commit never gets tagged or released.
 on:
@@ -32,6 +41,9 @@ jobs:
           # workflow_run defaults to the tip of the default branch, which is not
           # necessarily the commit CI validated.
           ref: ${{ github.event.workflow_run.head_sha }}
+          # commitizen resolves the current version from git tags, so it needs
+          # the full history and all tags. Under a shallow clone it would read
+          # the project version as 0.0.0 and tag nonsense.
           fetch-depth: 0
 
       - name: Configure git identity
@@ -39,88 +51,47 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - name: Determine version bump
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Compute release tag
         id: bump
         run: |
-          # Get the latest semver tag. The `|| true` keeps `set -o pipefail`
-          # from aborting the step when there are no matching tags yet.
-          latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-          if [ -z "$latest_tag" ]; then
-            echo "No semver tag found, starting at v0.1.0"
-            echo "new_tag=v0.1.0" >> "$GITHUB_OUTPUT"
-            exit 0
+          set -euo pipefail
+          # --increment MINOR is what expresses "a merge into main is a
+          # release". It is forced rather than inferred from commit messages,
+          # which means a `type!:` subject or a BREAKING CHANGE: footer no
+          # longer auto-bumps major. That is intentional: a major release is a
+          # rare, explicit human act (`cz bump --increment MAJOR`, run by hand
+          # and pushed). Do not add breaking-change detection here -- that is
+          # exactly the hand-rolled version decisioning this rewrite removed.
+          #
+          # There is also no "no feat/fix/perf commits, skip" early exit any
+          # more. A merge into main is an explicit release event, so a
+          # docs/chore-only merge still cuts a release.
+          uvx --from 'commitizen==4.17.0' cz bump --yes --increment MINOR --dry-run \
+            > /tmp/cz-bump.log
+          cat /tmp/cz-bump.log
+
+          # Read the answer out of a file rather than piping cz straight into
+          # grep/sed. Under `set -o pipefail` an early-exiting reader can leave
+          # the producer killed by SIGPIPE (exit 141), which would fail the step
+          # on a successful match. Several past bugs here came from exactly that.
+          new_tag=$(sed -n 's/^tag to create: //p' /tmp/cz-bump.log | head -1)
+          if [ -z "$new_tag" ]; then
+            echo "::error::could not determine the tag to create from cz output"
+            exit 1
           fi
-
-          echo "Latest tag: $latest_tag"
-
-          # Commit SHAs since the last tag. We iterate SHAs rather than reading
-          # subjects line-by-line so that commit *bodies* (and therefore
-          # BREAKING CHANGE footers) are visible.
-          shas=$(git log "$latest_tag"..HEAD --format=%H)
-
-          if [ -z "$shas" ]; then
-            echo "No new commits since $latest_tag"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Parse current version
-          version="${latest_tag#v}"
-          major=$(echo "$version" | cut -d. -f1)
-          minor=$(echo "$version" | cut -d. -f2)
-          patch=$(echo "$version" | cut -d. -f3)
-
-          # Determine bump type. Precedence: major > minor > patch.
-          bump="none"
-          while IFS= read -r sha; do
-            [ -n "$sha" ] || continue
-            body=$(git log -1 --format=%B "$sha")
-            subject=${body%%$'\n'*}
-
-            # Note: matches are done with bash [[ =~ ]] / here-strings rather
-            # than pipelines, so `set -o pipefail` cannot turn an early-exiting
-            # `grep -q` (SIGPIPE, status 141) into a false negative.
-            if [[ "$subject" =~ ^[a-zA-Z]+(\(.+\))?!: ]]; then
-              # e.g. "feat!: ..." / "refactor(api)!: ..."
-              bump="major"
-            elif grep -qE '^(BREAKING CHANGE|BREAKING-CHANGE):' <<<"$body"; then
-              # Conventional Commits breaking-change footer in the body.
-              bump="major"
-            elif [[ "$subject" =~ ^feat(\(.+\))?: ]] && [ "$bump" != "major" ]; then
-              bump="minor"
-            elif [[ "$subject" =~ ^(fix|perf)(\(.+\))?: ]] && [ "$bump" = "none" ]; then
-              bump="patch"
-            fi
-          done <<EOF
-          $shas
-          EOF
-
-          if [ "$bump" = "none" ]; then
-            echo "No feat/fix/perf/breaking commits, skipping tag"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$bump" = "major" ]; then
-            major=$((major + 1))
-            minor=0
-            patch=0
-          elif [ "$bump" = "minor" ]; then
-            minor=$((minor + 1))
-            patch=0
-          else
-            patch=$((patch + 1))
-          fi
-
-          new_tag="v${major}.${minor}.${patch}"
-          echo "Bump: $bump -> $new_tag"
+          echo "Release tag: $new_tag"
           echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
 
       - name: Create tag
-        if: steps.bump.outputs.skip != 'true'
         env:
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
         run: |
+          set -euo pipefail
+          # Idempotent: a re-run of this workflow must not fail the job.
           if git rev-parse -q --verify "refs/tags/$NEW_TAG" >/dev/null; then
             echo "Tag $NEW_TAG already exists, nothing to push"
           else
@@ -133,11 +104,11 @@ jobs:
       # release here instead. release.yml remains the path for tags pushed
       # manually by a human.
       - name: Create GitHub release
-        if: steps.bump.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
         run: |
+          set -euo pipefail
           if gh release view "$NEW_TAG" >/dev/null 2>&1; then
             echo "Release $NEW_TAG already exists, nothing to do"
             exit 0

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -71,14 +71,14 @@ jobs:
           # more. A merge into main is an explicit release event, so a
           # docs/chore-only merge still cuts a release.
           uvx --from 'commitizen==4.17.0' cz bump --yes --increment MINOR --dry-run \
-            > /tmp/cz-bump.log
-          cat /tmp/cz-bump.log
+            > "$RUNNER_TEMP/cz-bump.log"
+          cat "$RUNNER_TEMP/cz-bump.log"
 
           # Read the answer out of a file rather than piping cz straight into
           # grep/sed. Under `set -o pipefail` an early-exiting reader can leave
           # the producer killed by SIGPIPE (exit 141), which would fail the step
           # on a successful match. Several past bugs here came from exactly that.
-          new_tag=$(sed -n 's/^tag to create: //p' /tmp/cz-bump.log | head -1)
+          new_tag=$(sed -n 's/^tag to create: //p' "$RUNNER_TEMP/cz-bump.log" | head -1)
           if [ -z "$new_tag" ]; then
             echo "::error::could not determine the tag to create from cz output"
             exit 1

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -79,15 +79,23 @@ jobs:
           # nightly push gets a tag and stays addressable -- including a
           # docs/chore-only one, which the old workflow also did deliberately.
           # Do not add commit-message inspection here.
+          # NOTE: this step FAILS with `[NO_VERSION_SPECIFIED]` (exit 4) on any
+          # nightly-dev commit whose pyproject.toml has no [tool.commitizen]
+          # section. That is a GUARANTEED red window between this landing on main
+          # and main being merged down into nightly-dev, because the config
+          # arrives with that merge. cz's error message says nothing about the
+          # cause, so: if you see [NO_VERSION_SPECIFIED] here, merge main into
+          # nightly-dev. Failing loudly is the intended behaviour -- it is much
+          # better than guessing a version -- but it is not self-explanatory.
           uvx --from 'commitizen==4.17.0' cz bump --yes --increment PATCH --dry-run \
-            > /tmp/cz-bump.log
-          cat /tmp/cz-bump.log
+            > "$RUNNER_TEMP/cz-bump.log"
+          cat "$RUNNER_TEMP/cz-bump.log"
 
           # Read the answer out of a file rather than piping cz straight into
           # grep/sed. Under `set -o pipefail` an early-exiting reader can leave
           # the producer killed by SIGPIPE (exit 141), which would fail the step
           # on a successful match. Several past bugs here came from exactly that.
-          new_tag=$(sed -n 's/^tag to create: //p' /tmp/cz-bump.log | head -1)
+          new_tag=$(sed -n 's/^tag to create: //p' "$RUNNER_TEMP/cz-bump.log" | head -1)
           if [ -z "$new_tag" ]; then
             echo "::error::could not determine the tag to create from cz output"
             exit 1

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -1,17 +1,26 @@
 name: Nightly Tag
 
-# Tags nightly-dev with a PEP 440 pre-release (e.g. v2.17.0-rc.3) after CI
-# passes. Full releases are cut only by auto-tag.yml, and only on main, when
-# nightly-dev is merged down at the weekly integration.
+# Tags nightly-dev after CI passes. nightly-dev is the rolling branch and it
+# consumes PATCH numbers: with main stable at X.Y.0, validated nightly pushes
+# become X.Y.1, X.Y.2, ... one per push. The weekly merge into main then cuts
+# the next stable X.(Y+1).0 via auto-tag.yml.
 #
-# The tag names the version the weekly merge will cut, so v2.17.0-rc.3 means
-# "third validated nightly build heading for 2.17.0". setuptools-scm resolves it
-# to 2.17.0rc3, which PEP 440 orders after 2.16.0 and before 2.17.0.
+# The version arithmetic is done by commitizen (`cz bump`), configured in
+# pyproject.toml under [tool.commitizen]. Nothing here parses or increments a
+# version number; that used to be duplicated bash (`cut -d.`, `$((patch + 1))`,
+# plus an rc-counter `sed`/`sort -n` pipeline) and it is deliberately gone. Do
+# not reintroduce it.
 #
-# -rc is used rather than -dev because setuptools-scm rejects any tag ending in
-# .devN for N>0 ("create a new supported one ending in .dev0"), reserving the
-# dev segment for its own commit-distance counting. That rules out an
-# incrementing dev scheme.
+# These are now ORDINARY release tags, not -rc.N pre-releases. That retires the
+# whole reason the old pre-release scheme existed (setuptools-scm rejects tags
+# ending in .devN for N>0, which ruled out an incrementing -dev.N scheme, so -rc
+# was used instead). Consequence to be aware of: because a nightly tag is no
+# longer a PEP 440 pre-release, any tool resolving "the latest version" will now
+# consider a nightly to be latest. The package is not published to PyPI, so
+# nothing installs from an index today, but this is a real property of the
+# scheme rather than an oversight.
+#
+# No GitHub release is created here -- see the end of this file.
 #
 # This file MUST live on the default branch (main). GitHub only dispatches
 # workflow_run for workflows present on the default branch, so a copy that
@@ -28,9 +37,9 @@ on:
 permissions:
   contents: write
 
-# Two merges landing back-to-back would otherwise both compute the same rc
-# counter and the second push would fail. Serialize instead of cancelling so no
-# merge gets skipped.
+# Two pushes landing back-to-back would otherwise both compute the same tag and
+# the second push would fail. Serialize instead of cancelling so no push gets
+# skipped.
 concurrency:
   group: nightly-tag
   cancel-in-progress: false
@@ -47,6 +56,9 @@ jobs:
           # workflow_run defaults to the tip of the default branch, which is not
           # the commit CI validated.
           ref: ${{ github.event.workflow_run.head_sha }}
+          # commitizen resolves the current version from git tags, so it needs
+          # the full history and all tags. Under a shallow clone it would read
+          # the project version as 0.0.0 and tag nonsense.
           fetch-depth: 0
 
       - name: Configure git identity
@@ -54,88 +66,41 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - name: Determine pre-release tag
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Compute nightly tag
         id: bump
         run: |
-          # Latest FULL release tag. The anchored pattern deliberately excludes
-          # pre-release tags, so this matches auto-tag.yml's baseline exactly.
-          latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-          if [ -z "$latest_tag" ]; then
-            base_version="0.1.0"
-            shas=$(git log --format=%H)
-          else
-            echo "Latest release tag: $latest_tag"
-            base_version="${latest_tag#v}"
-            shas=$(git log "$latest_tag"..HEAD --format=%H)
+          set -euo pipefail
+          # --increment PATCH is what expresses "nightly-dev consumes patch
+          # numbers". It is forced rather than inferred, so every validated
+          # nightly push gets a tag and stays addressable -- including a
+          # docs/chore-only one, which the old workflow also did deliberately.
+          # Do not add commit-message inspection here.
+          uvx --from 'commitizen==4.17.0' cz bump --yes --increment PATCH --dry-run \
+            > /tmp/cz-bump.log
+          cat /tmp/cz-bump.log
+
+          # Read the answer out of a file rather than piping cz straight into
+          # grep/sed. Under `set -o pipefail` an early-exiting reader can leave
+          # the producer killed by SIGPIPE (exit 141), which would fail the step
+          # on a successful match. Several past bugs here came from exactly that.
+          new_tag=$(sed -n 's/^tag to create: //p' /tmp/cz-bump.log | head -1)
+          if [ -z "$new_tag" ]; then
+            echo "::error::could not determine the tag to create from cz output"
+            exit 1
           fi
-
-          if [ -z "$shas" ]; then
-            echo "No new commits since $latest_tag"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          major=$(echo "$base_version" | cut -d. -f1)
-          minor=$(echo "$base_version" | cut -d. -f2)
-          patch=$(echo "$base_version" | cut -d. -f3)
-
-          # Same bump precedence as auto-tag.yml (major > minor > patch), so the
-          # tag names the version the weekly merge to main will cut.
-          bump="none"
-          while IFS= read -r sha; do
-            [ -n "$sha" ] || continue
-            body=$(git log -1 --format=%B "$sha")
-            subject=${body%%$'\n'*}
-
-            if [[ "$subject" =~ ^[a-zA-Z]+(\(.+\))?!: ]]; then
-              bump="major"
-            elif grep -qE '^(BREAKING CHANGE|BREAKING-CHANGE):' <<<"$body"; then
-              bump="major"
-            elif [[ "$subject" =~ ^feat(\(.+\))?: ]] && [ "$bump" != "major" ]; then
-              bump="minor"
-            elif [[ "$subject" =~ ^(fix|perf)(\(.+\))?: ]] && [ "$bump" = "none" ]; then
-              bump="patch"
-            fi
-          done <<EOF
-          $shas
-          EOF
-
-          if [ "$bump" = "none" ]; then
-            # Unlike auto-tag.yml, a chore/docs-only nightly still gets a tag so
-            # every validated nightly commit is addressable. It carries the next
-            # patch version, since that is what a release would be.
-            echo "No feat/fix/perf/breaking commits; tagging as a patch pre-release"
-            bump="patch"
-          fi
-
-          if [ "$bump" = "major" ]; then
-            major=$((major + 1)); minor=0; patch=0
-          elif [ "$bump" = "minor" ]; then
-            minor=$((minor + 1)); patch=0
-          else
-            patch=$((patch + 1))
-          fi
-
-          next="${major}.${minor}.${patch}"
-
-          # Increment the rc counter for this target version. Tags for other
-          # versions are irrelevant.
-          last_n=$(git tag --list "v${next}-rc.*" \
-            | sed -E "s/^v${next}-rc\.([0-9]+)$/\1/" \
-            | grep -E '^[0-9]+$' \
-            | sort -n \
-            | tail -1 || true)
-          n=$(( ${last_n:-0} + 1 ))
-
-          new_tag="v${next}-rc.${n}"
-          echo "Bump: $bump -> $new_tag"
+          echo "Nightly tag: $new_tag"
           echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
 
-      - name: Create pre-release tag
-        if: steps.bump.outputs.skip != 'true'
+      - name: Create tag
         env:
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
         run: |
+          set -euo pipefail
+          # Idempotent: a re-run of this workflow must not fail the job.
           if git rev-parse -q --verify "refs/tags/$NEW_TAG" >/dev/null; then
             echo "Tag $NEW_TAG already exists, nothing to push"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Changed
+
+- **Release versioning is now rolling, and driven by [commitizen](https://commitizen-tools.github.io/commitizen/)
+  instead of hand-rolled bash.** `main` is stable and always `X.Y.0`; merging
+  `nightly-dev` down cuts the release as a minor bump. `nightly-dev` consumes the
+  patch numbers above it — `X.Y.1`, `X.Y.2`, … — one per validated push. So
+  stable `2.19.0` is followed by nightlies `2.19.1`, `2.19.2`, and the next merge
+  to `main` cuts `2.20.0`.
+
+  This replaces the `-rc.N` pre-release scheme. Both tagging workflows previously
+  duplicated the same version arithmetic in shell (`cut -d.` to split the
+  version, `$((minor + 1))` to bump it, a `sed`/`sort -n` pipeline to advance the
+  rc counter); all of it is deleted. `cz bump --increment {MINOR,PATCH}` does the
+  arithmetic, configured under `[tool.commitizen]` with `version_provider = "scm"`
+  so the version is read from git tags and there is no version string in a file
+  and no version-bump commit.
+
+  Because nightly tags are now ordinary release tags, the `setuptools-scm`
+  workaround that the old scheme existed for is retired: `-rc` was chosen only
+  because `setuptools-scm` rejects tags ending in `.devN` for `N > 0`, which
+  ruled out an incrementing `-dev.N` counter.
+
+- **A merge into `main` now always cuts a release**, including a docs- or
+  chore-only one. The old workflow skipped tagging when it found no
+  `feat`/`fix`/`perf` commits; a merge to `main` is an explicit release event, so
+  that early exit is gone. `nightly-dev` already tagged unconditionally, so that
+  every validated nightly commit stays addressable.
+
+- **No existing tag was moved or deleted.** The `-rc.N` tags remain as history.
+
+### Removed
+
+- **Automatic major version bumps.** A `type!:` subject or a `BREAKING CHANGE:`
+  footer no longer bumps the major version by itself, because the increment is
+  now forced per branch rather than inferred from commit messages. This is
+  deliberate — reintroducing breaking-change detection would reintroduce the
+  hand-rolled version decisioning this change removes. A major release is instead
+  an explicit human act: run `cz bump --increment MAJOR` and push the resulting
+  tag.
+
+### Notes
+
+- Nightly tags are no longer PEP 440 pre-releases, so any tool that resolves
+  "the latest version" from raw version numbers will now treat a nightly as
+  latest. hate_crack's own startup update check is unaffected: it reads GitHub's
+  "latest release" endpoint and nightly builds publish no GitHub release. The
+  package is not published to PyPI (only a defensive name placeholder exists), so
+  nothing installs from an index today, but this is a real property of the scheme
+  rather than an oversight.
+- `release.yml` is unchanged and remains the path for tags pushed by a human;
+  tags pushed with `GITHUB_TOKEN` do not dispatch workflow events, so it never
+  fires for the bot-pushed tags above.
+
 ## [2.18.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,13 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   that early exit is gone. `nightly-dev` already tagged unconditionally, so that
   every validated nightly commit stays addressable.
 
-- **No existing tag was moved or deleted.** The `-rc.N` tags remain as history.
+- **Transition.** With `v2.18.0` as the baseline on `main`, the first release
+  under the new scheme is `v2.19.0`, and `nightly-dev` then rolls `v2.19.1`,
+  `v2.19.2`, … Both are monotonic against the highest surviving tag,
+  `v2.19.0-rc.11` (`2.19.0rc11 < 2.19.0 < 2.19.1`). The three `v3.0.0-rc.*` tags
+  were deleted from the remote as part of this transition, as a deliberate human
+  decision — they advertised a `3.0.0` release that is not being cut. All other
+  `-rc.N` tags remain as history and must not be deleted.
 
 ### Removed
 
@@ -49,8 +55,28 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   an explicit human act: run `cz bump --increment MAJOR` and push the resulting
   tag.
 
+  Note that four commits already on `nightly-dev` are marked breaking and would
+  have cut a major release under the old rules — three `feat(config)!:` and one
+  `refactor(config)!:`, all part of the config-file split. Under the new rules
+  they do not; they ship inside the next minor release. That is the intended
+  trade-off, recorded here so it is a decision rather than a surprise.
+
 ### Notes
 
+- **Merge `main` down into `nightly-dev` immediately after this release.** Until
+  you do, every validated `nightly-dev` push fails its tagging job with
+  `[NO_VERSION_SPECIFIED]` (exit 4), because `nightly-dev`'s `pyproject.toml` has
+  no `[tool.commitizen]` section yet — the config arrives with that merge. The
+  failure is loud and cannot mistag anything, which is the right failure mode, but
+  commitizen's error text says nothing about the cause. Expect a conflict in
+  `pyproject.toml` during the merge.
+- One transition hazard, on the record: in a hypothetical state where the
+  commitizen config had reached `nightly-dev` but the new `v2.19.0` tag was not
+  yet reachable from it, the nightly job would compute `v2.19.0` — the same tag
+  `main` cuts — and the idempotency guard would then quietly leave that nightly
+  commit untagged. In practice this cannot happen, because the config and the tag
+  arrive in the same merge-down commit. It is noted because it is the one way the
+  two branches could contend for a version number.
 - Nightly tags are no longer PEP 440 pre-releases, so any tool that resolves
   "the latest version" from raw version numbers will now treat a nightly as
   latest. hate_crack's own startup update check is unaffected: it reads GitHub's

--- a/README.md
+++ b/README.md
@@ -678,10 +678,17 @@ hate_crack can automatically check GitHub for newer releases on startup. This fe
 | Release | `--update` | `main` | The latest cut release. This is the default and what the startup check offers. |
 | Nightly | `--nightly` | `nightly-dev` | Work that has passed CI but has not been released yet. |
 
-The startup check only ever offers releases. It reads GitHub's "latest release"
-endpoint, which excludes pre-releases, and nightly builds publish no GitHub
-release at all — so enabling `check_for_updates` will never pull you onto a
-nightly.
+Versions follow a rolling scheme: `main` is stable and always `X.Y.0`, while
+`nightly-dev` consumes the patch numbers above it (`X.Y.1`, `X.Y.2`, …), one per
+validated push. Merging `nightly-dev` into `main` cuts the next `X.(Y+1).0`.
+
+The startup check only ever offers releases, because nightly builds publish no
+GitHub release at all and the check reads GitHub's "latest release" endpoint — so
+enabling `check_for_updates` will never pull you onto a nightly. Note that this
+is now the *only* thing separating the two channels: a nightly tag is an
+ordinary release tag rather than a pre-release, so a tool that ranks raw version
+numbers (rather than GitHub releases) will consider a nightly to be the latest
+version.
 
 Either flag switches your checkout to the corresponding branch first (and
 refuses to do so if you have uncommitted changes). If you are running a nightly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,28 @@ hate_crack = [
 version_scheme = "no-guess-dev"
 local_scheme = "no-local-version"
 
+[tool.commitizen]
+# The release workflows drive `cz bump` instead of hand-rolling version
+# arithmetic in bash. Both settings below are load-bearing:
+#
+#   version_provider = "scm" - read the current version from git tags rather
+#   than from a version string in a file. There is nothing to rewrite and no
+#   version-bump commit, which is what lets commitizen compose with the
+#   setuptools_scm config above.
+#
+#   tag_format = "v$version" - the repo's tags have always been v-prefixed.
+#   Commitizen defaults to a bare "$version", which would create tags that
+#   neither setuptools_scm nor any existing tooling recognises and would break
+#   continuity with every tag already published.
+#
+# The bump size is NOT inferred from commit messages. Each workflow forces it
+# with --increment, because in this repo the branch decides the bump: main is
+# MINOR (stable X.Y.0), nightly-dev is PATCH (rolling X.Y.1, X.Y.2, ...).
+version_provider = "scm"
+tag_format = "v$version"
+# No CHANGELOG.md rewrite on bump; the changelog is maintained by hand.
+update_changelog_on_bump = false
+
 [tool.ruff]
 exclude = [
     "build",
@@ -113,4 +135,8 @@ dev = [
     "pytest-cov==7.1.0",
     "pytest-timeout>=2.4.0",
     "pexpect>=4.9.0",
+    # Drives version bumps in the release workflows; see [tool.commitizen].
+    "commitizen==4.17.0",
+    # Used by tests/test_release_versioning.py to parse the workflow YAML.
+    "pyyaml==6.0.3",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,45 @@
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
 import pytest
+
+# Environment variables that point git at a specific repository, index, or
+# object store. Git sets these for its own hooks, so a `git push` running the
+# prek pre-push hook exports them into pytest -- and any test that shells out to
+# git in a throwaway repo then operates on the OUTER repo's index instead of its
+# own. That surfaced as `git commit` failing during setup in
+# tests/test_upgrade_real_git.py, but only under the hook, never on a bare
+# `pytest` run, which makes it the kind of failure that gets dismissed as flaky.
+#
+# GIT_AUTHOR_* / GIT_COMMITTER_* are deliberately NOT stripped: they only affect
+# identity, and a hook-supplied identity is harmless.
+_GIT_REPO_LOCATION_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_PREFIX",
+)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _isolate_git_environment():
+    """Unset inherited git repo-location variables for the whole session.
+
+    Session-scoped and autouse so it also covers tests that shell out to git
+    from a fixture's setup, which is where this bit first.
+    """
+    saved = {k: os.environ[k] for k in _GIT_REPO_LOCATION_VARS if k in os.environ}
+    for key in saved:
+        del os.environ[key]
+    try:
+        yield
+    finally:
+        os.environ.update(saved)
 
 
 def load_hate_crack_module(monkeypatch):

--- a/tests/test_release_versioning.py
+++ b/tests/test_release_versioning.py
@@ -1,0 +1,219 @@
+"""Guards on the release-versioning wiring.
+
+The scheme is: ``main`` is stable at ``X.Y.0`` (a MINOR bump per merge) and
+``nightly-dev`` rolls through patch numbers ``X.Y.1``, ``X.Y.2`` (a PATCH bump
+per validated push). The arithmetic is commitizen's job, not this repo's.
+
+These tests deliberately assert the *configuration and wiring*, not the version
+numbers commitizen produces. Re-testing commitizen's arithmetic here would just
+re-encode the hand-rolled assumptions this setup exists to remove. What can break
+silently is the glue: a lost ``tag_format``, a dropped ``--increment``, or the old
+bash version math creeping back in.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+AUTO_TAG = WORKFLOWS / "auto-tag.yml"
+NIGHTLY_TAG = WORKFLOWS / "nightly-tag.yml"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as fh:
+        loaded = yaml.safe_load(fh)
+    assert isinstance(loaded, dict), f"{path.name} did not parse to a mapping"
+    return loaded
+
+
+def _commitizen_config() -> dict[str, Any]:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        data = tomllib.load(fh)
+    tool = data.get("tool", {})
+    assert "commitizen" in tool, "pyproject.toml is missing [tool.commitizen]"
+    return tool["commitizen"]
+
+
+def _run_steps(path: Path) -> list[dict[str, Any]]:
+    """Every step of every job in a workflow, as dicts."""
+    workflow = _load_yaml(path)
+    steps: list[dict[str, Any]] = []
+    for job in workflow["jobs"].values():
+        for step in job.get("steps", []):
+            if isinstance(step, dict):
+                steps.append(step)
+    return steps
+
+
+def _shell_body(path: Path) -> str:
+    """Concatenated `run:` bodies of a workflow.
+
+    Parsed out of the YAML rather than read as raw text, so that assertions
+    about shell content cannot be satisfied (or defeated) by a comment
+    elsewhere in the file.
+    """
+    return "\n".join(step["run"] for step in _run_steps(path) if "run" in step)
+
+
+# --- commitizen configuration ------------------------------------------------
+
+
+def test_commitizen_uses_v_prefixed_tag_format() -> None:
+    """Tags must stay ``v``-prefixed.
+
+    Commitizen defaults to a bare ``$version``. A regression here would create
+    unprefixed tags that break continuity with every existing tag and with
+    setuptools-scm's tag parsing.
+    """
+    assert _commitizen_config().get("tag_format") == "v$version"
+
+
+def test_commitizen_reads_version_from_scm() -> None:
+    """The version lives in git tags, not in a file.
+
+    ``version_provider = "scm"`` is what lets commitizen compose with the
+    setuptools-scm config: no version string to rewrite and no bump commit.
+    """
+    assert _commitizen_config().get("version_provider") == "scm"
+
+
+def test_commitizen_is_pinned_in_dev_dependencies() -> None:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        data = tomllib.load(fh)
+    dev = data["dependency-groups"]["dev"]
+    pins = [d for d in dev if d.split("==")[0].strip() == "commitizen"]
+    assert pins, "commitizen missing from the dev dependency group"
+    assert "==" in pins[0], f"commitizen must be pinned exactly, got {pins[0]!r}"
+
+
+# --- workflow wiring ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "increment"),
+    [
+        pytest.param(NIGHTLY_TAG, "PATCH", id="nightly-dev-consumes-patch"),
+        pytest.param(AUTO_TAG, "MINOR", id="main-cuts-minor"),
+    ],
+)
+def test_workflow_forces_the_right_increment(path: Path, increment: str) -> None:
+    """The branch decides the bump, and it must be forced explicitly.
+
+    Without ``--increment`` commitizen would infer the bump from commit
+    messages, which is the behaviour this scheme replaces.
+    """
+    body = _shell_body(path)
+    assert "cz bump" in body, f"{path.name} does not invoke `cz bump`"
+    assert f"--increment {increment}" in body, (
+        f"{path.name} must force `--increment {increment}`"
+    )
+    other = "MINOR" if increment == "PATCH" else "PATCH"
+    assert f"--increment {other}" not in body, (
+        f"{path.name} must not also use `--increment {other}`"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param(AUTO_TAG, id="auto-tag"),
+        pytest.param(NIGHTLY_TAG, id="nightly-tag"),
+    ],
+)
+def test_workflow_has_no_hand_rolled_version_math(path: Path) -> None:
+    """The bash version arithmetic must not creep back.
+
+    These are the exact shapes the old workflows used: splitting a version with
+    ``cut -d.`` and incrementing with arithmetic expansion.
+    """
+    body = _shell_body(path)
+    forbidden = [
+        "cut -d. -f",
+        "$((major",
+        "$((minor",
+        "$((patch",
+        "$(( major",
+        "$(( minor",
+        "$(( patch",
+    ]
+    found = [snippet for snippet in forbidden if snippet in body]
+    assert not found, f"{path.name} reintroduced hand-rolled version math: {found}"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param(AUTO_TAG, id="auto-tag"),
+        pytest.param(NIGHTLY_TAG, id="nightly-tag"),
+    ],
+)
+def test_workflow_checks_out_the_validated_commit_with_full_history(path: Path) -> None:
+    """``workflow_run`` defaults to the default-branch tip, not the tested commit.
+
+    ``fetch-depth: 0`` is equally load-bearing: commitizen resolves the current
+    version from tags and a shallow clone has none.
+    """
+    checkouts = [
+        s for s in _run_steps(path) if "actions/checkout" in str(s.get("uses"))
+    ]
+    assert len(checkouts) == 1, f"{path.name} should have exactly one checkout step"
+    with_ = checkouts[0].get("with", {})
+    assert with_.get("ref") == "${{ github.event.workflow_run.head_sha }}"
+    assert with_.get("fetch-depth") == 0
+
+
+def test_auto_tag_creates_a_github_release() -> None:
+    """Tags pushed with GITHUB_TOKEN do not dispatch release.yml, so main's
+    release has to be created here."""
+    assert "gh release create" in _shell_body(AUTO_TAG)
+
+
+def test_nightly_tag_creates_no_github_release() -> None:
+    """Nightlies are addressable tags only; releases are cut on main."""
+    body = _shell_body(NIGHTLY_TAG)
+    assert "gh release create" not in body
+    assert "softprops/action-gh-release" not in str(_run_steps(NIGHTLY_TAG))
+
+
+def test_auto_tag_does_not_skip_chore_only_merges() -> None:
+    """A merge into main is an explicit release event.
+
+    The old workflow exited early when there were no feat/fix/perf commits; that
+    early exit is gone, so no step may be gated on a `skip` output.
+    """
+    for step in _run_steps(AUTO_TAG):
+        condition = str(step.get("if", ""))
+        assert "skip" not in condition, f"unexpected skip gate on step {step!r}"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param(AUTO_TAG, id="auto-tag"),
+        pytest.param(NIGHTLY_TAG, id="nightly-tag"),
+    ],
+)
+def test_workflow_tag_push_is_idempotent(path: Path) -> None:
+    """A re-run must not fail the job on an already-existing tag."""
+    assert "git rev-parse -q --verify" in _shell_body(path)
+
+
+@pytest.mark.parametrize(
+    ("path", "group"),
+    [
+        pytest.param(AUTO_TAG, "auto-tag", id="auto-tag"),
+        pytest.param(NIGHTLY_TAG, "nightly-tag", id="nightly-tag"),
+    ],
+)
+def test_workflow_serializes_instead_of_cancelling(path: Path, group: str) -> None:
+    """Back-to-back merges must queue, not cancel, or one goes untagged."""
+    concurrency = _load_yaml(path)["concurrency"]
+    assert concurrency["group"] == group
+    assert concurrency["cancel-in-progress"] is False

--- a/tests/test_release_versioning.py
+++ b/tests/test_release_versioning.py
@@ -4,15 +4,29 @@ The scheme is: ``main`` is stable at ``X.Y.0`` (a MINOR bump per merge) and
 ``nightly-dev`` rolls through patch numbers ``X.Y.1``, ``X.Y.2`` (a PATCH bump
 per validated push). The arithmetic is commitizen's job, not this repo's.
 
-These tests deliberately assert the *configuration and wiring*, not the version
-numbers commitizen produces. Re-testing commitizen's arithmetic here would just
-re-encode the hand-rolled assumptions this setup exists to remove. What can break
-silently is the glue: a lost ``tag_format``, a dropped ``--increment``, or the old
-bash version math creeping back in.
+These tests do not re-test commitizen's arithmetic -- that is the tool's job, and
+re-encoding it here would resurrect the assumptions this setup removed. They
+guard two other things:
+
+* **Configuration coherence**, which breaks silently: a lost ``tag_format``, a
+  dropped ``version_provider``, a drifted version pin.
+* **The behaviour of the shell that remains.** The two load-bearing guards (tag
+  idempotency and the empty-tag check) are tested by *extracting the step script
+  from the YAML and running it* -- against a real git repository with a real bare
+  remote, and against a stub ``uvx`` on ``PATH``. An earlier version of this file
+  asserted those two by literal substring and a reviewer defeated both without
+  any test failing: replacing the whole ``if``/``else`` with an unconditional
+  ``git tag && git push`` still matched, because the substring lived elsewhere in
+  the file. Substring assertions here are sensitive to formatting and blind to
+  behaviour, which is exactly backwards. Do not convert these back.
 """
 
 from __future__ import annotations
 
+import os
+import re
+import shutil
+import subprocess
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -25,6 +39,19 @@ WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 AUTO_TAG = WORKFLOWS / "auto-tag.yml"
 NIGHTLY_TAG = WORKFLOWS / "nightly-tag.yml"
 
+BOTH_WORKFLOWS = [
+    pytest.param(AUTO_TAG, id="auto-tag"),
+    pytest.param(NIGHTLY_TAG, id="nightly-tag"),
+]
+
+# The version commitizen is pinned to. Asserted to agree across the dev
+# dependency group and both workflow invocations; see
+# test_commitizen_pin_agrees_everywhere for why that matters.
+COMMITIZEN_PIN = "4.17.0"
+
+
+# --- parsing helpers ---------------------------------------------------------
+
 
 def _load_yaml(path: Path) -> dict[str, Any]:
     with path.open("rb") as fh:
@@ -34,11 +61,14 @@ def _load_yaml(path: Path) -> dict[str, Any]:
 
 
 def _commitizen_config() -> dict[str, Any]:
-    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
-        data = tomllib.load(fh)
-    tool = data.get("tool", {})
+    tool = _pyproject().get("tool", {})
     assert "commitizen" in tool, "pyproject.toml is missing [tool.commitizen]"
     return tool["commitizen"]
+
+
+def _pyproject() -> dict[str, Any]:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)
 
 
 def _run_steps(path: Path) -> list[dict[str, Any]]:
@@ -60,6 +90,40 @@ def _shell_body(path: Path) -> str:
     elsewhere in the file.
     """
     return "\n".join(step["run"] for step in _run_steps(path) if "run" in step)
+
+
+def _code_lines(path: Path) -> list[str]:
+    """Shell lines of a workflow with comments and blanks removed.
+
+    Comment stripping matters: every denial below would otherwise be trippable
+    by a comment that merely *mentions* the forbidden construct, and this file
+    is full of prose explaining what must not come back.
+    """
+    lines = []
+    for raw in _shell_body(path).splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        lines.append(raw)
+    return lines
+
+
+def _script(path: Path, step_name: str) -> str:
+    """The `run:` script of the uniquely-named step."""
+    matches = [s for s in _run_steps(path) if s.get("name") == step_name and "run" in s]
+    assert len(matches) == 1, (
+        f"{path.name} should have exactly one step named {step_name!r}, "
+        f"found {len(matches)}"
+    )
+    return matches[0]["run"]
+
+
+def _tag_step_name(path: Path) -> str:
+    return "Create tag"
+
+
+def _compute_step_name(path: Path) -> str:
+    return "Compute release tag" if path == AUTO_TAG else "Compute nightly tag"
 
 
 # --- commitizen configuration ------------------------------------------------
@@ -84,16 +148,30 @@ def test_commitizen_reads_version_from_scm() -> None:
     assert _commitizen_config().get("version_provider") == "scm"
 
 
-def test_commitizen_is_pinned_in_dev_dependencies() -> None:
-    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
-        data = tomllib.load(fh)
-    dev = data["dependency-groups"]["dev"]
+def test_commitizen_pin_agrees_everywhere() -> None:
+    """The pin appears in three places and they must not drift.
+
+    The workflows install commitizen with ``uvx --from`` and never run
+    ``uv sync --dev``, so the dev-group pin does not constrain CI at all.
+    Bumping only the dev group would change what a developer runs locally while
+    CI silently kept tagging with the old version -- and nothing would fail.
+    """
+    dev = _pyproject()["dependency-groups"]["dev"]
     pins = [d for d in dev if d.split("==")[0].strip() == "commitizen"]
-    assert pins, "commitizen missing from the dev dependency group"
-    assert "==" in pins[0], f"commitizen must be pinned exactly, got {pins[0]!r}"
+    assert pins == [f"commitizen=={COMMITIZEN_PIN}"], (
+        f"dev group commitizen pin should be commitizen=={COMMITIZEN_PIN}, got {pins}"
+    )
+
+    for path in (AUTO_TAG, NIGHTLY_TAG):
+        found = re.findall(r"--from\s+'commitizen==([0-9][^']*)'", _shell_body(path))
+        assert found, f"{path.name} does not install a pinned commitizen"
+        assert set(found) == {COMMITIZEN_PIN}, (
+            f"{path.name} pins commitizen{found}, expected {COMMITIZEN_PIN} "
+            "to match the dev dependency group"
+        )
 
 
-# --- workflow wiring ---------------------------------------------------------
+# --- the anti-hand-rolling invariant ----------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -103,57 +181,250 @@ def test_commitizen_is_pinned_in_dev_dependencies() -> None:
         pytest.param(AUTO_TAG, "MINOR", id="main-cuts-minor"),
     ],
 )
-def test_workflow_forces_the_right_increment(path: Path, increment: str) -> None:
-    """The branch decides the bump, and it must be forced explicitly.
+def test_cz_bump_is_the_only_thing_that_produces_a_version(
+    path: Path, increment: str
+) -> None:
+    """The user's hard constraint: do not hand-roll a versioning scheme.
 
-    Without ``--increment`` commitizen would infer the bump from commit
-    messages, which is the behaviour this scheme replaces.
+    This is stated as a POSITIVE invariant -- exactly one command computes the
+    version, it is ``cz bump``, and the tag actually used is read back from that
+    command's output -- because the previous denylist-only form was defeatable.
+    A reviewer reintroduced the exact rc-counter pipeline this change deleted
+    (``git tag --list | sed -E ... | sort -n | tail -1`` feeding
+    ``n=$(( last_n + 1 ))``) and every test still passed, because the denylist
+    happened to enumerate ``$((major`` and friends but not ``sort -n``,
+    ``sed -E`` or a bare ``$((``.
+
+    The denials below are a second line of defence, not the primary one.
     """
-    body = _shell_body(path)
-    assert "cz bump" in body, f"{path.name} does not invoke `cz bump`"
-    assert f"--increment {increment}" in body, (
-        f"{path.name} must force `--increment {increment}`"
+    lines = _code_lines(path)
+
+    bump_lines = [ln for ln in lines if "cz bump" in ln]
+    assert len(bump_lines) == 1, (
+        f"{path.name} must invoke `cz bump` exactly once, found {len(bump_lines)}"
+    )
+    bump = bump_lines[0]
+    assert f"--increment {increment}" in bump, (
+        f"{path.name} must force `--increment {increment}`; got: {bump.strip()}"
+    )
+    assert "--dry-run" in bump, (
+        f"{path.name} must use --dry-run; the tag is pushed explicitly afterwards"
     )
     other = "MINOR" if increment == "PATCH" else "PATCH"
-    assert f"--increment {other}" not in body, (
-        f"{path.name} must not also use `--increment {other}`"
-    )
+    assert other not in _shell_body(path), f"{path.name} must not reference `{other}`"
 
+    # The tag that gets pushed must come from cz's own output, not be assembled
+    # locally. Any assignment to new_tag has to read the cz log.
+    assignments = [ln for ln in lines if re.match(r"\s*new_tag=", ln)]
+    assert assignments, f"{path.name} never assigns new_tag"
+    for assignment in assignments:
+        assert "cz-bump.log" in assignment, (
+            f"{path.name} builds new_tag without reading cz's output, which is "
+            f"hand-rolled versioning: {assignment.strip()}"
+        )
 
-@pytest.mark.parametrize(
-    "path",
-    [
-        pytest.param(AUTO_TAG, id="auto-tag"),
-        pytest.param(NIGHTLY_TAG, id="nightly-tag"),
-    ],
-)
-def test_workflow_has_no_hand_rolled_version_math(path: Path) -> None:
-    """The bash version arithmetic must not creep back.
-
-    These are the exact shapes the old workflows used: splitting a version with
-    ``cut -d.`` and incrementing with arithmetic expansion.
-    """
-    body = _shell_body(path)
+    # Second line of defence: constructs that only appear when someone is
+    # parsing, comparing or incrementing a version number in shell.
     forbidden = [
-        "cut -d. -f",
-        "$((major",
-        "$((minor",
-        "$((patch",
-        "$(( major",
-        "$(( minor",
-        "$(( patch",
+        "cut -d",  # splitting MAJOR.MINOR.PATCH
+        "$((",  # any arithmetic expansion, not just $((patch
+        "expr ",
+        "sort -n",  # ranking an rc counter
+        "sort -V",  # ranking version strings
+        "sort -rV",
+        "sort -v",
+        "--sort=-v:refname",
+        "sed -E",  # extracting a counter out of a tag name
+        "git tag --list",  # enumerating tags to derive the next one
+        "git tag -l",
+        "git describe",
     ]
-    found = [snippet for snippet in forbidden if snippet in body]
+    found = [snippet for snippet in forbidden if snippet in "\n".join(lines)]
     assert not found, f"{path.name} reintroduced hand-rolled version math: {found}"
 
 
-@pytest.mark.parametrize(
-    "path",
-    [
-        pytest.param(AUTO_TAG, id="auto-tag"),
-        pytest.param(NIGHTLY_TAG, id="nightly-tag"),
-    ],
-)
+# --- behavioural: tag creation is idempotent --------------------------------
+
+
+def _init_repo_with_remote(tmp_path: Path) -> tuple[Path, Path]:
+    """A real git repo with a real bare remote. No subprocess mocking.
+
+    Asserting on a mocked ``subprocess`` would only re-check the command
+    strings, which is what let the substring version of this test be defeated.
+    A real remote means the push either happens or it does not.
+    """
+    git = shutil.which("git")
+    assert git, "git is required for this test"
+    remote = tmp_path / "remote.git"
+    work = tmp_path / "work"
+    subprocess.run([git, "init", "--bare", "-q", str(remote)], check=True)
+    subprocess.run([git, "init", "-q", str(work)], check=True)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.invalid",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.invalid",
+    }
+    (work / "f.txt").write_text("x\n")
+    subprocess.run([git, "add", "f.txt"], cwd=work, check=True, env=env)
+    subprocess.run(
+        [git, "commit", "-q", "-m", "c", "--no-gpg-sign"],
+        cwd=work,
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        [git, "remote", "add", "origin", str(remote)], cwd=work, check=True, env=env
+    )
+    return work, remote
+
+
+def _run_script(
+    script: str, cwd: Path, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    bash = shutil.which("bash")
+    assert bash, "bash is required for this test"
+    return subprocess.run(
+        [bash, "-c", script],
+        cwd=cwd,
+        env={**os.environ, **env},
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
+def test_tag_creation_is_actually_idempotent(path: Path, tmp_path: Path) -> None:
+    """Re-running the workflow must not fail on an already-existing tag.
+
+    Behavioural, not textual: the real "Create tag" script runs twice against a
+    real repo and a real bare remote. The substring form of this test survived
+    the tag-existence ``if``/``else`` being replaced by an unconditional
+    ``git tag && git push``, which is precisely the regression it is named for --
+    the second run would then die on "tag already exists".
+    """
+    work, remote = _init_repo_with_remote(tmp_path)
+    script = _script(path, _tag_step_name(path))
+    env = {
+        "NEW_TAG": "v9.9.9",
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.invalid",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.invalid",
+    }
+
+    first = _run_script(script, work, env)
+    assert first.returncode == 0, f"first run failed:\n{first.stdout}\n{first.stderr}"
+    remote_tags = subprocess.run(
+        [str(shutil.which("git")), "tag", "--points-at", "HEAD"],
+        cwd=work,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "v9.9.9" in remote_tags, "first run did not create the tag"
+    pushed = subprocess.run(
+        [str(shutil.which("git")), "ls-remote", "--tags", str(remote)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "refs/tags/v9.9.9" in pushed, "first run did not push the tag"
+
+    second = _run_script(script, work, env)
+    assert second.returncode == 0, (
+        "re-running the tag step must not fail when the tag already exists, "
+        f"but it exited {second.returncode}:\n{second.stdout}\n{second.stderr}"
+    )
+
+
+# --- behavioural: the empty-tag guard ---------------------------------------
+
+
+def _uvx_stub(tmp_path: Path, output: str, exit_code: int = 0) -> Path:
+    """A directory to prepend to PATH containing a fake `uvx`.
+
+    Lets the compute step run without network access or a real commitizen, so
+    the guard around cz's *output* can be exercised directly.
+    """
+    bindir = tmp_path / "stubbin"
+    bindir.mkdir()
+    stub = bindir / "uvx"
+    stub.write_text(f"#!/bin/sh\ncat <<'CZEOF'\n{output}\nCZEOF\nexit {exit_code}\n")
+    stub.chmod(0o755)
+    return bindir
+
+
+@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
+def test_compute_step_extracts_the_tag_cz_reports(path: Path, tmp_path: Path) -> None:
+    """The happy path: the pushed tag is whatever cz said, verbatim.
+
+    Also exercises the deliberately pipeline-free extraction. Piping cz into
+    ``sed`` directly would risk the producer dying on SIGPIPE (141) under
+    ``set -o pipefail`` and failing the step on a *successful* match.
+    """
+    output = (
+        "bump: version 4.5.6 -> 4.5.7\ntag to create: v4.5.7\nincrement detected: PATCH"
+    )
+    bindir = _uvx_stub(tmp_path, output)
+    gh_output = tmp_path / "gh_output"
+    gh_output.write_text("")
+    result = _run_script(
+        _script(path, _compute_step_name(path)),
+        tmp_path,
+        {
+            "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(gh_output),
+        },
+    )
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert "new_tag=v4.5.7" in gh_output.read_text()
+
+
+@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
+def test_compute_step_fails_when_cz_reports_no_tag(path: Path, tmp_path: Path) -> None:
+    """An unparseable cz output must fail the job, not push an empty tag.
+
+    Nothing asserted this guard existed before. Without it a change to
+    commitizen's output wording -- a rename of the "tag to create:" line -- makes
+    the next step run ``git tag ""``, and the failure would be reported as
+    something other than "we could not read the version".
+    """
+    bindir = _uvx_stub(tmp_path, "bump: nothing to do, and no tag line at all")
+    gh_output = tmp_path / "gh_output"
+    gh_output.write_text("")
+    result = _run_script(
+        _script(path, _compute_step_name(path)),
+        tmp_path,
+        {
+            "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(gh_output),
+        },
+    )
+    assert result.returncode != 0, (
+        "the compute step must fail when cz reports no tag, otherwise the next "
+        f"step tags the empty string. stdout:\n{result.stdout}"
+    )
+    assert "new_tag=" not in gh_output.read_text(), (
+        "no new_tag may be emitted when the tag could not be determined"
+    )
+
+
+@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
+def test_compute_step_writes_to_runner_temp(path: Path) -> None:
+    """Use the runner's scratch dir, not a fixed path in /tmp."""
+    body = _shell_body(path)
+    assert "$RUNNER_TEMP" in body or "${RUNNER_TEMP}" in body
+    assert "/tmp/cz-bump" not in body
+
+
+# --- wiring that has no behaviour to execute --------------------------------
+
+
+@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
 def test_workflow_checks_out_the_validated_commit_with_full_history(path: Path) -> None:
     """``workflow_run`` defaults to the default-branch tip, not the tested commit.
 
@@ -185,24 +456,16 @@ def test_nightly_tag_creates_no_github_release() -> None:
 def test_auto_tag_does_not_skip_chore_only_merges() -> None:
     """A merge into main is an explicit release event.
 
-    The old workflow exited early when there were no feat/fix/perf commits; that
-    early exit is gone, so no step may be gated on a `skip` output.
+    The old workflow exited early when it found no feat/fix/perf commits. Both
+    halves of that mechanism are checked: no step may be gated on a `skip`
+    output, and no shell may emit one -- a reintroduced in-shell
+    ``echo skip=true >> "$GITHUB_OUTPUT"; exit 0`` would otherwise pass.
     """
     for step in _run_steps(AUTO_TAG):
         condition = str(step.get("if", ""))
         assert "skip" not in condition, f"unexpected skip gate on step {step!r}"
-
-
-@pytest.mark.parametrize(
-    "path",
-    [
-        pytest.param(AUTO_TAG, id="auto-tag"),
-        pytest.param(NIGHTLY_TAG, id="nightly-tag"),
-    ],
-)
-def test_workflow_tag_push_is_idempotent(path: Path) -> None:
-    """A re-run must not fail the job on an already-existing tag."""
-    assert "git rev-parse -q --verify" in _shell_body(path)
+    for line in _code_lines(AUTO_TAG):
+        assert "skip=" not in line, f"auto-tag emits a skip output: {line.strip()}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_upgrade_real_git.py
+++ b/tests/test_upgrade_real_git.py
@@ -12,6 +12,7 @@ published history: every commit got a new SHA, so a clone predating it shares no
 ancestor with origin and holds tags pointing at objects origin no longer has.
 """
 
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -215,3 +216,35 @@ def test_upgrade_path_has_no_pull(hc_module_real_git):
     ]
     offenders = [lit for lit in literals if "pull" in lit]
     assert not offenders, f"_run_upgrade() must not pull: {offenders}"
+
+
+def test_inherited_git_repo_vars_do_not_leak_into_throwaway_repos(tmp_path):
+    """The session fixture in conftest must strip git's repo-location vars.
+
+    Git exports these to its own hooks, so `git push` running the prek pre-push
+    hook leaks them into pytest, and every test in this file then operates on
+    the outer repo's index rather than its own tmp_path repo. Asserted here
+    rather than in a conftest test because this is the file that broke.
+    """
+    for key in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_PREFIX",
+    ):
+        assert key not in os.environ, (
+            f"{key} is set during the test session; a test that shells out to "
+            "git will operate on the wrong repository. See "
+            "_isolate_git_environment in tests/conftest.py."
+        )
+
+    # And prove the practical consequence is gone: a commit in a fresh repo works.
+    repo = tmp_path / "scratch"
+    _init(repo)
+    (repo / "f.txt").write_text("x\n")
+    _git("add", "f.txt", cwd=repo)
+    _git("commit", "-qm", "initial", cwd=repo)
+    assert _git("rev-parse", "--short", "HEAD", cwd=repo).stdout.strip()


### PR DESCRIPTION
## What

`main` becomes stable at `X.Y.0` and `nightly-dev` becomes the rolling branch that consumes patch numbers:

```
stable 2.19.0  ->  nightly 2.19.1, 2.19.2  ->  merge to main  ->  stable 2.20.0
```

This replaces the `-rc.N` pre-release scheme, which existed only because `setuptools-scm` rejects tags ending in `.devN` for N>0. That workaround is retired.

## No workflow computes a version number

Both tagging workflows previously hand-rolled the arithmetic in bash — `cut -d.`, `$((patch + 1))`, plus an rc-counter `sed`/`sort -n` pipeline — **duplicated across two files**. All of it is gone, replaced by `commitizen`:

```
uvx --from 'commitizen==4.17.0' cz bump --yes --increment {MINOR,PATCH} --dry-run
```

Configured in `pyproject.toml` with `version_provider = "scm"` (version read from git tags, so no version string to rewrite and no bump commit) and `tag_format = "v$version"` (this repo's tags have always been `v`-prefixed; commitizen's bare default would break continuity with every existing tag and with `setuptools-scm`).

The increment is **forced per branch** rather than inferred from commit messages, because here the branch decides the bump.

## Behaviour changes worth reviewing

- **`type!:` / `BREAKING CHANGE:` no longer auto-bumps major.** Intentional. A major release is now an explicit human act: `cz bump --increment MAJOR`. Four `!` commits currently on `nightly-dev` would have cut `v3.0.0` under the old rules; the transition instead cuts `v2.19.0`.
- **A docs/chore-only merge to `main` still cuts a release.** `auto-tag.yml`'s "no feat/fix/perf, skip" early exit is removed, because a merge to `main` is now an explicit release event.
- **Nightly tags are ordinary release tags, not PEP 440 pre-releases.** Any tool ranking raw version numbers will treat a nightly as latest. The startup update check is unaffected because it reads GitHub's "latest release" endpoint and nightlies publish no release. `README.md`'s justification for that check previously rested on "excludes pre-releases", which is now false and has been rewritten.

## Transition

The three `v3.0.0-rc.*` tags were deleted from origin by deliberate decision (auto-created earlier today, no GitHub releases attached). Highest surviving tag is `v2.19.0-rc.11`. Verified with real `cz bump --dry-run` runs in throwaway clones:

| Mode | Baseline | Produces |
|---|---|---|
| `main` | `2.18.0` | **`v2.19.0`** |
| `nightly-dev`, steady state | `2.19.0` | **`v2.19.1`** |

Monotonic: `2.19.0rc11 < 2.19.0 < 2.19.1 < 2.20.0`.

**Merge `main` down into `nightly-dev` immediately after this lands.** `nightly-tag.yml` runs `cz` against the checked-out `pyproject.toml`, so until `[tool.commitizen]` reaches `nightly-dev` every nightly push fails with `[NO_VERSION_SPECIFIED]`. It fails loudly rather than tagging wrongly, but the error names nothing useful. Both this and the transition collision hazard are recorded in the CHANGELOG.

## Tests

`tests/test_release_versioning.py` asserts configuration and wiring, never commitizen's arithmetic. The first version of these tests matched literal substrings and was **defeatable** — a review reintroduced the exact deleted rc-counter pipeline and all 16 tests passed. They were rewritten to assert behaviour and every guard was mutation-tested:

| Mutation | Result |
|---|---|
| Reintroduce the rc-counter pipeline | fails `test_cz_bump_is_the_only_thing_that_produces_a_version` |
| Replace the tag-exists guard with unconditional `git tag && git push` | fails `test_tag_creation_is_actually_idempotent` (real `fatal: tag already exists`) |
| Delete the empty-tag guard | fails `test_compute_step_fails_when_cz_reports_no_tag` |
| Disagree the commitizen pin across its three locations | fails `test_commitizen_pin_agrees_everywhere` |
| Reintroduce an in-shell `skip=true` | fails `test_auto_tag_does_not_skip_chore_only_merges` |

The tag test runs the extracted step script twice against a real git repo with a real bare remote rather than mocking `subprocess` — mocked subprocess only re-checks command strings, which is what let the substring version be defeated.

## Also fixed here

A separate bug this PR tripped over: git exports `GIT_DIR`/`GIT_INDEX_FILE` to its own hooks, so `git push` running the prek pre-push hook leaked them into pytest, and every test shelling out to git in a `tmp_path` repo operated on the outer repo's index. `git commit` failed during fixture setup in `test_upgrade_real_git.py` — **only under the hook, never on a bare `pytest` run**, which is the kind of failure that gets written off as flaky. A session-scoped autouse fixture in `tests/conftest.py` unsets the repo-location variables.

## Verification

1521 passed / 29 skipped, and identically green with `GIT_INDEX_FILE`/`GIT_DIR` deliberately set. `ruff check`, `ruff format --check`, `ty` all clean. `release.yml` untouched; no existing tag moved.

Refs #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)