### PR TITLE
fix(release): derive the version bump from the batch, not from the branch

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,13 +1,19 @@
 name: Auto Tag
 
-# Cuts the stable release on main. main is always X.Y.0: merging nightly-dev
-# down is the release event, and it is always a MINOR bump.
+# Cuts the stable release on main by promoting the candidate that nightly-dev
+# has been building: a fix-only cycle ends at X.Y.(Z+1), a cycle containing any
+# feature ends at X.(Y+1).0.
 #
-# The version arithmetic is done by commitizen (`cz bump`), configured in
-# pyproject.toml under [tool.commitizen] with version_provider = "scm" and
-# tag_format = "v$version". Nothing here parses or increments a version number;
-# that used to be ~70 lines of `cut -d.` and `$((minor + 1))` duplicated with
-# nightly-tag.yml, and it is deliberately gone. Do not reintroduce it.
+# main is NOT always X.Y.0 and the bump is NOT forced. Both of those were true
+# here until 2026-07-31, and both were wrong: every merge cut a minor regardless
+# of content, so two bugfix merges took the project 2.20.0 -> 2.22.0 in an hour
+# with no feature between them.
+#
+# The policy lives in tools/next_version.py, shared with nightly-tag.yml and
+# unit-tested in tests/test_next_version.py. Nothing here parses or increments a
+# version number; that used to be ~70 lines of `cut -d.` and `$((minor + 1))`
+# duplicated across both workflows, and it is deliberately gone. Do not
+# reintroduce it -- add to the module, where it can be tested.
 #
 # Runs only after the CI workflow finishes successfully on main, so a broken
 # commit never gets tagged or released.
@@ -51,39 +57,15 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
-        with:
-          python-version: "3.13"
-
       - name: Compute release tag
         id: bump
         run: |
           set -euo pipefail
-          # --increment MINOR is what expresses "a merge into main is a
-          # release". It is forced rather than inferred from commit messages,
-          # which means a `type!:` subject or a BREAKING CHANGE: footer no
-          # longer auto-bumps major. That is intentional: a major release is a
-          # rare, explicit human act (`cz bump --increment MAJOR`, run by hand
-          # and pushed). Do not add breaking-change detection here -- that is
-          # exactly the hand-rolled version decisioning this rewrite removed.
-          #
-          # There is also no "no feat/fix/perf commits, skip" early exit any
-          # more. A merge into main is an explicit release event, so a
-          # docs/chore-only merge still cuts a release.
-          uvx --from 'commitizen==4.17.0' cz bump --yes --increment MINOR --dry-run \
-            > "$RUNNER_TEMP/cz-bump.log"
-          cat "$RUNNER_TEMP/cz-bump.log"
-
-          # Read the answer out of a file rather than piping cz straight into
-          # grep/sed. Under `set -o pipefail` an early-exiting reader can leave
-          # the producer killed by SIGPIPE (exit 141), which would fail the step
-          # on a successful match. Several past bugs here came from exactly that.
-          new_tag=$(sed -n 's/^tag to create: //p' "$RUNNER_TEMP/cz-bump.log" | head -1)
-          if [ -z "$new_tag" ]; then
-            echo "::error::could not determine the tag to create from cz output"
-            exit 1
-          fi
-          echo "Release tag: $new_tag"
+          # The whole decision -- which component moves, and to what -- is
+          # tools/next_version.py's. Keeping it out of YAML is the point: this
+          # step cannot be unit-tested and the policy can.
+          new_tag=$(python3 tools/next_version.py --channel stable)
+          echo "Release tag: ${new_tag:-<nothing to tag>}"
           echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
 
       - name: Create tag
@@ -91,6 +73,16 @@ jobs:
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
         run: |
           set -euo pipefail
+          # Empty means no commits since the last release -- a re-run on an
+          # already-released commit. Nothing to do, and not an error.
+          #
+          # This is NOT the old "no feat/fix/perf commits, skip" early exit: a
+          # docs- or chore-only merge is still a release, it just cuts a patch
+          # rather than a minor. Only a genuinely empty batch is skipped.
+          if [ -z "$NEW_TAG" ]; then
+            echo "No commits since the last release; nothing to tag"
+            exit 0
+          fi
           # Idempotent: a re-run of this workflow must not fail the job.
           if git rev-parse -q --verify "refs/tags/$NEW_TAG" >/dev/null; then
             echo "Tag $NEW_TAG already exists, nothing to push"
@@ -109,6 +101,10 @@ jobs:
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
         run: |
           set -euo pipefail
+          if [ -z "$NEW_TAG" ]; then
+            echo "No tag was created; no release to publish"
+            exit 0
+          fi
           if gh release view "$NEW_TAG" >/dev/null 2>&1; then
             echo "Release $NEW_TAG already exists, nothing to do"
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      # tools/next_version.py is listed individually rather than by directory:
+      # it is executed by both tagging workflows, so it has to be held to the
+      # same standard, but the rest of tools/ predates linting and does not pass
+      # yet. Widening to all of tools/ is issue #237.
       - name: Ruff (lint)
-        run: uv run ruff check hate_crack tests
+        run: uv run ruff check hate_crack tests tools/next_version.py
 
       - name: Ruff (format)
-        run: uv run ruff format --check hate_crack tests
+        run: uv run ruff format --check hate_crack tests tools/next_version.py
 
       - name: Ty
         # ty 0.0.63 fails CI on warning-level diagnostics by default;

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -1,24 +1,28 @@
 name: Nightly Tag
 
-# Tags nightly-dev after CI passes. nightly-dev is the rolling branch and it
-# consumes PATCH numbers: with main stable at X.Y.0, validated nightly pushes
-# become X.Y.1, X.Y.2, ... one per push. The weekly merge into main then cuts
-# the next stable X.(Y+1).0 via auto-tag.yml.
+# Tags nightly-dev after CI passes, as a RELEASE CANDIDATE for whichever version
+# the batch is heading toward: v2.20.1rc1, v2.20.1rc2, ... for a fix-only cycle,
+# v2.21.0rc1 for one containing a feature. Merging down to main then promotes
+# that same target to its final release.
 #
-# The version arithmetic is done by commitizen (`cz bump`), configured in
-# pyproject.toml under [tool.commitizen]. Nothing here parses or increments a
-# version number; that used to be duplicated bash (`cut -d.`, `$((patch + 1))`,
-# plus an rc-counter `sed`/`sort -n` pipeline) and it is deliberately gone. Do
-# not reintroduce it.
+# These are real PEP 440 pre-releases, so they order correctly against both ends:
 #
