### PR TITLE
feat(config): repair a migration a schema change stranded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+### Added
+- **Startup now offers to finish a migration that a later schema change
+  stranded.** `write_env_from_legacy()` only runs when there is no `.env` yet --
+  once both files exist, the bootstrap has nothing more to do. So a key that
+  becomes env-homed *after* a user's `.env` was written stays in their
+  `config.json`, where the loader ignores it and warns about it on every single
+  start, and nothing finishes the move except hand-editing JSON. `OLLAMA_HOST`
+  did exactly that. On a real install this meant twelve ignored keys, including
+  `hashview_api_key` and the whole `ollama*` group, silently inert.
+
+  `finish_stale_migration()` turns those warnings into an answerable question:
+  it lists the stranded key names, and on `y` copies their values into the
+  `.env` and prunes them from `config.json`, backing the original up first. A
+  key already set in the `.env` keeps that value -- the `.env` is the live
+  source, and copying the stale copy over it would silently revert a setting in
+  use -- but is still pruned, since it was being ignored. A wrongly-typed value
+  is neither copied nor pruned, matching the first-stage migration: it is the
+  only record of what the user meant. Prompts and notes name keys only, never
+  values, since several are secrets.
+
+  It stays silent unless `SKIP_INIT` is off, both config paths resolved, and
+  stdin is a tty, so piped and scheduled runs cannot block on a prompt they
+  cannot answer. Declining is completely inert.
+
 ### Fixed
 - **The update check no longer loops forever when one commit carries two release
   tags.** The 2.20.0 release left commit `e37d568` tagged both `v2.19.15` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,30 +10,41 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 ## [Unreleased]
 
 ### Added
-- **Startup now offers to finish a migration that a later schema change
-  stranded.** `write_env_from_legacy()` only runs when there is no `.env` yet --
-  once both files exist, the bootstrap has nothing more to do. So a key that
-  becomes env-homed *after* a user's `.env` was written stays in their
-  `config.json`, where the loader ignores it and warns about it on every single
-  start, and nothing finishes the move except hand-editing JSON. `OLLAMA_HOST`
-  did exactly that. On a real install this meant twelve ignored keys, including
+- **Startup now finishes a migration that a later schema change stranded.**
+  `write_env_from_legacy()` only runs when there is no `.env` yet -- once both
+  files exist, the bootstrap has nothing more to do. So a key that becomes
+  env-homed *after* a user's `.env` was written stays in their `config.json`,
+  where the loader ignores it and warns about it on every single start, and
+  nothing finishes the move except hand-editing JSON. `OLLAMA_HOST` did exactly
+  that. On a real install this meant twelve ignored keys, including
   `hashview_api_key` and the whole `ollama*` group, silently inert.
 
-  `finish_stale_migration()` turns those warnings into an answerable question:
-  it lists the stranded key names, and on `y` copies their values into the
-  `.env` and prunes them from `config.json`, backing the original up first. A
-  key already set in the `.env` keeps that value -- the `.env` is the live
+  `finish_stale_migration()` now copies those values into the `.env` and prunes
+  them from `config.json`, backing the original up first. It does so without
+  asking, matching `write_env_from_legacy()`, which also rewrites `config.json`
+  unprompted: a stranded key is already being ignored, so leaving it preserves
+  nothing but the warning -- and the warning *was* the prompt. Running
+  unprompted also means scheduled and piped runs get repaired, which is exactly
+  where a prompt would hang or be dismissed forever.
+
+  A key already set in the `.env` keeps that value -- the `.env` is the live
   source, and copying the stale copy over it would silently revert a setting in
   use -- but is still pruned, since it was being ignored. A wrongly-typed value
   is neither copied nor pruned, matching the first-stage migration: it is the
-  only record of what the user meant. Prompts and notes name keys only, never
-  values, since several are secrets.
-
-  It stays silent unless `SKIP_INIT` is off, both config paths resolved, and
-  stdin is a tty, so piped and scheduled runs cannot block on a prompt they
-  cannot answer. Declining is completely inert.
+  only record of what the user meant. Notes name keys only, never values, since
+  several are secrets. Skipped entirely under `SKIP_INIT`, and any failure is
+  reported and swallowed rather than stopping startup.
 
 ### Fixed
+- **A second migration no longer overwrites the first one's backup.** The prune
+  step wrote to a fixed `<config.json>.pre-split.bak`, which was safe while it
+  ran once per install at `.env` creation. Now that `finish_stale_migration()`
+  can run again -- any time a further key becomes env-homed -- a plain copy onto
+  that path silently replaced the only copy of the genuinely pre-split
+  `config.json`. Observed for real: a repair clobbered a `.pre-split.bak` written
+  weeks earlier. Backups now fall back to `.pre-split.bak.2`, `.3` and so on, so
+  a used name is never reused.
+
 - **The update check no longer loops forever when one commit carries two release
   tags.** The 2.20.0 release left commit `e37d568` tagged both `v2.19.15` and
   `v2.20.0`, because `nightly-dev` and `main` pointed at the same commit and both

