### PR TITLE
fix(update): treat being on the release commit as up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Fixed
+- **The update check no longer loops forever when one commit carries two release
+  tags.** The 2.20.0 release left commit `e37d568` tagged both `v2.19.15` and
+  `v2.20.0`, because `nightly-dev` and `main` pointed at the same commit and both
+  tag workflows fired on it. `git describe` breaks a same-commit tie by ref
+  iteration order, which is lexicographic, so the *lower* tag wins: setuptools-scm
+  reported 2.19.15 while the releases API reported 2.20.0. Every start offered an
+  upgrade, and accepting it re-fetched the same tags, landed on the same commit
+  and regenerated the same version, so no number of upgrades could clear it. It
+  affected every user who upgraded to 2.20.0.
+
+  `check_for_updates()` now treats "the latest release tag points at HEAD" as up
+  to date regardless of the version string, since being on the released commit is
+  the authoritative answer and a version derived from `describe` is not. Any
+  failure to establish that -- no checkout, no such tag locally, no git -- falls
+  back to the version comparison, so installs that are not git clones still get
+  the notice.
+
+  Covered by `tests/test_upgrade_convergence.py`, which runs real git so the
+  version really comes from a real `describe`. It asserts the property the
+  existing upgrade tests missed: they cover upgrade *mechanics*, but nothing
+  checked that upgrading is a *fixed point*. Both halves of this bug are
+  individually correct and only fail composed, so mechanics-only tests could not
+  have caught it.
+
+  The release pipeline can still produce the ambiguous state; that half is being
+  addressed separately in the versioning-policy work (#221).
+
 ## [2.20.0] - 2026-07-31
 
 ### Added

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1535,6 +1535,54 @@ def _run_upgrade(branch="main"):
     raise SystemExit(0)
 
 
+def _head_is_at_release_tag(tag):
+    """True when *tag* exists in the local checkout and points at HEAD.
+
+    The version comparison alone cannot decide "am I up to date", because the
+    version is whatever `git describe` resolves to and a commit can carry more
+    than one release tag. When it does, describe breaks the tie by ref iteration
+    order -- lexicographic -- so the LOWER tag wins: v2.19.15 over v2.20.0 on
+    e37d568, the 2026-07-31 release. The version then never reaches the released
+    one no matter how many times the upgrade runs, and every start re-offers it.
+
+    Being on the commit the release points at is the authoritative answer, so it
+    takes priority. Any failure here (no checkout, unknown tag, no git) returns
+    False and leaves the version comparison in charge, which keeps the notice
+    working for installs that are not git clones.
+    """
+    if not tag or not _re_tag_name.fullmatch(tag):
+        return False
+    try:
+        import subprocess
+
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=_repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if head.returncode != 0:
+            return False
+        # ^{commit} so an annotated tag resolves to its commit rather than the
+        # tag object, which would never equal HEAD.
+        tagged = subprocess.run(
+            ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}^{{commit}}"],
+            cwd=_repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if tagged.returncode != 0:
+            return False
+        return head.stdout.strip() == tagged.stdout.strip() != ""
+    except Exception:
+        return False
+
+
+# Tag names come from the releases API, so they are remote input. Constrain them
+# to the shape this project actually publishes before handing one to git.
+_re_tag_name = re.compile(r"v?[0-9][0-9A-Za-z.\-+]*")
+
+
 def check_for_updates():
     """Check GitHub for a newer release and print a notice if one exists."""
     try:
@@ -1555,7 +1603,7 @@ def check_for_updates():
             return
         from packaging.version import parse
 
-        if parse(latest) > parse(local_base):
+        if parse(latest) > parse(local_base) and not _head_is_at_release_tag(tag):
             print(
                 f"\n  Update available: {latest} (current: {local_base})."
                 f"\n  See https://github.com/trustedsec/hate_crack/releases\n"

--- a/tests/test_upgrade_convergence.py
+++ b/tests/test_upgrade_convergence.py
@@ -1,0 +1,254 @@
+"""The upgrade must converge: upgrading once must stop the offer.
+
+Everything in test_version_check.py and test_upgrade_real_git.py asserts upgrade
+*mechanics* -- which commands get built, whether HEAD moves, whether a rewritten
+clone recovers. None of it asserts the property users actually care about: after
+an upgrade succeeds, the next start must not offer the same upgrade again.
+
+That gap let a real loop ship. On 2026-07-31 the release pipeline left commit
+e37d568 carrying two tags, v2.19.15 (cut by nightly-tag.yml) and v2.20.0 (cut by
+auto-tag.yml), because main and nightly-dev pointed at the same commit and both
+workflow_run triggers fired on it. `git describe` breaks a same-commit tie by ref
+iteration order, which is lexicographic, so v2.19.15 wins and setuptools-scm
+reports 2.19.15. The releases API reports 2.20.0. Every start offered an upgrade;
+accepting it re-fetched the same two tags, landed on the same commit, regenerated
+the same 2.19.15, and offered again on the next start. No number of upgrades
+could clear it, and it affected every user who upgraded to that release.
+
+The tests here run real git so the version really comes from a real describe.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.test_upgrade_real_git import _git, _init
+
+
+def _release_response(tag):
+    """A stand-in for the GitHub releases-latest payload."""
+    resp = MagicMock()
+    resp.json.return_value = {"tag_name": tag}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+@pytest.fixture
+def hc_module():
+    import importlib
+    import os
+
+    os.environ["HATE_CRACK_SKIP_INIT"] = "1"
+    return importlib.import_module("hate_crack.main")
+
+
+@pytest.fixture
+def double_tagged_remote_and_clone(tmp_path):
+    """A remote whose released commit carries two tags from two version series.
+
+    Returns (remote, clone, describe_version, release_tag). The clone sits on
+    main at the released commit, exactly as a user who just upgraded would.
+    """
+    remote = _init(tmp_path / "remote")
+    (remote / "app.py").write_text("print('2.19.14')\n")
+    _git("add", "-A", cwd=remote)
+    _git("commit", "-qm", "previous release", cwd=remote)
+    _git("tag", "v2.19.14", cwd=remote)
+
+    (remote / "app.py").write_text("print('2.20.0')\n")
+    _git("add", "-A", cwd=remote)
+    _git("commit", "-qm", "docs(changelog): cut the [Unreleased] section", cwd=remote)
+    # The collision: nightly-tag.yml cut the patch, auto-tag.yml cut the minor,
+    # both on this one commit.
+    _git("tag", "v2.19.15", cwd=remote)
+    _git("tag", "v2.20.0", cwd=remote)
+
+    clone = tmp_path / "clone"
+    _git("clone", "-q", str(remote), str(clone), cwd=tmp_path)
+
+    described = _git(
+        "describe", "--tags", "--long", "--match", "*[0-9]*", cwd=clone
+    ).stdout.strip()
+    return remote, clone, described, "v2.20.0"
+
+
+def test_describe_picks_the_lower_tag_when_a_commit_carries_two(
+    double_tagged_remote_and_clone,
+):
+    """The precondition, in real git: the version can never reach the release.
+
+    setuptools-scm derives the version from this exact command, so whatever it
+    resolves to is what __version__ becomes. Asserted so that a future git
+    changing its tie-break is a visible failure here rather than a silent
+    behaviour change in the update check.
+    """
+    _remote, clone, described, _release_tag = double_tagged_remote_and_clone
+    assert described.startswith("v2.19.15-0-"), (
+        f"expected describe to resolve to the lower co-located tag, got {described}"
+    )
+    # Both tags really are on HEAD -- the fixture is not just missing v2.20.0.
+    points_at = set(_git("tag", "--points-at", "HEAD", cwd=clone).stdout.split())
+    assert points_at == {"v2.19.15", "v2.20.0"}
+
+
+def test_no_offer_when_head_already_carries_the_latest_release_tag(
+    hc_module, double_tagged_remote_and_clone, capsys
+):
+    """The regression: being AT the release means up to date, whatever describe says.
+
+    This is the loop. The version string is genuinely lower than the release, so
+    a pure version comparison offers an upgrade that cannot possibly change
+    anything, forever.
+    """
+    _remote, clone, _described, release_tag = double_tagged_remote_and_clone
+
+    with (
+        patch.object(hc_module, "_repo_root", str(clone)),
+        patch("hate_crack.__version__", "2.19.15"),
+        patch.object(hc_module, "REQUESTS_AVAILABLE", True),
+        patch.object(
+            hc_module.requests, "get", return_value=_release_response(release_tag)
+        ),
+        patch("builtins.input", side_effect=AssertionError("must not prompt")),
+    ):
+        hc_module.check_for_updates()
+
+    out = capsys.readouterr().out
+    assert "Update available" not in out, (
+        "offered an upgrade while already sitting on the release tag: " + out
+    )
+
+
+def test_offer_still_fires_when_the_release_tag_is_not_at_head(
+    hc_module, double_tagged_remote_and_clone, capsys
+):
+    """The guard must not swallow real updates -- the case that matters most.
+
+    Same repository, but the clone is parked one commit back, so there genuinely
+    is something to upgrade to.
+    """
+    _remote, clone, _described, release_tag = double_tagged_remote_and_clone
+    _git("checkout", "-q", "v2.19.14", cwd=clone)
+
+    with (
+        patch.object(hc_module, "_repo_root", str(clone)),
+        patch("hate_crack.__version__", "2.19.14"),
+        patch.object(hc_module, "REQUESTS_AVAILABLE", True),
+        patch.object(
+            hc_module.requests, "get", return_value=_release_response(release_tag)
+        ),
+        patch("builtins.input", return_value="n"),
+    ):
+        hc_module.check_for_updates()
+
+    assert "Update available: 2.20.0" in capsys.readouterr().out
+
+
+def test_offer_still_fires_when_there_is_no_git_repo(hc_module, tmp_path, capsys):
+    """A non-checkout install has no HEAD to compare, so fall back to versions.
+
+    Without this, making the tag check authoritative would silence the update
+    notice entirely for anyone running from an unpacked tarball.
+    """
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+
+    with (
+        patch.object(hc_module, "_repo_root", str(plain)),
+        patch("hate_crack.__version__", "2.19.14"),
+        patch.object(hc_module, "REQUESTS_AVAILABLE", True),
+        patch.object(
+            hc_module.requests, "get", return_value=_release_response("v2.20.0")
+        ),
+        patch("builtins.input", return_value="n"),
+    ):
+        hc_module.check_for_updates()
+
+    assert "Update available: 2.20.0" in capsys.readouterr().out
+
+
+def test_upgrade_is_a_fixed_point(hc_module, double_tagged_remote_and_clone, capsys):
+    """End to end: upgrade for real, then prove the next start stays quiet.
+
+    The two halves of the loop are only visible together. Each half looks correct
+    in isolation -- _run_upgrade does land on origin's tip, and check_for_updates
+    does compare versions correctly -- but composed they never terminate.
+    """
+    _remote, clone, _described, release_tag = double_tagged_remote_and_clone
+    # Park the clone one commit back so the upgrade has real work to do.
+    _git("checkout", "-q", "-B", "main", "v2.19.14", cwd=clone)
+
+    real_run = subprocess.run
+
+    def stub_install(cmd, *args, **kwargs):
+        if kwargs.get("shell"):
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return real_run(cmd, *args, **kwargs)
+
+    with (
+        patch.object(hc_module, "_repo_root", str(clone)),
+        patch("subprocess.run", side_effect=stub_install),
+        pytest.raises(SystemExit) as exc,
+    ):
+        hc_module._run_upgrade()
+    assert exc.value.code == 0, capsys.readouterr().out
+
+    # The upgrade landed on the released commit, and the release tag is here.
+    assert (
+        _git("rev-parse", "HEAD", cwd=clone).stdout.strip()
+        == _git("rev-parse", "main", cwd=_remote).stdout.strip()
+    )
+    assert release_tag in _git("tag", "--points-at", "HEAD", cwd=clone).stdout.split()
+
+    # setuptools-scm would still regenerate the LOWER version from this tree, so
+    # the restarted process is back where it started as far as versions go.
+    regenerated = _git(
+        "describe", "--tags", "--long", "--match", "*[0-9]*", cwd=clone
+    ).stdout.strip()
+    assert regenerated.startswith("v2.19.15-0-")
+
+    capsys.readouterr()
+    with (
+        patch.object(hc_module, "_repo_root", str(clone)),
+        patch("hate_crack.__version__", "2.19.15"),
+        patch.object(hc_module, "REQUESTS_AVAILABLE", True),
+        patch.object(
+            hc_module.requests, "get", return_value=_release_response(release_tag)
+        ),
+        patch("builtins.input", side_effect=AssertionError("must not prompt again")),
+    ):
+        hc_module.check_for_updates()
+
+    out = capsys.readouterr().out
+    assert "Update available" not in out, (
+        "upgrade did not converge -- the restarted process offers it again: " + out
+    )
+
+
+def test_tag_name_from_the_api_is_never_shell_interpreted(
+    hc_module, double_tagged_remote_and_clone, capsys
+):
+    """The tag name is remote input and now reaches git, so pin that it is safe.
+
+    A hostile or merely malformed tag_name must not run a command or crash the
+    check; the worst it may do is fail to match and fall through to the version
+    comparison.
+    """
+    _remote, clone, _described, _release_tag = double_tagged_remote_and_clone
+    canary = clone / "pwned"
+
+    with (
+        patch.object(hc_module, "_repo_root", str(clone)),
+        patch("hate_crack.__version__", "2.19.15"),
+        patch.object(hc_module, "REQUESTS_AVAILABLE", True),
+        patch.object(
+            hc_module.requests,
+            "get",
+            return_value=_release_response("v2.20.0; touch pwned"),
+        ),
+        patch("builtins.input", return_value="n"),
+    ):
+        hc_module.check_for_updates()
+
+    assert not canary.exists(), "tag name from the API reached a shell"

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -38,8 +38,25 @@ def upgrade_procs(current_branch="main", dirty=False, final_returncode=0):
     return procs
 
 
-# Index of the shell chain within upgrade_procs()' clean sequence.
-FINAL_CALL = 6
+def head_check_procs(at_release_tag=False):
+    """The git calls check_for_updates() makes before it decides to offer.
+
+    _head_is_at_release_tag() asks `rev-parse HEAD` and `rev-parse
+    refs/tags/<tag>^{commit}` so that sitting on the released commit counts as up
+    to date even when `git describe` resolves the version to a lower tag that
+    shares the commit. Any test driving the upgrade *through* check_for_updates
+    has to supply these first; tests calling _run_upgrade() directly do not.
+
+    Defaults to the tag being absent locally, which is what makes the offer fire.
+    """
+    if at_release_tag:
+        return [_proc(stdout="cafe1234\n"), _proc(stdout="cafe1234\n")]
+    return [_proc(stdout="cafe1234\n"), _proc(1)]
+
+
+# The shell chain is always the last call of upgrade_procs()' clean sequence.
+# Indexed from the end so prepending the head check above does not shift it.
+FINAL_CALL = -1
 
 
 @pytest.fixture
@@ -173,12 +190,41 @@ class TestCheckForUpdates:
             patch.object(hc_module, "requests") as mock_requests,
             patch.object(hc_module, "REQUESTS_AVAILABLE", True),
             patch("builtins.input", return_value="n"),
-            patch("subprocess.run") as mock_run,
+            patch("subprocess.run", side_effect=head_check_procs()) as mock_run,
         ):
             mock_requests.get.return_value = mock_resp
             hc_module.check_for_updates()
 
-        mock_run.assert_not_called()
+        # check_for_updates consults git to decide whether to offer at all, so
+        # "nothing ran" is no longer the right assertion. What must not happen is
+        # the upgrade itself: no install chain, and nothing that moves the repo.
+        for call in mock_run.call_args_list:
+            assert not call[1].get("shell"), f"ran the install chain: {call}"
+            argv = call[0][0]
+            assert argv[:2] == ["git", "rev-parse"], f"unexpected command: {argv}"
+
+    def test_no_offer_when_head_is_the_release_commit(self, hc_module, capsys):
+        """A lower version string does not mean out of date.
+
+        The 2026-07-31 release tagged one commit v2.19.15 and v2.20.0; describe
+        picks the lower one, so the version can never catch up and the offer
+        repeated forever. tests/test_upgrade_convergence.py covers this against
+        real git; this pins the same behaviour at the unit level.
+        """
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"tag_name": "v99.0.0"}
+        mock_resp.raise_for_status = MagicMock()
+
+        with (
+            patch.object(hc_module, "requests") as mock_requests,
+            patch.object(hc_module, "REQUESTS_AVAILABLE", True),
+            patch("subprocess.run", side_effect=head_check_procs(at_release_tag=True)),
+            patch("builtins.input", side_effect=AssertionError("must not prompt")),
+        ):
+            mock_requests.get.return_value = mock_resp
+            hc_module.check_for_updates()
+
+        assert "Update available" not in capsys.readouterr().out
 
     def test_upgrade_accepted_runs_make_and_exits(self, hc_module, capsys):
         mock_resp = MagicMock()
@@ -189,13 +235,16 @@ class TestCheckForUpdates:
             patch.object(hc_module, "requests") as mock_requests,
             patch.object(hc_module, "REQUESTS_AVAILABLE", True),
             patch("builtins.input", return_value="y"),
-            patch("subprocess.run", side_effect=upgrade_procs()) as mock_run,
+            patch(
+                "subprocess.run",
+                side_effect=head_check_procs() + upgrade_procs(),
+            ) as mock_run,
             pytest.raises(SystemExit),
         ):
             mock_requests.get.return_value = mock_resp
             hc_module.check_for_updates()
 
-        assert mock_run.call_count == 7
+        assert mock_run.call_count == 9
         make_cmd = mock_run.call_args_list[FINAL_CALL][0][0]
         assert "make install" in make_cmd
         # A pull would abort on a rewritten-history clone; the checkout already
@@ -214,7 +263,10 @@ class TestCheckForUpdates:
             patch.object(hc_module, "requests") as mock_requests,
             patch.object(hc_module, "REQUESTS_AVAILABLE", True),
             patch("builtins.input", return_value="y"),
-            patch("subprocess.run", side_effect=upgrade_procs(final_returncode=1)),
+            patch(
+                "subprocess.run",
+                side_effect=head_check_procs() + upgrade_procs(final_returncode=1),
+            ),
             patch("shutil.which", return_value="/usr/local/bin/uv"),
             patch("os.path.isfile", return_value=True),
             pytest.raises(SystemExit),
@@ -362,12 +414,16 @@ class TestRunUpgrade:
             patch.object(hc_module, "requests") as mock_requests,
             patch.object(hc_module, "REQUESTS_AVAILABLE", True),
             patch("builtins.input", side_effect=KeyboardInterrupt),
-            patch("subprocess.run") as mock_run,
+            patch("subprocess.run", side_effect=head_check_procs()) as mock_run,
         ):
             mock_requests.get.return_value = mock_resp
             hc_module.check_for_updates()
 
-        mock_run.assert_not_called()
+        # Only the read-only head check may have run -- Ctrl-C at the prompt must
+        # not start an upgrade. See head_check_procs().
+        for call in mock_run.call_args_list:
+            assert not call[1].get("shell"), f"ran the install chain: {call}"
+            assert call[0][0][:2] == ["git", "rev-parse"], f"unexpected: {call}"
 
     # ------------------------------------------------------------------
     # Branch-switch behavior: when the user runs the upgrade from a


### PR DESCRIPTION
## The bug

Every user who upgraded to 2.20.0 fell into an upgrade loop that no number of upgrades could clear.

Commit `e37d568` carries two release tags, `v2.19.15` and `v2.20.0`, and both are on origin — `nightly-dev` and `main` pointed at the same commit, so both tag workflows fired on it. `git describe` breaks a same-commit tie by ref iteration order, which is lexicographic, so the **lower** tag wins:

```
$ git describe --dirty --tags --long --match '*[0-9]*'
v2.19.15-0-ge37d568
```

setuptools-scm therefore reports `2.19.15` while the releases API reports `2.20.0`, so `check_for_updates()` offers an upgrade. Accepting it runs `_run_upgrade()`, which fetches, checks out `origin/main` (already there), reinstalls, and forces a version regeneration — which re-runs the same `describe`, gets `2.19.15` again, and offers again on the next start. The `--tags --force` fetch even restores the stale `v2.19.15` tag on machines that didn't have it.

Nightly users are affected too: `origin/nightly-dev` and `origin/main` are currently the same commit, and because the startup check calls `_run_upgrade()` with the default `branch="main"`, accepting the prompt also moves them onto the release channel.

## The fix

The version comparison cannot decide "am I up to date" when one commit can carry more than one release tag. Being on the commit the release points at is the authoritative answer, so `_head_is_at_release_tag()` checks that first and it wins. Any failure to establish it — no checkout, no such tag locally, no git at all — returns False and leaves the version comparison in charge, so installs that are not git clones keep their update notice.

The tag name comes from the releases API, so it is remote input; it is shape-checked and only ever passed to `git rev-parse` as an argv element, never through a shell.

## Tests

`tests/test_upgrade_convergence.py` runs real git against a fixture remote whose released commit carries two tags, so the version genuinely comes from a real `describe`. It pins the tie-break itself, the no-offer case, both must-still-offer cases (release tag not at HEAD, and no git repo at all), and the end-to-end fixed point — upgrade for real, then prove a restart stays quiet.

The gap this fell through is worth naming: `test_version_check.py` and `test_upgrade_real_git.py` both cover upgrade **mechanics** — which commands get built, whether HEAD moves, whether a rewritten clone recovers. Neither covered **convergence**. Both halves of this bug are individually correct — `_run_upgrade` really does land on origin's tip, and `check_for_updates` really does compare versions correctly — and only fail when composed, so mechanics-only tests could not have caught it.

Four existing tests asserted `subprocess.run.assert_not_called()` as a proxy for "no install ran". Now that the check consults git before deciding whether to offer, they assert the narrower thing they meant: no install chain, and nothing that moves the repo.

## Scope

This fixes the client half only. The pipeline can still produce a commit with two release tags; #221's rewrite of both tag workflows already addresses that, both by returning "nothing to tag" when HEAD is at the latest release and by putting the release on main's merge commit. I've left details of the collision in a comment there rather than touching those files here.

Full suite green: 2056 passed, against a 2049 baseline on `main`. `make ty` reports the same 48 pre-existing diagnostics as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