-# These are now ORDINARY release tags, not -rc.N pre-releases. That retires the
-# whole reason the old pre-release scheme existed (setuptools-scm rejects tags
-# ending in .devN for N>0, which ruled out an incrementing -dev.N scheme, so -rc
-# was used instead). Consequence to be aware of: because a nightly tag is no
-# longer a PEP 440 pre-release, any tool resolving "the latest version" will now
-# consider a nightly to be latest. The package is not published to PyPI, so
-# nothing installs from an index today, but this is a real property of the
-# scheme rather than an oversight.
+#     2.20.0  <  2.20.1rc1  <  2.20.1rc2  <  2.20.1  <  2.21.0rc1  <  2.21.0
+#
+# Two earlier schemes here got that wrong. Tagging vX.Y.0-rc.N aimed candidates
+# at the *current* cycle's version, so a candidate sorted below the release it
+# was heading for. Replacing them with ordinary final versions removed the
+# pre-release marker entirely, so anything ranking versions saw a nightly as the
+# latest release. Aiming one version forward fixes both.
+#
+# The target can change mid-cycle: the first `feat` to land moves it from
+# X.Y.(Z+1) to X.(Y+1).0, and candidate numbering restarts for the new target.
+# That is intended -- the number always names what the batch would ship as today.
+#
+# The policy lives in tools/next_version.py, shared with auto-tag.yml and
+# unit-tested in tests/test_next_version.py. Nothing here parses or increments a
+# version number. Do not reintroduce that -- add to the module, where it can be
+# tested.
 #
 # No GitHub release is created here -- see the end of this file.
 #
@@ -66,41 +70,14 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
-        with:
-          python-version: "3.13"
-
       - name: Compute nightly tag
         id: bump
         run: |
           set -euo pipefail
-          # --increment PATCH is what expresses "nightly-dev consumes patch
-          # numbers". It is forced rather than inferred, so every validated
-          # nightly push gets a tag and stays addressable -- including a
-          # docs/chore-only one, which the old workflow also did deliberately.
-          # Do not add commit-message inspection here.
-          # NOTE: this step FAILS with `[NO_VERSION_SPECIFIED]` (exit 4) on any
-          # nightly-dev commit whose pyproject.toml has no [tool.commitizen]
-          # section. That is a GUARANTEED red window between this landing on main
-          # and main being merged down into nightly-dev, because the config
-          # arrives with that merge. cz's error message says nothing about the
-          # cause, so: if you see [NO_VERSION_SPECIFIED] here, merge main into
-          # nightly-dev. Failing loudly is the intended behaviour -- it is much
-          # better than guessing a version -- but it is not self-explanatory.
-          uvx --from 'commitizen==4.17.0' cz bump --yes --increment PATCH --dry-run \
-            > "$RUNNER_TEMP/cz-bump.log"
-          cat "$RUNNER_TEMP/cz-bump.log"
-
-          # Read the answer out of a file rather than piping cz straight into
-          # grep/sed. Under `set -o pipefail` an early-exiting reader can leave
-          # the producer killed by SIGPIPE (exit 141), which would fail the step
-          # on a successful match. Several past bugs here came from exactly that.
-          new_tag=$(sed -n 's/^tag to create: //p' "$RUNNER_TEMP/cz-bump.log" | head -1)
-          if [ -z "$new_tag" ]; then
-            echo "::error::could not determine the tag to create from cz output"
-            exit 1
-          fi
-          echo "Nightly tag: $new_tag"
+          # tools/next_version.py owns the decision; see the header. This step
+          # deliberately contains no version logic of its own.
+          new_tag=$(python3 tools/next_version.py --channel nightly)
+          echo "Nightly tag: ${new_tag:-<nothing to tag>}"
           echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
 
       - name: Create tag
@@ -108,6 +85,13 @@ jobs:
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
         run: |
           set -euo pipefail
+          # Empty means no commits since the last release: nothing to build a
+          # candidate from. Not an error -- a workflow re-run lands here, and
+          # `git tag ""` would fail with a message about nothing in particular.
+          if [ -z "$NEW_TAG" ]; then
+            echo "No commits since the last release; nothing to tag"
+            exit 0
+          fi
           # Idempotent: a re-run of this workflow must not fail the job.
           if git rev-parse -q --verify "refs/tags/$NEW_TAG" >/dev/null; then
             echo "Tag $NEW_TAG already exists, nothing to push"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+### Fixed