--- a/hate_crack/config_writer.py
+++ b/hate_crack/config_writer.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from hate_crack.config_schema import (
@@ -394,7 +394,7 @@ def _prune_migrated_keys(legacy_json_path: str, migrated: Sequence[str]) -> str:
     with open(legacy_json_path) as fh:
         data = json.load(fh)
 
-    backup_path = f"{legacy_json_path}.pre-split.bak"
+    backup_path = _free_backup_path(legacy_json_path)
     shutil.copy2(legacy_json_path, backup_path)
 
     drop = set(migrated)
@@ -418,13 +418,8 @@ def _prune_migrated_keys(legacy_json_path: str, migrated: Sequence[str]) -> str:
     return backup_path
 
 
-def finish_stale_migration(
-    legacy_json_path: str,
-    env_path: str,
-    *,
-    confirm: Callable[[list[str]], bool],
-) -> list[str]:
-    """Offer to finish a migration that a later schema change stranded.
+def finish_stale_migration(legacy_json_path: str, env_path: str) -> list[str]:
+    """Finish a migration that a later schema change stranded.
 
     :func:`write_env_from_legacy` only runs when there is no `.env` yet -- once
     both files exist, startup has nothing more to do. So a key that becomes
@@ -433,11 +428,13 @@ def finish_stale_migration(
     single start, and nothing finishes the move except hand-editing JSON.
     ``OLLAMA_HOST`` did exactly that. This is the way out.
 
-    ``confirm`` is called with the sorted legacy key names, and only when there
-    is something to clean up -- prompting when the answer cannot matter is how a
-    prompt gets trained into reflexive dismissal. It is injected rather than
-    read here so the decision (tty? non-interactive run? ``--yes``?) belongs to
-    the caller, and so tests need not patch :func:`input`.
+    Repairs without asking, which is deliberate and matches
+    :func:`write_env_from_legacy`: the first-stage migration also copies keys out
+    and rewrites ``config.json`` unprompted. A key stranded here is *already*
+    being ignored, so leaving it in place preserves nothing except the warning,
+    and a prompt on every start is what the warning already was. The original
+    ``config.json`` is copied to ``<config.json>.pre-split.bak`` first, and the
+    notes returned say exactly which keys moved.
 
     Two rules differ from the first-stage migration, both because a `.env`
     already exists:
@@ -468,14 +465,6 @@ def finish_stale_migration(
         return []
 
     notes: list[str] = []
-    if not confirm(stale):
-        notes.append(
-            f"Left {len(stale)} setting(s) in {legacy_json_path}: "
-            f"{', '.join(stale)}. They stay ignored until they move to "
-            f"{env_path}."
-        )
-        return notes
-
     existing = _read_env_names(env_path)
     to_add: dict[str, Any] = {}
     prune: list[str] = []
@@ -524,6 +513,38 @@ def finish_stale_migration(
         f"{legacy_json_path}. The original is saved as {backup_path}."
     )
     return notes
+
+
+def _free_backup_path(legacy_json_path: str) -> str:
+    """A backup path for ``legacy_json_path`` that does not already exist.
+
+    ``<config.json>.pre-split.bak`` when that name is free, then
+    ``.pre-split.bak.2``, ``.3`` and so on.
+
+    The fixed name was safe while this ran exactly once per install, at `.env`
+    creation. :func:`finish_stale_migration` can run again -- any time a further
+    key becomes ``home="env"`` -- and a plain ``copy2`` onto the same path would
+    silently replace the first migration's backup, which is the only copy of the
+    user's genuinely pre-split ``config.json``. Overwriting the safety net during
+    the operation it exists to protect is not acceptable, so a used name is never
+    reused. Observed for real: a second-stage repair clobbered a
+    ``.pre-split.bak`` written weeks earlier.
+
+    Bounded rather than looping forever: something is wrong if an install has
+    accumulated a hundred of these, and silently spinning would be worse than
+    failing the backup and leaving ``config.json`` alone.
+    """
+    base = f"{legacy_json_path}.pre-split.bak"
+    if not os.path.exists(base):
+        return base
+    for suffix in range(2, 100):
+        candidate = f"{base}.{suffix}"
+        if not os.path.exists(candidate):
+            return candidate
+    raise OSError(
+        f"refusing to overwrite a backup: {base} and .2-.99 all exist; "
+        "remove some by hand"
+    )
 
 
 def _read_env_names(env_path: str) -> set[str]:

--- a/hate_crack/config_writer.py
+++ b/hate_crack/config_writer.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from hate_crack.config_schema import (
@@ -416,6 +416,168 @@ def _prune_migrated_keys(legacy_json_path: str, migrated: Sequence[str]) -> str:
         raise
 
     return backup_path
+
+
+def finish_stale_migration(
+    legacy_json_path: str,
+    env_path: str,
+    *,
+    confirm: Callable[[list[str]], bool],
+) -> list[str]:
+    """Offer to finish a migration that a later schema change stranded.
+
+    :func:`write_env_from_legacy` only runs when there is no `.env` yet -- once
+    both files exist, startup has nothing more to do. So a key that becomes
+    ``home="env"`` *after* a user's `.env` was written stays in their
+    ``config.json``, where the loader ignores it and warns about it on every
+    single start, and nothing finishes the move except hand-editing JSON.
+    ``OLLAMA_HOST`` did exactly that. This is the way out.
+
+    ``confirm`` is called with the sorted legacy key names, and only when there
+    is something to clean up -- prompting when the answer cannot matter is how a
+    prompt gets trained into reflexive dismissal. It is injected rather than
+    read here so the decision (tty? non-interactive run? ``--yes``?) belongs to
+    the caller, and so tests need not patch :func:`input`.
+
+    Two rules differ from the first-stage migration, both because a `.env`
+    already exists:
+
+    * A key already present in the `.env` is **not** overwritten. That file is
+      the live source; copying the stale ``config.json`` value over it would
+      silently revert a setting the user is actively using, which is the exact
+      cross-file precedence the split removed. It is still pruned from
+      ``config.json``, where it was being ignored anyway.
+    * A wrongly-typed value is neither copied nor pruned, matching
+      :func:`write_env_from_legacy`: it is the only remaining record of what the
+      user meant to set.
+
+    Notes and the ``confirm`` payload name keys only, never values -- several of
+    these keys are secrets.
+    """
+    with open(legacy_json_path) as fh:
+        legacy_data = json.load(fh)
+    if not isinstance(legacy_data, dict):
+        return []
+
+    stale = sorted(
+        key
+        for key in legacy_data
+        if (entry := BY_LEGACY.get(key)) is not None and entry.home == "env"
+    )
+    if not stale:
+        return []
+
+    notes: list[str] = []
+    if not confirm(stale):
+        notes.append(
+            f"Left {len(stale)} setting(s) in {legacy_json_path}: "
+            f"{', '.join(stale)}. They stay ignored until they move to "
+            f"{env_path}."
+        )
+        return notes
+
+    existing = _read_env_names(env_path)
+    to_add: dict[str, Any] = {}
+    prune: list[str] = []
+    already: list[str] = []
+
+    for key in stale:
+        entry = BY_LEGACY[key]
+        value = legacy_data[key]
+        if isinstance(value, bool) != isinstance(entry.default, bool) or not isinstance(
+            value, type(entry.default)
+        ):
+            notes.append(
+                f"{legacy_json_path}: key {key!r} has an unexpected type; left it "
+                "in place rather than guessing, so nothing was lost."
+            )
+            continue
+        if entry.env in existing:
+            already.append(key)
+        else:
+            to_add[entry.env] = value
+        prune.append(key)
+
+    if not prune:
+        return notes
+
+    if to_add:
+        _append_env_values(env_path, to_add)
+    if already:
+        notes.append(
+            f"{', '.join(already)}: already set in {env_path}, so that value was "
+            "kept and the config.json copy discarded."
+        )
+
+    try:
+        backup_path = _prune_migrated_keys(legacy_json_path, prune)
+    except OSError as exc:
+        notes.append(
+            f"Could not rewrite {legacy_json_path} to drop the copied keys "
+            f"({exc}); they are now read from {env_path} only, so delete them by "
+            "hand to stop the warnings."
+        )
+        return notes
+
+    notes.append(
+        f"Moved {', '.join(prune)} into {env_path} and removed them from "
+        f"{legacy_json_path}. The original is saved as {backup_path}."
+    )
+    return notes
+
+
+def _read_env_names(env_path: str) -> set[str]:
+    """Names assigned in ``env_path``, or an empty set if it is unreadable.
+
+    Only names are needed, so this does not coerce or validate anything: the
+    question is strictly "would writing this key overwrite something".
+    """
+    names: set[str] = set()
+    try:
+        with open(env_path) as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                names.add(line.split("=", 1)[0].strip())
+    except OSError:
+        return set()
+    return names
+
+
+def _append_env_values(env_path: str, values: Mapping[str, Any]) -> None:
+    """Append ``values`` to an existing `.env`, preserving what is there.
+
+    Deliberately not :func:`write_env`, which renders a *complete* file from a
+    config mapping: rewriting the whole thing here would drop any comment the
+    user added and reorder their file. Appending keeps the diff to the lines
+    actually being added. Written through a temp file so a failure part-way
+    cannot leave a half-line behind in the file holding their API keys, and the
+    existing mode is carried over rather than assumed.
+    """
+    with open(env_path) as fh:
+        current = fh.read()
+    if current and not current.endswith("\n"):
+        current += "\n"
+
+    additions = "".join(
+        f"{render_line(BY_ENV_NAME[name], value)}\n" for name, value in values.items()
+    )
+
+    directory = os.path.dirname(os.path.abspath(env_path)) or "."
+    tmp_path = os.path.join(directory, f".env-{os.urandom(8).hex()}.tmp")
+    fd = os.open(tmp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, mode=0o600)
+    try:
+        with os.fdopen(fd, "w") as tmp:
+            tmp.write(current + additions)
+        shutil.copymode(env_path, tmp_path)
+        os.replace(tmp_path, env_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _regenerate_env_example() -> str:

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -564,6 +564,65 @@ def _initialize_env(legacy_json_path):
     return destination
 
 
+def _offer_stale_migration_cleanup(env_path, legacy_json_path):
+    """Offer to finish a migration stranded by a later schema change.
+
+    The loader has just warned, once per key, that some ``config.json`` entries
+    are ignored because they belong in the `.env`. Those warnings are all a user
+    could act on before, and acting meant hand-editing JSON -- so in practice
+    they printed on every start forever. This turns them into a question that
+    can actually be answered.
+
+    Deliberately silent unless *all* of these hold:
+
+    * Not ``SKIP_INIT`` -- the test suite imports this module constantly and must
+      never be asked anything, nor rewrite config as an import side effect.
+    * Both paths resolved -- with either file missing, the bootstrap above owns
+      the situation and has already done the right thing.
+    * stdin is a tty -- a piped or scheduled run (`--hashview`, cron, the e2e
+      suite) must not block on a prompt it cannot answer. Those runs keep seeing
+      the loader warnings, which is the status quo, not a regression.
+
+    Any failure here is reported and swallowed: a config-tidying offer must
+    never be the reason hate_crack fails to start.
+    """
+    if SKIP_INIT or not env_path or not legacy_json_path:
+        return
+    try:
+        if not sys.stdin.isatty():
+            return
+    except (AttributeError, ValueError):
+        return
+
+    def confirm(keys):
+        print(
+            f"\n[!] {len(keys)} setting(s) in {legacy_json_path} are ignored "
+            "because they belong in the .env file:"
+        )
+        for key in keys:
+            print(f"      {key}")
+        print(
+            "    They can be moved for you. Values already set in the .env are "
+            "kept, and\n    the original config.json is backed up first."
+        )
+        try:
+            answer = input("    Move them now? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return False
+        return answer in ("y", "yes")
+
+    try:
+        notes = _config_writer.finish_stale_migration(
+            legacy_json_path, env_path, confirm=confirm
+        )
+    except Exception as exc:
+        print(f"[!] Could not tidy {legacy_json_path}: {exc}")
+        return
+    for note in notes:
+        print(f"[!] {note}")
+
+
 def _describe_config_source(path, created, detail=None):
     """One right-hand side for :func:`_print_config_sources`."""
     if path is None:
@@ -647,6 +706,8 @@ _config_result = _config_loader.load_config_or_exit(
 config_parser = _config_result.config
 for _warning in _config_result.warnings:
     print(f"[!] {_warning}")
+
+_offer_stale_migration_cleanup(_env_path, _legacy_json_path)
 
 # The real environment already outranks both config files inside the loader
 # (that is what

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -564,58 +564,34 @@ def _initialize_env(legacy_json_path):
     return destination
 
 
-def _offer_stale_migration_cleanup(env_path, legacy_json_path):
-    """Offer to finish a migration stranded by a later schema change.
+def _finish_stale_migration(env_path, legacy_json_path):
+    """Finish a migration stranded by a later schema change.
 
     The loader has just warned, once per key, that some ``config.json`` entries
-    are ignored because they belong in the `.env`. Those warnings are all a user
-    could act on before, and acting meant hand-editing JSON -- so in practice
-    they printed on every start forever. This turns them into a question that
-    can actually be answered.
+    are ignored because they belong in the `.env`. Acting on those warnings meant
+    hand-editing JSON, so in practice they printed on every start forever. This
+    does the move instead.
 
-    Deliberately silent unless *all* of these hold:
+    Unprompted, matching the first-stage migration in
+    :func:`hate_crack.config_writer.write_env_from_legacy`, which also rewrites
+    ``config.json`` without asking. There is nothing to weigh: the keys are
+    already being ignored, so leaving them preserves only the warning. It also
+    means scheduled and piped runs get repaired too -- gating this on a tty would
+    leave exactly the automated runs nobody is watching printing the warnings
+    forever.
 
-    * Not ``SKIP_INIT`` -- the test suite imports this module constantly and must
-      never be asked anything, nor rewrite config as an import side effect.
-    * Both paths resolved -- with either file missing, the bootstrap above owns
-      the situation and has already done the right thing.
-    * stdin is a tty -- a piped or scheduled run (`--hashview`, cron, the e2e
-      suite) must not block on a prompt it cannot answer. Those runs keep seeing
-      the loader warnings, which is the status quo, not a regression.
+    Skipped when ``SKIP_INIT`` is set -- the test suite imports this module
+    constantly and rewriting config as an import side effect is not acceptable --
+    or when either path is unresolved, in which case the bootstrap above owns the
+    situation and has already done the right thing.
 
-    Any failure here is reported and swallowed: a config-tidying offer must
-    never be the reason hate_crack fails to start.
+    Any failure is reported and swallowed: tidying config must never be the
+    reason hate_crack fails to start.
     """
     if SKIP_INIT or not env_path or not legacy_json_path:
         return
     try:
-        if not sys.stdin.isatty():
-            return
-    except (AttributeError, ValueError):
-        return
-
-    def confirm(keys):
-        print(
-            f"\n[!] {len(keys)} setting(s) in {legacy_json_path} are ignored "
-            "because they belong in the .env file:"
-        )
-        for key in keys:
-            print(f"      {key}")
-        print(
-            "    They can be moved for you. Values already set in the .env are "
-            "kept, and\n    the original config.json is backed up first."
-        )
-        try:
-            answer = input("    Move them now? [y/N] ").strip().lower()
-        except (EOFError, KeyboardInterrupt):
-            print()
-            return False
-        return answer in ("y", "yes")
-
-    try:
-        notes = _config_writer.finish_stale_migration(
-            legacy_json_path, env_path, confirm=confirm
-        )
+        notes = _config_writer.finish_stale_migration(legacy_json_path, env_path)
     except Exception as exc:
         print(f"[!] Could not tidy {legacy_json_path}: {exc}")
         return
@@ -707,7 +683,7 @@ config_parser = _config_result.config
 for _warning in _config_result.warnings:
     print(f"[!] {_warning}")
 
-_offer_stale_migration_cleanup(_env_path, _legacy_json_path)
+_finish_stale_migration(_env_path, _legacy_json_path)
 
 # The real environment already outranks both config files inside the loader
 # (that is what

--- a/tests/test_config_writer.py
+++ b/tests/test_config_writer.py
@@ -529,7 +529,7 @@ def test_migrated_pair_reproduces_the_pre_split_configuration(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# finish_stale_migration: the second-stage cleanup, offered not forced
+# finish_stale_migration: the second-stage cleanup, applied not offered
 # ---------------------------------------------------------------------------
 #
 # write_env_from_legacy only ever runs when there is no `.env` yet (see
@@ -551,36 +551,40 @@ def _stranded_setup(tmp_path, json_extra=None, env_lines=""):
     return legacy_path, env_path
 
 
-def test_stale_cleanup_does_not_prompt_when_there_is_nothing_stale(tmp_path):
-    """No stranded keys means no question. Asking anyway trains people to
-    dismiss the prompt, which is how the real one gets ignored."""
+def test_stale_cleanup_is_inert_when_there_is_nothing_stale(tmp_path):
+    """The common case by far: every start must leave both files alone and say
+    nothing, or this becomes a rewrite of the user's config on every launch."""
     legacy_path, env_path = _stranded_setup(tmp_path)
-    asked = []
-
-    notes = finish_stale_migration(
-        str(legacy_path),
-        str(env_path),
-        confirm=lambda keys: asked.append(keys) or True,
-    )
-
-    assert asked == [], "prompted with no stale keys present"
-    assert notes == []
-
-
-def test_stale_cleanup_declined_changes_nothing(tmp_path):
-    """Declining must be completely inert -- this rewrites the user's config."""
-    legacy_path, env_path = _stranded_setup(tmp_path, {"ollamaModel": "synthetic"})
     before_json = legacy_path.read_text()
     before_env = env_path.read_text()
 
-    notes = finish_stale_migration(
-        str(legacy_path), str(env_path), confirm=lambda keys: False
-    )
+    notes = finish_stale_migration(str(legacy_path), str(env_path))
 
+    assert notes == []
     assert legacy_path.read_text() == before_json
     assert env_path.read_text() == before_env
     assert not (tmp_path / "config.json.pre-split.bak").exists()
-    # The user still deserves to know the keys stay inert.
+
+
+def test_stale_cleanup_never_asks_anything(monkeypatch, tmp_path):
+    """Repairs unprompted, like write_env_from_legacy.
+
+    A stranded key is already ignored, so there is nothing to weigh, and the
+    warning it produces was itself the prompt. It also has to work on runs
+    nobody is watching -- cron, `--hashview`, a piped session -- which is
+    precisely where a prompt would hang or be skipped forever.
+    """
+    legacy_path, env_path = _stranded_setup(tmp_path, {"ollamaModel": "synthetic"})
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("finish_stale_migration must not prompt")
+
+    monkeypatch.setattr("builtins.input", explode)
+
+    notes = finish_stale_migration(str(legacy_path), str(env_path))
+
+    assert "ollamaModel" not in json.loads(legacy_path.read_text())
+    assert dotenv_values(str(env_path))["OLLAMA_MODEL"] == "synthetic"
     assert any("ollamaModel" in note for note in notes)
 
 
@@ -589,9 +593,7 @@ def test_stale_cleanup_moves_the_value_and_prunes_the_json(tmp_path):
         tmp_path, {"ollamaModel": "synthetic-model", "pipal_count": 3}
     )
 
-    notes = finish_stale_migration(
-        str(legacy_path), str(env_path), confirm=lambda keys: True
-    )
+    notes = finish_stale_migration(str(legacy_path), str(env_path))
 
     parsed = dotenv_values(str(env_path))
     assert coerce(BY_ENV["OLLAMA_MODEL"], parsed["OLLAMA_MODEL"]) == "synthetic-model"
@@ -617,9 +619,7 @@ def test_stale_cleanup_never_overwrites_a_value_already_in_the_env(tmp_path):
         env_lines="OLLAMA_MODEL=live-env-value\n",
     )
 
-    notes = finish_stale_migration(
-        str(legacy_path), str(env_path), confirm=lambda keys: True
-    )
+    notes = finish_stale_migration(str(legacy_path), str(env_path))
 
     parsed = dotenv_values(str(env_path))
     assert coerce(BY_ENV["OLLAMA_MODEL"], parsed["OLLAMA_MODEL"]) == "live-env-value"
@@ -633,9 +633,7 @@ def test_stale_cleanup_leaves_wrong_typed_values_alone(tmp_path):
     record of what the user meant, so it is neither copied nor deleted."""
     legacy_path, env_path = _stranded_setup(tmp_path, {"pipal_count": "not-an-int"})
 
-    notes = finish_stale_migration(
-        str(legacy_path), str(env_path), confirm=lambda keys: True
-    )
+    notes = finish_stale_migration(str(legacy_path), str(env_path))
 
     assert "pipal_count" in json.loads(legacy_path.read_text())
     assert "PIPAL_COUNT" not in dotenv_values(str(env_path))
@@ -643,8 +641,8 @@ def test_stale_cleanup_leaves_wrong_typed_values_alone(tmp_path):
     assert not any("not-an-int" in note for note in notes)
 
 
-def test_stale_cleanup_notes_and_prompt_never_expose_values(tmp_path):
-    """Several stranded keys are secrets; the prompt lists names only."""
+def test_stale_cleanup_notes_never_expose_values(tmp_path):
+    """Several stranded keys are secrets; the notes list names only."""
     legacy_path, env_path = _stranded_setup(
         tmp_path,
         {
@@ -652,33 +650,32 @@ def test_stale_cleanup_notes_and_prompt_never_expose_values(tmp_path):
             "hashmob_api_key": "another-synthetic-sentinel",
         },
     )
-    seen = []
+    notes = finish_stale_migration(str(legacy_path), str(env_path))
 
-    notes = finish_stale_migration(
-        str(legacy_path),
-        str(env_path),
-        confirm=lambda keys: seen.extend(keys) or True,
-    )
-
-    blob = "\n".join(notes) + "\n".join(seen)
+    blob = "\n".join(notes)
     assert "hashview_api_key" in blob and "hashmob_api_key" in blob
     assert "synthetic-sentinel-key" not in blob
     assert "another-synthetic-sentinel" not in blob
 
 
-def test_stale_cleanup_leaves_json_homed_and_unknown_keys_out_of_it(tmp_path):
+def test_stale_cleanup_leaves_json_homed_and_unknown_keys_alone(tmp_path):
     """A json-homed key is not stranded, and an unrecognized one is a note the
-    user is keeping. Offering to delete either would be wrong."""
+    user is keeping. Touching either would be wrong -- and this is the assertion
+    that stops a future widening of the stale-key query from eating the file."""
     legacy_path, env_path = _stranded_setup(tmp_path, {"ollamaModel": "synthetic"})
-    offered = []
 
-    finish_stale_migration(
-        str(legacy_path),
-        str(env_path),
-        confirm=lambda keys: offered.extend(keys) or True,
-    )
+    notes = finish_stale_migration(str(legacy_path), str(env_path))
 
-    assert offered == ["ollamaModel"]
+    remaining = json.loads(legacy_path.read_text())
+    assert remaining == {
+        "hcatBin": "hashcat-custom",
+        "some_retired_key": "note to self",
+    }
+    # Only the one stranded key is ever named.
+    joined = "\n".join(notes)
+    assert "ollamaModel" in joined
+    assert "hcatBin" not in joined
+    assert "some_retired_key" not in joined
 
 
 def test_stale_cleanup_result_loads_clean(tmp_path):
@@ -688,7 +685,7 @@ def test_stale_cleanup_result_loads_clean(tmp_path):
         tmp_path, {"ollamaModel": "synthetic-model", "ollamaNumCtx": 4096}
     )
 
-    finish_stale_migration(str(legacy_path), str(env_path), confirm=lambda keys: True)
+    finish_stale_migration(str(legacy_path), str(env_path))
 
     loaded = load_config(
         env_path=str(env_path), legacy_json_path=str(legacy_path), environ={}
@@ -696,3 +693,25 @@ def test_stale_cleanup_result_loads_clean(tmp_path):
     assert loaded.warnings == []
     assert loaded.config["ollamaModel"] == "synthetic-model"
     assert loaded.config["ollamaNumCtx"] == 4096
+
+
+def test_stale_cleanup_never_clobbers_an_earlier_backup(tmp_path):
+    """The second-stage repair can run more than once, and the fixed backup name
+    made a later run overwrite the first migration's copy -- the only record of
+    the genuinely pre-split config.json. Observed for real on an install whose
+    .pre-split.bak was weeks old.
+    """
+    legacy_path, env_path = _stranded_setup(tmp_path, {"ollamaModel": "first"})
+    original_backup = tmp_path / "config.json.pre-split.bak"
+    original_backup.write_text('{"the": "original pre-split config"}\n')
+
+    finish_stale_migration(str(legacy_path), str(env_path))
+
+    # The pre-existing backup is untouched...
+    assert json.loads(original_backup.read_text()) == {
+        "the": "original pre-split config"
+    }
+    # ...and this run's backup went somewhere else, holding the pre-run state.
+    second = tmp_path / "config.json.pre-split.bak.2"
+    assert second.exists(), "second-stage repair did not write its own backup"
+    assert "ollamaModel" in json.loads(second.read_text())

--- a/tests/test_config_writer.py
+++ b/tests/test_config_writer.py
@@ -26,6 +26,7 @@ from hate_crack.config_writer import (
     emit_value,
     render_env,
     write_env,
+    finish_stale_migration,
     write_env_from_legacy,
 )
 
@@ -525,3 +526,173 @@ def test_migrated_pair_reproduces_the_pre_split_configuration(tmp_path):
     assert after["pipalPath"] == os.path.expanduser("~/tools/pipal")
     assert after["hcatDebugLogPath"] == os.path.expanduser("~/custom/debug")
     assert after["ollamaAutoResearch"] is False
+
+
+# ---------------------------------------------------------------------------
+# finish_stale_migration: the second-stage cleanup, offered not forced
+# ---------------------------------------------------------------------------
+#
+# write_env_from_legacy only ever runs when there is no `.env` yet (see
+# _initialize_env in main.py: "Both present -> nothing to do"). So a key that
+# becomes env-homed *after* a user's `.env` was written is stranded in their
+# config.json forever: the loader ignores it and warns about it on every single
+# start, and nothing can finish the move except hand-editing JSON. OLLAMA_HOST
+# did exactly that. This is the path out of that state.
+
+
+def _stranded_setup(tmp_path, json_extra=None, env_lines=""):
+    """A user who already migrated, then had more keys become env-homed."""
+    legacy_path = tmp_path / "config.json"
+    data = {"hcatBin": "hashcat-custom", "some_retired_key": "note to self"}
+    data.update(json_extra or {})
+    legacy_path.write_text(json.dumps(data, indent=2) + "\n")
+    env_path = tmp_path / ".env"
+    env_path.write_text(env_lines)
+    return legacy_path, env_path
+
+
+def test_stale_cleanup_does_not_prompt_when_there_is_nothing_stale(tmp_path):
+    """No stranded keys means no question. Asking anyway trains people to
+    dismiss the prompt, which is how the real one gets ignored."""
+    legacy_path, env_path = _stranded_setup(tmp_path)
+    asked = []
+
+    notes = finish_stale_migration(
+        str(legacy_path),
+        str(env_path),
+        confirm=lambda keys: asked.append(keys) or True,
+    )
+
+    assert asked == [], "prompted with no stale keys present"
+    assert notes == []
+
+
+def test_stale_cleanup_declined_changes_nothing(tmp_path):
+    """Declining must be completely inert -- this rewrites the user's config."""
+    legacy_path, env_path = _stranded_setup(tmp_path, {"ollamaModel": "synthetic"})
+    before_json = legacy_path.read_text()
+    before_env = env_path.read_text()
+
+    notes = finish_stale_migration(
+        str(legacy_path), str(env_path), confirm=lambda keys: False
+    )
+
+    assert legacy_path.read_text() == before_json
+    assert env_path.read_text() == before_env
+    assert not (tmp_path / "config.json.pre-split.bak").exists()
+    # The user still deserves to know the keys stay inert.
+    assert any("ollamaModel" in note for note in notes)
+
+
+def test_stale_cleanup_moves_the_value_and_prunes_the_json(tmp_path):
+    legacy_path, env_path = _stranded_setup(
+        tmp_path, {"ollamaModel": "synthetic-model", "pipal_count": 3}
+    )
+
+    notes = finish_stale_migration(
+        str(legacy_path), str(env_path), confirm=lambda keys: True
+    )
+
+    parsed = dotenv_values(str(env_path))
+    assert coerce(BY_ENV["OLLAMA_MODEL"], parsed["OLLAMA_MODEL"]) == "synthetic-model"
+    assert coerce(BY_ENV["PIPAL_COUNT"], parsed["PIPAL_COUNT"]) == 3
+
+    remaining = json.loads(legacy_path.read_text())
+    assert "ollamaModel" not in remaining
+    assert "pipal_count" not in remaining
+    # Everything that is genuinely config.json's business survives untouched.
+    assert remaining["hcatBin"] == "hashcat-custom"
+    assert remaining["some_retired_key"] == "note to self"
+    assert (tmp_path / "config.json.pre-split.bak").exists()
+    assert any("ollamaModel" in note for note in notes)
+
+
+def test_stale_cleanup_never_overwrites_a_value_already_in_the_env(tmp_path):
+    """`.env` is the live source, so it wins. Copying the stale config.json
+    value over it would silently revert a setting the user is actively using --
+    the exact failure the split exists to prevent."""
+    legacy_path, env_path = _stranded_setup(
+        tmp_path,
+        {"ollamaModel": "stale-json-value"},
+        env_lines="OLLAMA_MODEL=live-env-value\n",
+    )
+
+    notes = finish_stale_migration(
+        str(legacy_path), str(env_path), confirm=lambda keys: True
+    )
+
+    parsed = dotenv_values(str(env_path))
+    assert coerce(BY_ENV["OLLAMA_MODEL"], parsed["OLLAMA_MODEL"]) == "live-env-value"
+    # But it is still removed from config.json, since it was being ignored there.
+    assert "ollamaModel" not in json.loads(legacy_path.read_text())
+    assert any("already set" in note for note in notes)
+
+
+def test_stale_cleanup_leaves_wrong_typed_values_alone(tmp_path):
+    """Matching write_env_from_legacy: a value we cannot carry is the only
+    record of what the user meant, so it is neither copied nor deleted."""
+    legacy_path, env_path = _stranded_setup(tmp_path, {"pipal_count": "not-an-int"})
+
+    notes = finish_stale_migration(
+        str(legacy_path), str(env_path), confirm=lambda keys: True
+    )
+
+    assert "pipal_count" in json.loads(legacy_path.read_text())
+    assert "PIPAL_COUNT" not in dotenv_values(str(env_path))
+    assert any("pipal_count" in note and "type" in note for note in notes)
+    assert not any("not-an-int" in note for note in notes)
+
+
+def test_stale_cleanup_notes_and_prompt_never_expose_values(tmp_path):
+    """Several stranded keys are secrets; the prompt lists names only."""
+    legacy_path, env_path = _stranded_setup(
+        tmp_path,
+        {
+            "hashview_api_key": "synthetic-sentinel-key",
+            "hashmob_api_key": "another-synthetic-sentinel",
+        },
+    )
+    seen = []
+
+    notes = finish_stale_migration(
+        str(legacy_path),
+        str(env_path),
+        confirm=lambda keys: seen.extend(keys) or True,
+    )
+
+    blob = "\n".join(notes) + "\n".join(seen)
+    assert "hashview_api_key" in blob and "hashmob_api_key" in blob
+    assert "synthetic-sentinel-key" not in blob
+    assert "another-synthetic-sentinel" not in blob
+
+
+def test_stale_cleanup_leaves_json_homed_and_unknown_keys_out_of_it(tmp_path):
+    """A json-homed key is not stranded, and an unrecognized one is a note the
+    user is keeping. Offering to delete either would be wrong."""
+    legacy_path, env_path = _stranded_setup(tmp_path, {"ollamaModel": "synthetic"})
+    offered = []
+
+    finish_stale_migration(
+        str(legacy_path),
+        str(env_path),
+        confirm=lambda keys: offered.extend(keys) or True,
+    )
+
+    assert offered == ["ollamaModel"]
+
+
+def test_stale_cleanup_result_loads_clean(tmp_path):
+    """The end state must produce no loader warnings at all -- that is the
+    entire point, since the warnings are what the user sees every start."""
+    legacy_path, env_path = _stranded_setup(
+        tmp_path, {"ollamaModel": "synthetic-model", "ollamaNumCtx": 4096}
+    )
+
+    finish_stale_migration(str(legacy_path), str(env_path), confirm=lambda keys: True)
+
+    loaded = load_config(
+        env_path=str(env_path), legacy_json_path=str(legacy_path), environ={}
+    )
+    assert loaded.warnings == []
+    assert loaded.config["ollamaModel"] == "synthetic-model"
+    assert loaded.config["ollamaNumCtx"] == 4096


### PR DESCRIPTION
## The gap

There *is* a migration — `write_env_from_legacy()` — and it does the right thing, including pruning what it copies. It just can never run twice: `_initialize_env()` is only reached when `env_path is None`, and its own docstring names the case, *"Both present -> nothing to do."*

So a key that becomes `home="env"` **after** a user's `.env` was written is stranded. It sits in `config.json`, where the loader ignores it and warns about it on every single start, and nothing finishes the move except hand-editing JSON. `OLLAMA_HOST` did exactly that.

On a real install this meant twelve ignored keys — `hashview_url`, `hashview_api_key`, `hashmob_api_key`, both `notify_pushover_*`, the six `ollama*` keys and the `pipal` ones — each printing a warning at every start while doing nothing.

## The change

`finish_stale_migration()` copies those values into the `.env` and prunes them from `config.json`, backing the original up first.

It does this **without asking**, matching `write_env_from_legacy()`, which also rewrites `config.json` unprompted. A stranded key is already being ignored, so leaving it preserves nothing but the warning — and that warning, printed every start with no way to act on it, *was* the prompt. Running unprompted also covers the runs nobody is watching (cron, `--hashview`, anything piped), which is precisely where a prompt would hang or be dismissed forever.

Two rules differ from the first-stage migration, both because a `.env` already exists:

- **A key already set in the `.env` keeps that value.** That file is the live source; copying the stale `config.json` value over it would silently revert a setting in use — the cross-file precedence the split removed. It is still pruned from `config.json`, where it was ignored anyway.
- **A wrongly-typed value is neither copied nor pruned**, matching `write_env_from_legacy()`: it is the only record of what the user meant.

`SKIP_INIT` short-circuits everything, so importing the module in tests cannot rewrite config as a side effect, and any failure is reported and swallowed rather than stopping startup. The `.env` is appended to rather than re-rendered, so user comments and key order survive; both rewrites go through a temp file and carry the existing mode over, since one of these files holds API keys.

## Also fixed: a clobbered backup

`_prune_migrated_keys()` wrote to a fixed `<config.json>.pre-split.bak`. Safe while it ran once per install — but this function can run again whenever another key becomes env-homed, and a plain `copy2` onto that path silently replaces the only copy of the genuinely pre-split `config.json`. That overwrites the safety net during the operation it exists to protect.

Not hypothetical: verifying the repair against a real install clobbered a `.pre-split.bak` written weeks earlier. Nothing was lost in that instance, because the keys it recorded had already moved into the `.env`, but the next case might differ. Backups now fall back to `.pre-split.bak.2`, `.3` and so on, bounded at 99 so a pathological install fails the backup rather than spinning.

## Verification

Ten unit tests: inert when nothing is stale, never prompts, the value moving and the JSON being pruned, the `.env`-wins rule, the wrong-type carve-out, notes never containing values (several keys are secrets), json-homed and unrecognized keys never touched, the backup never clobbered, and — the point — that the end state loads with **zero** loader warnings.

Verified against the real twelve-key install: all twelve moved, the loader now reports no warnings, and all twelve values load live.

Full suite: 2068 passed. `ruff` clean.

One note for reviewers reproducing the backup fix: run it with `__pycache__` cleared. A stale `.pyc` sharing an mtime second with the source initially made the fix look ineffective, which cost me a detour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