+- **Release versions now reflect what is in the batch.** `auto-tag.yml` forced
+  `cz bump --increment MINOR` on every merge into `main`, so the second component
+  moved regardless of content and `main` could never produce an `X.Y.Z` with a
+  non-zero patch. Two bugfix merges took the project from 2.20.0 to 2.22.0 inside
+  an hour with no feature between them. The forcing was annotated as deliberate
+  (*"It is forced rather than inferred from commit messages… Do not add
+  breaking-change detection here"*); that annotation described the bug, not a
+  requirement.
+
+  The policy is now ordinary semver, derived from the commits since the last
+  release: any `feat` means the batch is heading for `X.(Y+1).0`, and a batch of
+  only fixes, docs and chores is heading for `X.Y.(Z+1)`. Applied to this
+  afternoon's history, the two releases would have been 2.20.1 and 2.21.0 rather
+  than 2.21.0 and 2.22.0.
+
+  `nightly-dev` now tags release candidates for whichever version the batch is
+  heading toward (`v2.20.1rc1`, `v2.20.1rc2`, …) and merging down to `main`
+  promotes that target to its final release. These are real PEP 440
+  pre-releases, so they order correctly at both ends --
+  `2.20.0 < 2.20.1rc1 < 2.20.1rc2 < 2.20.1 < 2.21.0rc1 < 2.21.0` -- which is the
+  property the two previous schemes each missed. Tagging `vX.Y.0-rc.N` aimed
+  candidates at the current cycle's version, so a candidate sorted below the
+  release it was heading for; replacing them with ordinary final versions dropped
+  the pre-release marker entirely, so anything ranking versions saw a nightly as
+  the latest release. Aiming one version forward fixes both.
+
+  The major component is still never bumped automatically: a `!` subject or a
+  `BREAKING CHANGE:` footer counts as a feature. An automatic major is one
+  mistyped subject line away from an irreversible published release, so it stays
+  an explicit human act.
+
+  The policy moved out of YAML into `tools/next_version.py`, shared by both
+  workflows and unit-tested in `tests/test_next_version.py` (43 tests, including
+  the ordering asserted against the real PEP 440 parser). The workflow steps that
+  consume it are themselves executed against real repositories in
+  `tests/test_release_versioning.py`, so a wrong *value* now fails a test -- the
+  previous tests stubbed `uvx` and could only prove the step parsed a fixed
+  string, never that the policy was right. Both workflows also now skip cleanly
+  when a batch is empty instead of tagging the empty string.
+
 ### Added
 - **Startup now finishes a migration that a later schema change stranded.**
   `write_env_from_legacy()` only runs when there is no `.env` yet -- once both

--- a/README.md
+++ b/README.md
@@ -721,17 +721,36 @@ hate_crack can automatically check GitHub for newer releases on startup. This fe
 | Release | `--update` | `main` | The latest cut release. This is the default and what the startup check offers. |
 | Nightly | `--nightly` | `nightly-dev` | Work that has passed CI but has not been released yet. |
 
-Versions follow a rolling scheme: `main` is stable and always `X.Y.0`, while
-`nightly-dev` consumes the patch numbers above it (`X.Y.1`, `X.Y.2`, …), one per
-validated push. Merging `nightly-dev` into `main` cuts the next `X.(Y+1).0`.
+Versions follow ordinary semver, with the bump derived from what is actually in
+the batch. The second component moves **only for features**: a cycle containing
+any `feat` commit is heading for `X.(Y+1).0`, and a cycle of nothing but fixes,
+docs and chores is heading for `X.Y.(Z+1)`.
+
+`nightly-dev` tags release candidates for whichever version the batch is heading
+toward — `v2.20.1rc1`, `v2.20.1rc2`, … — and merging down to `main` promotes that
+same target to its final release. Candidates are real PEP 440 pre-releases, so
+they order correctly at both ends:
+
+    2.20.0  <  2.20.1rc1  <  2.20.1rc2  <  2.20.1  <  2.21.0rc1  <  2.21.0
+
+The target can change mid-cycle: the first `feat` to land moves it from
+`X.Y.(Z+1)` to `X.(Y+1).0`, and candidate numbering restarts for the new target.
+The number always names what the batch would ship as today.
+
+The major component is never bumped automatically — a `!` subject or a
+`BREAKING CHANGE:` footer counts as a feature, because an automatic major is one
+mistyped subject line away from an irreversible published release. A major is an
+explicit human act: tag and push it by hand.
+
+The policy lives in `tools/next_version.py`, shared by both tagging workflows and
+unit-tested in `tests/test_next_version.py`.
 
 The startup check only ever offers releases, because nightly builds publish no
 GitHub release at all and the check reads GitHub's "latest release" endpoint — so
-enabling `check_for_updates` will never pull you onto a nightly. Note that this
-is now the *only* thing separating the two channels: a nightly tag is an
-ordinary release tag rather than a pre-release, so a tool that ranks raw version
-numbers (rather than GitHub releases) will consider a nightly to be the latest
-version.
+enabling `check_for_updates` will never pull you onto a nightly. Two things keep
+the channels apart now: that, and the fact that a candidate is a genuine PEP 440
+pre-release, so a tool ranking raw version numbers also treats it as older than
+the release it becomes.
 
 Either flag switches your checkout to the corresponding branch first (and
 refuses to do so if you have uncommitted changes). If you are running a nightly

--- a/tests/test_next_version.py
+++ b/tests/test_next_version.py
@@ -1,0 +1,345 @@
+"""Tests for tools/next_version.py -- the release policy itself.
+
+The policy is ordinary semver with the bump derived from the batch: the second
+component moves only for features, `nightly-dev` cuts release candidates for the
+version the batch is heading toward, and `main` cuts the final of that same
+target.
+
+Two prior schemes in this repo got the *ordering* wrong, so the ordering is
+asserted here against the real PEP 440 parser rather than by eyeball:
+
+* Tagging `vX.Y.0-rc.N` aimed candidates at the *current* cycle's version, so a
+  candidate sorted below the release it was heading for.
+* Making nightlies ordinary final versions removed the pre-release marker
+  entirely, so any tool ranking versions considered a nightly to be the latest
+  release.
+
+Aiming candidates one version forward fixes both: a candidate sorts above the
+release that precedes it and below the release it becomes, and it is still a
+pre-release.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+from packaging.version import parse
+
+from tools.next_version import (
+    commit_messages,
+    compute,
+    has_feature,
+    latest_final,
+    next_rc_number,
+    parse_final,
+    target_version,
+)
+
+# --- the baseline ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tag,expected",
+    [
+        ("v2.20.0", (2, 20, 0)),
+        ("v10.4.7", (10, 4, 7)),
+        # Not released versions: a candidate, a dev build, a local version, and
+        # the shapes a hand-pushed tag might take.
+        ("v2.20.1rc1", None),
+        ("v2.20.1.dev3", None),
+        ("v2.20.0+g1234567", None),
+        ("2.20.0", None),
+        ("v2.20", None),
+        ("nightly", None),
+    ],
+)
+def test_only_released_versions_are_baseline_candidates(tag, expected):
+    """The baseline must be something that actually shipped.
+
+    Letting a candidate be the baseline would compound: 2.20.1rc1 would beget
+    2.20.2rc1 without 2.20.1 ever existing.
+    """
+    assert parse_final(tag) == expected
+
+
+def test_latest_final_ignores_candidates_and_picks_the_highest():
+    tags = ["v2.19.0", "v2.20.0", "v2.20.1rc1", "v2.20.1rc2", "v2.21.0rc1"]
+    assert latest_final(tags) == (2, 20, 0)
+
+
+def test_latest_final_compares_numerically_not_lexically():
+    """The bug that started all of this was a lexical tie-break: '2.19.15' sorts
+    above '2.20.0' as text, and below it as a version."""
+    assert latest_final(["v2.9.0", "v2.10.0"]) == (2, 10, 0)
+    assert latest_final(["v2.19.15", "v2.20.0"]) == (2, 20, 0)
+
+
+def test_no_tags_at_all_starts_from_zero():
+    assert latest_final([]) == (0, 0, 0)
+    assert latest_final(["nightly", "some-marker"]) == (0, 0, 0)
+
+
+# --- feature detection ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "feat: add a thing",
+        "feat(config): add a thing",
+        "feat!: replace a thing",
+        "feat(config)!: replace a thing",
+        "FEAT: shouting still counts",
+    ],
+)
+def test_feature_subjects_are_detected(subject):
+    assert has_feature([subject])
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "fix: repair a thing",
+        "fix(config): repair a thing",
+        "docs(changelog): write a thing",
+        "chore: bump a thing",
+        "test: cover a thing",
+        "refactor: move a thing",
+        "perf: speed a thing up",
+        "ci: retag a thing",
+    ],
+)
+def test_non_feature_subjects_are_not_features(subject):
+    assert not has_feature([subject])
+
+
+def test_the_word_feature_in_a_body_does_not_promote_the_batch():
+    """Anchored at the subject on purpose. A fix whose body explains which
+    feature it repairs must not cut a minor release."""
+    message = "fix(attacks): correct the mask\n\nThis feature was broken: feat\n"
+    assert not has_feature([message])
+
+
+def test_a_breaking_footer_counts_as_a_feature_not_a_major():
+    """Deliberate: an automatic major is one mistyped subject away from an
+    irreversible published release, so major stays a human act."""
+    assert has_feature(["fix: something\n\nBREAKING CHANGE: it moved\n"])
+    assert has_feature(["refactor!: rename the entry point"])
+    base = (2, 20, 0)
+    assert target_version(base, ["refactor!: rename it"]) == (2, 21, 0)
+
+
+def test_one_feature_among_many_fixes_still_cuts_a_minor():
+    messages = ["fix: a", "docs: b", "feat: c", "chore: d"]
+    assert target_version((2, 20, 0), messages) == (2, 21, 0)
+
+
+# --- the target version -----------------------------------------------------
+
+
+def test_fix_only_batch_moves_the_third_component():
+    assert target_version((2, 20, 0), ["fix: a", "docs: b"]) == (2, 20, 1)
+
+
+def test_fix_only_batch_builds_on_a_previous_patch():
+    assert target_version((2, 20, 1), ["fix: a"]) == (2, 20, 2)
+
+
+def test_feature_batch_moves_the_second_and_zeroes_the_third():
+    assert target_version((2, 20, 7), ["feat: a"]) == (2, 21, 0)
+
+
+def test_an_empty_batch_has_no_target():
+    """A workflow re-run on an already-tagged commit must cut nothing rather
+    than invent a version."""
+    assert target_version((2, 20, 0), []) is None
+    assert compute("stable", ["v2.20.0"], []) is None
+    assert compute("nightly", ["v2.20.0"], []) is None
+
+
+# --- candidate numbering ----------------------------------------------------
+
+
+def test_first_candidate_for_a_target_is_rc1():
+    assert next_rc_number((2, 20, 1), ["v2.20.0"]) == 1
+
+
+def test_candidates_count_upward_within_a_target():
+    tags = ["v2.20.0", "v2.20.1rc1", "v2.20.1rc2"]
+    assert next_rc_number((2, 20, 1), tags) == 3
+
+
+def test_candidate_numbering_is_per_target():
+    """A feature landing mid-cycle changes the target, and the new target starts
+    its own count rather than inheriting the old one."""
+    tags = ["v2.20.0", "v2.20.1rc1", "v2.20.1rc2"]
+    assert next_rc_number((2, 21, 0), tags) == 1
+
+
+def test_candidate_numbering_survives_a_deleted_tag():
+    """Counts from the highest seen, not from how many exist, so deleting rc2
+    cannot hand out rc2 again to a different commit."""
+    tags = ["v2.20.0", "v2.20.1rc1", "v2.20.1rc3"]
+    assert next_rc_number((2, 20, 1), tags) == 4
+
+
+# --- the two channels, and the ordering that motivates the whole design -----
+
+
+def test_nightly_cuts_a_candidate_for_the_next_version():
+    tags = ["v2.20.0"]
+    assert compute("nightly", tags, ["fix: a"]) == "v2.20.1rc1"
+    assert compute("nightly", tags, ["feat: a"]) == "v2.21.0rc1"
+
+
+def test_main_cuts_the_final_of_the_same_target():
+    """Merging nightly-dev down promotes the candidate rather than inventing a
+    different number: the fix-only cycle above ends at 2.20.1, not 2.21.0."""
+    tags = ["v2.20.0", "v2.20.1rc1", "v2.20.1rc2"]
+    assert compute("stable", tags, ["fix: a"]) == "v2.20.1"
+    assert compute("stable", ["v2.20.0", "v2.21.0rc1"], ["feat: a"]) == "v2.21.0"
+
+
+def test_candidates_sort_above_the_previous_release_and_below_their_own():
+    """The property both earlier schemes failed, checked with the real parser.
+
+    A candidate must look newer than what shipped before it and older than what
+    it becomes. Asserted end to end across a whole fix-only cycle.
+    """
+    shipped = parse("2.20.0")
+    rc1 = parse(compute("nightly", ["v2.20.0"], ["fix: a"]).lstrip("v"))
+    rc2 = parse(
+        compute("nightly", ["v2.20.0", "v2.20.1rc1"], ["fix: a", "fix: b"]).lstrip("v")
+    )
+    final = parse(
+        compute("stable", ["v2.20.0", "v2.20.1rc1", "v2.20.1rc2"], ["fix: a"]).lstrip(
+            "v"
+        )
+    )
+
+    assert shipped < rc1 < rc2 < final
+    assert rc1.is_prerelease and rc2.is_prerelease
+    assert not final.is_prerelease, "main must publish a real release, not a candidate"
+
+
+def test_a_feature_cycle_also_orders_correctly_against_the_fix_cycle():
+    """2.20.1 < 2.21.0rc1 < 2.21.0 -- a candidate for the next minor must not
+    look older than the patch release that preceded it."""
+    patch_release = parse("2.20.1")
+    rc = parse(compute("nightly", ["v2.20.1"], ["feat: a"]).lstrip("v"))
+    final = parse(compute("stable", ["v2.20.1", "v2.21.0rc1"], ["feat: a"]).lstrip("v"))
+    assert patch_release < rc < final
+
+
+def test_unknown_channel_is_a_loud_error():
+    with pytest.raises(ValueError):
+        compute("beta", ["v2.20.0"], ["fix: a"])
+
+
+# --- the git boundary -------------------------------------------------------
+
+
+def _git(*args, cwd):
+    return subprocess.run(
+        [str(shutil.which("git")), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.invalid",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.invalid",
+        },
+    ).stdout
+
+
+def test_commit_messages_keeps_multi_line_bodies_intact(tmp_path):
+    """NUL-delimited for a reason: a body with a blank line would otherwise be
+    split into separate 'commits', and a BREAKING CHANGE footer would be read as
+    its own subject."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", "-b", "main", cwd=repo)
+    (repo / "f.txt").write_text("a\n")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-qm", "fix: the first thing", cwd=repo)
+    _git("tag", "v2.20.0", cwd=repo)
+
+    (repo / "f.txt").write_text("b\n")
+    _git("add", "-A", cwd=repo)
+    _git(
+        "commit",
+        "-qm",
+        "fix: the second thing\n\nA body with a blank line.\n\nBREAKING CHANGE: yes\n",
+        cwd=repo,
+    )
+
+    messages = commit_messages(str(repo), (2, 20, 0))
+
+    assert len(messages) == 1, f"body split into separate messages: {messages}"
+    assert "BREAKING CHANGE: yes" in messages[0]
+    # And the footer is therefore seen, which is the point.
+    assert has_feature(messages)
+
+
+def test_commit_messages_since_baseline_excludes_the_baseline_itself(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", "-b", "main", cwd=repo)
+    (repo / "f.txt").write_text("a\n")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-qm", "feat: shipped already", cwd=repo)
+    _git("tag", "v2.20.0", cwd=repo)
+
+    assert commit_messages(str(repo), (2, 20, 0)) == []
+
+    (repo / "f.txt").write_text("b\n")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-qm", "fix: not yet shipped", cwd=repo)
+
+    messages = commit_messages(str(repo), (2, 20, 0))
+    assert len(messages) == 1
+    assert "not yet shipped" in messages[0]
+    assert not has_feature(messages), "the shipped feat must not leak into this batch"
+
+
+def test_baseline_need_not_be_reachable_from_head(tmp_path):
+    """main's release tag can sit on a commit nightly-dev does not contain.
+
+    A reachability-restricted baseline would compute the next nightly from a
+    stale release and hand out a version below what already shipped.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", "-b", "main", cwd=repo)
+    (repo / "f.txt").write_text("a\n")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-qm", "fix: base", cwd=repo)
+    _git("tag", "v2.20.0", cwd=repo)
+
+    # A release that happened on main, on a commit this branch will not contain.
+    (repo / "f.txt").write_text("released\n")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-qm", "fix: released on main", cwd=repo)
+    _git("tag", "v2.20.1", cwd=repo)
+
+    _git("checkout", "-q", "-b", "nightly-dev", "v2.20.0", cwd=repo)
+    (repo / "f.txt").write_text("nightly\n")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-qm", "fix: on the nightly branch", cwd=repo)
+
+    tags = [t for t in _git("tag", cwd=repo).splitlines() if t.strip()]
+    assert latest_final(tags) == (2, 20, 1), "baseline must see main's release tag"
+
+    messages = commit_messages(str(repo), (2, 20, 1))
+    got = compute("nightly", tags, messages)
+    assert got == "v2.20.2rc1", (
+        f"the next nightly must sort above the release that already shipped, got {got}"
+    )
+    assert parse("2.20.1") < parse(got.lstrip("v"))

--- a/tests/test_release_versioning.py
+++ b/tests/test_release_versioning.py
@@ -148,13 +148,13 @@ def test_commitizen_reads_version_from_scm() -> None:
     assert _commitizen_config().get("version_provider") == "scm"
 
 
-def test_commitizen_pin_agrees_everywhere() -> None:
-    """The pin appears in three places and they must not drift.
+def test_commitizen_pin_is_still_coherent() -> None:
+    """commitizen is a local convenience now, not part of tagging.
 
-    The workflows install commitizen with ``uvx --from`` and never run
-    ``uv sync --dev``, so the dev-group pin does not constrain CI at all.
-    Bumping only the dev group would change what a developer runs locally while
-    CI silently kept tagging with the old version -- and nothing would fail.
+    It used to compute the version in both workflows, which is why this test
+    once asserted the pin agreed across three places. The policy moved to
+    tools/next_version.py, so the workflows install nothing; only the dev-group
+    pin remains, and it is asserted so `cz commit` keeps working locally.
     """
     dev = _pyproject()["dependency-groups"]["dev"]
     pins = [d for d in dev if d.split("==")[0].strip() == "commitizen"]
@@ -163,11 +163,10 @@ def test_commitizen_pin_agrees_everywhere() -> None:
     )
 
     for path in (AUTO_TAG, NIGHTLY_TAG):
-        found = re.findall(r"--from\s+'commitizen==([0-9][^']*)'", _shell_body(path))
-        assert found, f"{path.name} does not install a pinned commitizen"
-        assert set(found) == {COMMITIZEN_PIN}, (
-            f"{path.name} pins commitizen{found}, expected {COMMITIZEN_PIN} "
-            "to match the dev dependency group"
+        body = _shell_body(path)
+        assert "cz bump" not in body, (
+            f"{path.name} computes a version with commitizen again; the policy "
+            "belongs in tools/next_version.py where it can be unit-tested"
         )
 
 
@@ -175,21 +174,21 @@ def test_commitizen_pin_agrees_everywhere() -> None:
 
 
 @pytest.mark.parametrize(
-    ("path", "increment"),
+    ("path", "channel"),
     [
-        pytest.param(NIGHTLY_TAG, "PATCH", id="nightly-dev-consumes-patch"),
-        pytest.param(AUTO_TAG, "MINOR", id="main-cuts-minor"),
+        pytest.param(NIGHTLY_TAG, "nightly", id="nightly-dev-cuts-candidates"),
+        pytest.param(AUTO_TAG, "stable", id="main-cuts-the-final"),
     ],
 )
-def test_cz_bump_is_the_only_thing_that_produces_a_version(
-    path: Path, increment: str
+def test_the_policy_module_is_the_only_thing_that_produces_a_version(
+    path: Path, channel: str
 ) -> None:
     """The user's hard constraint: do not hand-roll a versioning scheme.
 
-    This is stated as a POSITIVE invariant -- exactly one command computes the
-    version, it is ``cz bump``, and the tag actually used is read back from that
-    command's output -- because the previous denylist-only form was defeatable.
-    A reviewer reintroduced the exact rc-counter pipeline this change deleted
+    Stated as a POSITIVE invariant -- exactly one command computes the version,
+    it is tools/next_version.py, and the tag actually used is read back from that
+    command's output -- because the previous denylist-only form was defeatable. A
+    reviewer reintroduced the exact rc-counter pipeline this change deleted
     (``git tag --list | sed -E ... | sort -n | tail -1`` feeding
     ``n=$(( last_n + 1 ))``) and every test still passed, because the denylist
     happened to enumerate ``$((major`` and friends but not ``sort -n``,
@@ -199,28 +198,21 @@ def test_cz_bump_is_the_only_thing_that_produces_a_version(
     """
     lines = _code_lines(path)
 
-    bump_lines = [ln for ln in lines if "cz bump" in ln]
-    assert len(bump_lines) == 1, (
-        f"{path.name} must invoke `cz bump` exactly once, found {len(bump_lines)}"
+    calls = [ln for ln in lines if "next_version.py" in ln]
+    assert len(calls) == 1, (
+        f"{path.name} must call tools/next_version.py exactly once, found {len(calls)}"
     )
-    bump = bump_lines[0]
-    assert f"--increment {increment}" in bump, (
-        f"{path.name} must force `--increment {increment}`; got: {bump.strip()}"
+    assert f"--channel {channel}" in calls[0], (
+        f"{path.name} must ask for the {channel!r} channel; got: {calls[0].strip()}"
     )
-    assert "--dry-run" in bump, (
-        f"{path.name} must use --dry-run; the tag is pushed explicitly afterwards"
-    )
-    other = "MINOR" if increment == "PATCH" else "PATCH"
-    assert other not in _shell_body(path), f"{path.name} must not reference `{other}`"
 
-    # The tag that gets pushed must come from cz's own output, not be assembled
-    # locally. Any assignment to new_tag has to read the cz log.
+    # The tag that gets pushed must come from that call, not be assembled here.
     assignments = [ln for ln in lines if re.match(r"\s*new_tag=", ln)]
     assert assignments, f"{path.name} never assigns new_tag"
     for assignment in assignments:
-        assert "cz-bump.log" in assignment, (
-            f"{path.name} builds new_tag without reading cz's output, which is "
-            f"hand-rolled versioning: {assignment.strip()}"
+        assert "next_version.py" in assignment, (
+            f"{path.name} builds new_tag without asking the policy module, which "
+            f"is hand-rolled versioning: {assignment.strip()}"
         )
 
     # Second line of defence: constructs that only appear when someone is
@@ -238,6 +230,7 @@ def test_cz_bump_is_the_only_thing_that_produces_a_version(
         "git tag --list",  # enumerating tags to derive the next one
         "git tag -l",
         "git describe",
+        "cz bump",  # the policy is no longer commitizen's to decide
     ]
     found = [snippet for snippet in forbidden if snippet in "\n".join(lines)]
     assert not found, f"{path.name} reintroduced hand-rolled version math: {found}"
@@ -342,83 +335,125 @@ def test_tag_creation_is_actually_idempotent(path: Path, tmp_path: Path) -> None
 # --- behavioural: the empty-tag guard ---------------------------------------
 
 
-def _uvx_stub(tmp_path: Path, output: str, exit_code: int = 0) -> Path:
-    """A directory to prepend to PATH containing a fake `uvx`.
+def _git_env() -> dict[str, str]:
+    return {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.invalid",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.invalid",
+    }
 
-    Lets the compute step run without network access or a real commitizen, so
-    the guard around cz's *output* can be exercised directly.
+
+def _git_cmd(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        [str(shutil.which("git")), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**os.environ, **_git_env()},
+    ).stdout
+
+
+def _policy_repo(tmp_path: Path, subjects: list[str]) -> Path:
+    """A repo released at v2.20.0, plus *subjects* committed on top.
+
+    Carries a real copy of tools/next_version.py so the extracted workflow step
+    runs the actual policy, not a stub. The stub this replaced could only prove
+    the step parsed a fixed string; it could not have caught the policy itself
+    being wrong, which is exactly what was wrong.
     """
-    bindir = tmp_path / "stubbin"
-    bindir.mkdir()
-    stub = bindir / "uvx"
-    stub.write_text(f"#!/bin/sh\ncat <<'CZEOF'\n{output}\nCZEOF\nexit {exit_code}\n")
-    stub.chmod(0o755)
-    return bindir
+    repo, _remote = _init_repo_with_remote(tmp_path)
+    tools = repo / "tools"
+    tools.mkdir(exist_ok=True)
+    shutil.copy2(REPO_ROOT / "tools" / "next_version.py", tools / "next_version.py")
+    _git_cmd("add", "-A", cwd=repo)
+    _git_cmd("commit", "-qm", "chore: add the policy module", cwd=repo)
+    _git_cmd("tag", "v2.20.0", cwd=repo)
+    for subject in subjects:
+        (repo / "f.txt").write_text(subject + "\n")
+        _git_cmd("commit", "-qam", subject, cwd=repo)
+    return repo
 
 
-@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
-def test_compute_step_extracts_the_tag_cz_reports(path: Path, tmp_path: Path) -> None:
-    """The happy path: the pushed tag is whatever cz said, verbatim.
-
-    Also exercises the deliberately pipeline-free extraction. Piping cz into
-    ``sed`` directly would risk the producer dying on SIGPIPE (141) under
-    ``set -o pipefail`` and failing the step on a *successful* match.
-    """
-    output = (
-        "bump: version 4.5.6 -> 4.5.7\ntag to create: v4.5.7\nincrement detected: PATCH"
-    )
-    bindir = _uvx_stub(tmp_path, output)
+def _run_compute(path: Path, repo: Path, tmp_path: Path) -> tuple[str, object]:
     gh_output = tmp_path / "gh_output"
     gh_output.write_text("")
     result = _run_script(
         _script(path, _compute_step_name(path)),
-        tmp_path,
-        {
-            "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
-            "RUNNER_TEMP": str(tmp_path),
-            "GITHUB_OUTPUT": str(gh_output),
-        },
+        repo,
+        {"GITHUB_OUTPUT": str(gh_output), **_git_env()},
+    )
+    return gh_output.read_text(), result
+
+
+@pytest.mark.parametrize(
+    ("path", "subjects", "expected"),
+    [
+        pytest.param(AUTO_TAG, ["fix: a", "docs: b"], "v2.20.1", id="main-fixes-patch"),
+        pytest.param(
+            AUTO_TAG, ["fix: a", "feat: b"], "v2.21.0", id="main-feature-minor"
+        ),
+        pytest.param(
+            NIGHTLY_TAG, ["fix: a"], "v2.20.1rc1", id="nightly-fixes-patch-candidate"
+        ),
+        pytest.param(
+            NIGHTLY_TAG, ["feat: a"], "v2.21.0rc1", id="nightly-feature-candidate"
+        ),
+    ],
+)
+def test_compute_step_emits_the_tag_the_policy_dictates(
+    path: Path, subjects: list[str], expected: str, tmp_path: Path
+) -> None:
+    """End to end through the real step script and the real policy module.
+
+    This is the test the old cz-stub version could not be: it asserts the *value*
+    the workflow will tag, so a wrong policy fails here. The bug that prompted
+    the rewrite -- every merge to main cutting a minor regardless of content --
+    is caught by the ``main-fixes-patch`` case.
+    """
+    repo = _policy_repo(tmp_path, subjects)
+    written, result = _run_compute(path, repo, tmp_path)
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert f"new_tag={expected}" in written, (
+        f"{path.name} would tag {written.strip()!r}, expected new_tag={expected}"
+    )
+
+
+@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
+def test_compute_step_emits_an_empty_tag_for_an_empty_batch(
+    path: Path, tmp_path: Path
+) -> None:
+    """A re-run on an already-released commit has nothing to tag.
+
+    It must succeed and emit an empty new_tag, so the create step can skip. The
+    old shape failed the job here, which turned every workflow re-run red.
+    """
+    repo = _policy_repo(tmp_path, [])
+    written, result = _run_compute(path, repo, tmp_path)
+    assert result.returncode == 0, (
+        f"an empty batch must not fail the job:\n{result.stdout}\n{result.stderr}"
+    )
+    assert "new_tag=\n" in written or written.strip() == "new_tag=", (
+        f"expected an empty new_tag, got {written.strip()!r}"
+    )
+
+
+@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
+def test_create_tag_step_tags_nothing_when_the_tag_is_empty(
+    path: Path, tmp_path: Path
+) -> None:
+    """The other half of the empty-batch path: never run `git tag ""`.
+
+    Without this guard the create step tags the empty string, and the failure
+    surfaces as something other than "there was nothing to release".
+    """
+    repo, _remote = _init_repo_with_remote(tmp_path)
+    result = _run_script(
+        _script(path, _tag_step_name(path)), repo, {"NEW_TAG": "", **_git_env()}
     )
     assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
-    assert "new_tag=v4.5.7" in gh_output.read_text()
-
-
-@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
-def test_compute_step_fails_when_cz_reports_no_tag(path: Path, tmp_path: Path) -> None:
-    """An unparseable cz output must fail the job, not push an empty tag.
-
-    Nothing asserted this guard existed before. Without it a change to
-    commitizen's output wording -- a rename of the "tag to create:" line -- makes
-    the next step run ``git tag ""``, and the failure would be reported as
-    something other than "we could not read the version".
-    """
-    bindir = _uvx_stub(tmp_path, "bump: nothing to do, and no tag line at all")
-    gh_output = tmp_path / "gh_output"
-    gh_output.write_text("")
-    result = _run_script(
-        _script(path, _compute_step_name(path)),
-        tmp_path,
-        {
-            "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
-            "RUNNER_TEMP": str(tmp_path),
-            "GITHUB_OUTPUT": str(gh_output),
-        },
-    )
-    assert result.returncode != 0, (
-        "the compute step must fail when cz reports no tag, otherwise the next "
-        f"step tags the empty string. stdout:\n{result.stdout}"
-    )
-    assert "new_tag=" not in gh_output.read_text(), (
-        "no new_tag may be emitted when the tag could not be determined"
-    )
-
-
-@pytest.mark.parametrize("path", BOTH_WORKFLOWS)
-def test_compute_step_writes_to_runner_temp(path: Path) -> None:
-    """Use the runner's scratch dir, not a fixed path in /tmp."""
-    body = _shell_body(path)
-    assert "$RUNNER_TEMP" in body or "${RUNNER_TEMP}" in body
-    assert "/tmp/cz-bump" not in body
+    assert _git_cmd("tag", cwd=repo).strip() == "", "created a tag from an empty name"
 
 
 # --- wiring that has no behaviour to execute --------------------------------

--- a/tools/next_version.py
+++ b/tools/next_version.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Compute the next version tag for a branch, per hate_crack's release policy.
+
+The policy is ordinary semver, with the bump derived from what is actually in
+the batch:
+
+* **The second component moves only for features.** Any ``feat`` commit since
+  the last release means the batch is heading for ``X.(Y+1).0``. A batch of
+  nothing but fixes, docs and chores is heading for ``X.Y.(Z+1)``.
+* **``nightly-dev`` cuts release candidates** for whichever version the batch is
+  heading toward: ``v2.20.1rc1``, ``v2.20.1rc2``, … These are real PEP 440
+  pre-releases, so they sort *above* the release that precedes them and *below*
+  the release they become::
+
+      2.20.0  <  2.20.1rc1  <  2.20.1rc2  <  2.20.1  <  2.21.0rc1  <  2.21.0
+
+  That ordering is the whole point of targeting the *next* version rather than
+  the current one. An earlier scheme in this repo tagged ``v2.19.0-rc.N`` and was
+  removed for sorting below the release it was heading for; the fix is not to
+  abandon pre-releases but to aim them one version forward.
+* **``main`` cuts the final** of that same target. Merging ``nightly-dev`` down
+  promotes the candidate: a fix-only cycle ends at ``2.20.1``, a cycle with a
+  feature ends at ``2.21.0``.
+
+The major component is never bumped automatically. A ``!`` subject or a
+``BREAKING CHANGE:`` footer is treated as a feature here, because an automatic
+major is an irreversible published mistake waiting for one mistyped subject
+line; a major release stays an explicit human act (tag and push it by hand).
+
+Baseline is the highest final tag in the repository, deliberately NOT restricted
+to tags reachable from HEAD. ``main``'s release tag can sit on a commit that the
+``nightly-dev`` tip does not contain, and a reachability-restricted lookup would
+then compute the next nightly from a stale baseline and hand out a version below
+the release that already shipped.
+
+Everything above the git boundary is pure and unit-tested in
+tests/test_next_version.py. Both tagging workflows call this so the policy lives
+in exactly one place, expressed in Python where it can be tested rather than in
+YAML where it cannot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+# A released version: exactly vX.Y.Z. Anything with a pre-release, post-release
+# or local segment is deliberately excluded -- the baseline must be a version
+# that actually shipped.
+FINAL_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+# A candidate this policy produces: vX.Y.ZrcN.
+RC_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)rc(\d+)$")
+
+# A conventional-commit subject introducing a feature: `feat:`, `feat(scope):`,
+# and the breaking forms `feat!:` / `feat(scope)!:`. Anchored at the start of the
+# subject so a `feat` mentioned mid-sentence in a fix's body cannot promote the
+# whole batch to a minor bump.
+FEATURE_SUBJECT = re.compile(r"^feat(\([^)]*\))?!?:", re.IGNORECASE)
+
+# A breaking change under conventional commits: any type with `!` before the
+# colon, or a `BREAKING CHANGE:` footer. Treated as a feature, not a major --
+# see the module docstring.
+BREAKING = re.compile(
+    r"^[a-z]+(\([^)]*\))?!:|^BREAKING[ -]CHANGE:", re.IGNORECASE | re.MULTILINE
+)
+
+Version = tuple[int, int, int]
+
+
+def parse_final(tag: str) -> Version | None:
+    """``(major, minor, patch)`` for a released tag, else ``None``."""
+    match = FINAL_TAG.match(tag.strip())
+    if not match:
+        return None
+    return (int(match[1]), int(match[2]), int(match[3]))
+
+
+def latest_final(tags: list[str]) -> Version:
+    """Highest released version among *tags*, or ``(0, 0, 0)`` if there is none.
+
+    ``(0, 0, 0)`` means "nothing has shipped yet", which makes the first fix-only
+    batch 0.0.1 and the first batch with a feature 0.1.0.
+    """
+    finals = [v for v in (parse_final(tag) for tag in tags) if v is not None]
+    return max(finals) if finals else (0, 0, 0)
+
+
+def has_feature(messages: list[str]) -> bool:
+    """Does any commit in *messages* introduce a feature (or break something)?
+
+    Each element is a whole commit message, so the subject is its first line;
+    the ``BREAKING CHANGE:`` footer is matched anywhere in the body.
+    """
+    for message in messages:
+        subject = message.strip().splitlines()[0] if message.strip() else ""
+        if FEATURE_SUBJECT.match(subject.strip()):
+            return True
+        if BREAKING.search(message):
+            return True
+    return False
+
+
+def target_version(base: Version, messages: list[str]) -> Version | None:
+    """The version this batch is heading for, or ``None`` if it is empty.
+
+    ``None`` is not an error: a re-run of a workflow on an already-tagged commit
+    has no commits since the baseline, and the right answer there is "nothing to
+    tag" rather than a version nobody asked for.
+    """
+    if not messages:
+        return None
+    major, minor, patch = base
+    if has_feature(messages):
+        return (major, minor + 1, 0)
+    return (major, minor, patch + 1)
+
+
+def next_rc_number(target: Version, tags: list[str]) -> int:
+    """The next candidate number for *target*: one above the highest seen.
+
+    Counts from the tags rather than from a stored counter so a deleted or
+    re-pushed tag cannot make this hand out a number that is already taken.
+    """
+    highest = 0
+    for tag in tags:
+        match = RC_TAG.match(tag.strip())
+        if not match:
+            continue
+        if (int(match[1]), int(match[2]), int(match[3])) == target:
+            highest = max(highest, int(match[4]))
+    return highest + 1
+
+
+def format_version(version: Version) -> str:
+    return f"v{version[0]}.{version[1]}.{version[2]}"
+
+
+def compute(channel: str, tags: list[str], messages: list[str]) -> str | None:
+    """The tag to create for *channel*, or ``None`` when there is nothing to tag.
+
+    Pure: every input is passed in, so the whole policy is testable without a
+    repository. ``stable`` is ``main``'s final release; ``nightly`` is the
+    candidate heading for the same target.
+    """
+    if channel not in ("stable", "nightly"):
+        raise ValueError(f"unknown channel {channel!r}")
+    target = target_version(latest_final(tags), messages)
+    if target is None:
+        return None
+    if channel == "stable":
+        return format_version(target)
+    return f"{format_version(target)}rc{next_rc_number(target, tags)}"
+
+
+# ---------------------------------------------------------------------------
+# git boundary -- the only impure part, kept as thin as possible
+# ---------------------------------------------------------------------------
+
+
+def _git(args: list[str], repo_dir: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def git_tags(repo_dir: str) -> list[str]:
+    """Every tag in the repository, unordered.
+
+    Ordering is this module's job, not git's: asking git to sort would put the
+    policy back in a shell pipeline, which is what having this file avoids.
+    """
+    return [line for line in _git(["tag"], repo_dir).splitlines() if line.strip()]
+
+
+def commit_messages(repo_dir: str, base: Version) -> list[str]:
+    """Whole commit messages on HEAD since the *base* release, newest first.
+
+    A ``(0, 0, 0)`` base means nothing has shipped, so the entire history counts.
+    NUL-delimited because a commit body contains blank lines and any line-based
+    split would chop one message into several.
+    """
+    rev_range = "HEAD" if base == (0, 0, 0) else f"{format_version(base)}..HEAD"
+    out = _git(["log", rev_range, "--format=%B%x00"], repo_dir)
+    return [chunk for chunk in out.split("\0") if chunk.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel", required=True, choices=["stable", "nightly"])
+    parser.add_argument("--repo-dir", default=".")
+    args = parser.parse_args(argv)
+
+    tags = git_tags(args.repo_dir)
+    messages = commit_messages(args.repo_dir, latest_final(tags))
+    tag = compute(args.channel, tags, messages)
+    if tag is None:
+        return 0
+    print(tag)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The bug

`auto-tag.yml` forced `cz bump --increment MINOR` on every merge into `main`, so the second component moved regardless of what was in the batch, and `main` could never cut a non-zero patch. Today that took the project **2.20.0 → 2.22.0 in about an hour**, across two bugfix merges with no feature between them.

The forcing carried a comment describing itself as intentional — *"It is forced rather than inferred from commit messages… Do not add breaking-change detection here"* — and `README.md` documented the consequence as policy (*"`main` is stable and always `X.Y.0`"*). Per @bandrel both of those describe a bug rather than a requirement, so they're gone.

## The policy now

Ordinary semver, derived from the commits since the last release:

| Batch contains | Heads for |
|---|---|
| any `feat` (incl. `feat!`, `BREAKING CHANGE:`) | `X.(Y+1).0` |
| only `fix` / `docs` / `chore` / `test` / … | `X.Y.(Z+1)` |
| nothing | no tag |

`nightly-dev` cuts release candidates for whichever version the batch is heading toward — `v2.20.1rc1`, `v2.20.1rc2`, … — and `main` promotes that same target to its final release.

Replaying this afternoon's history through the new policy gives **2.20.1** and **2.21.0** instead of 2.21.0 and 2.22.0.

## Why candidates aim one version *forward*

This is the detail both previous schemes got wrong, so it's asserted against the real PEP 440 parser rather than by eyeball:

```
2.20.0  <  2.20.1rc1  <  2.20.1rc2  <  2.20.1  <  2.21.0rc1  <  2.21.0
```

- The `vX.Y.0-rc.N` scheme aimed candidates at the *current* cycle's version, so a candidate sorted **below** the release it was heading for.
- Replacing them with ordinary final versions (the current scheme, and #221's direction) dropped the pre-release marker entirely, so anything ranking raw versions read a nightly as the **latest release**.

Aiming one version forward fixes both at once: a candidate is newer than what shipped before it, older than what it becomes, and still a pre-release.

## Major stays manual

A `!` subject or a `BREAKING CHANGE:` footer counts as a **feature**, not a major. An automatic major is one mistyped subject line away from an irreversible published release, so it remains an explicit human act. Flagging this as the one place I chose the conservative reading rather than full semver inference — easy to change if you'd rather it be automatic.

## A structural bonus

Both channels now compute from the same target, so the two workflows can no longer disagree about a version. The double-tag that started today — `v2.19.15` and `v2.20.0` on one commit, from two independent series, which put every upgrading user into an unbreakable upgrade loop (#234) — is **structurally impossible** under this scheme.

## Testing

The policy moved out of YAML into `tools/next_version.py`, because YAML cannot be unit-tested. 43 tests in `tests/test_next_version.py` cover the baseline (candidates and dev builds excluded; numeric not lexical comparison), feature detection (including that the word "feature" in a fix's *body* does not promote the batch), target selection, candidate numbering (per-target, and surviving a deleted tag), and the ordering above.

`tests/test_release_versioning.py` was rewritten to match. Its old form stubbed `uvx` and could only prove the step *parsed* a fixed string — it could never have caught the policy being wrong. The steps now run against real repositories with a real copy of the policy module, so a wrong **value** fails a test; the `main-fixes-patch` case is exactly the bug this PR fixes. The anti-hand-rolled-versioning invariant is preserved and retargeted, with `cz bump` added to its denylist.

Both workflows also now skip cleanly on an empty batch instead of running `git tag ""` — caught by one of the new tests after a string replacement of mine silently no-opped, which is the argument for behavioral tests over substring ones in one sentence.

The now-dead `astral-sh/setup-uv` step is removed from both tag workflows since nothing there uses `uv` any more.

## Relationship to #221

#221 rewrites these same two files with a different policy (*"the patch component is always `0`"* for stable, nightlies as ordinary finals). Per @bandrel that direction is also not wanted, so this supersedes rather than builds on it. Happy to rebase onto it instead if that's preferred.

Full suite: 2113 passed. `ruff` and `ty` clean on everything in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

