### PR TITLE
fix(lint): bring tools/, packaging/ and hate_crack.py into the lint scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
-      # tools/next_version.py is listed individually rather than by directory:
-      # it is executed by both tagging workflows, so it has to be held to the
-      # same standard, but the rest of tools/ predates linting and does not pass
-      # yet. Widening to all of tools/ is issue #237.
       - name: Ruff (lint)
-        run: uv run ruff check hate_crack tests tools/next_version.py
+        run: uv run ruff check hate_crack tests tools packaging
 
       - name: Ruff (format)
-        run: uv run ruff format --check hate_crack tests tools/next_version.py
+        run: uv run ruff format --check hate_crack tests tools packaging
 
       - name: Ty
         # ty 0.0.63 fails CI on warning-level diagnostics by default;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
         run: uv sync --dev
 
       - name: Ruff (lint)
-        run: uv run ruff check hate_crack tests tools packaging
+        run: uv run ruff check hate_crack tests tools packaging hate_crack.py
 
       - name: Ruff (format)
-        run: uv run ruff format --check hate_crack tests tools packaging
+        run: uv run ruff format --check hate_crack tests tools packaging hate_crack.py
 
       - name: Ty
         # ty 0.0.63 fails CI on warning-level diagnostics by default;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,32 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   unprompted also means scheduled and piped runs get repaired, which is exactly
   where a prompt would hang or be dismissed forever.
 
+### Fixed
+- **`tools/`, `packaging/`, and the `hate_crack.py` entry point are now linted
+  everywhere, and a guard proves it.** No lint entry point named `tools/` or
+  `packaging/` at all, so an `F541` and a formatting drift sat unnoticed in
+  `tools/ollama_benchmark.py` until someone ran ruff by hand (issue #237). The
+  Makefile, `prek.toml`, and `.github/workflows/ci.yml` now all scope ruff to
+  `hate_crack tests tools packaging hate_crack.py`, and
+  `tests/test_lint_scope.py` reads those files directly so it fails the moment
+  any of them drifts from the others.
+
+  `hate_crack.py` -- the documented entry point (README.md) -- was invisible to
+  the drift guard itself: it only ever swept directories, so a root-level
+  module could never be flagged as unlinted even after the scope above was
+  widened. The guard now sweeps root `.py` files too. `hate_crack.py`'s 32
+  `F821`s are an intentional consequence of its `globals().setdefault()`
+  re-export shim (ruff can't see the runtime copy from `hate_crack/main.py`),
+  so they're silenced explicitly via `[tool.ruff.lint.per-file-ignores]` rather
+  than left to accumulate unexplained.
+
+  Two more gaps in the guard itself: `test_both_lint_and_format_are_checked_
+  everywhere` only asserted a command count, so two `ruff check` lines and zero
+  `ruff format --check` lines would still pass -- it now checks the verbs
+  actually present. And `test_the_declared_scope_actually_passes` ran `python
+  -m ruff` instead of `uv run ruff`, which can resolve a different ruff
+  entirely than every real gate uses.
+
   A key already set in the `.env` keeps that value -- the `.env` is the live
   source, and copying the stale copy over it would silently revert a setting in
   use -- but is still pruned, since it was being ignored. A wrongly-typed value

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ coverage:
 	HATE_CRACK_SKIP_INIT=$${HATE_CRACK_SKIP_INIT:-1} uv run pytest --cov=hate_crack --cov-report=term-missing
 
 ruff:
-	uv run ruff check hate_crack
+	uv run ruff check hate_crack tests tools packaging
+	uv run ruff format --check hate_crack tests tools packaging
 
 ty:
 	uv run ty check hate_crack

--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,8 @@ coverage:
 	HATE_CRACK_SKIP_INIT=$${HATE_CRACK_SKIP_INIT:-1} uv run pytest --cov=hate_crack --cov-report=term-missing
 
 ruff:
-	uv run ruff check hate_crack tests tools packaging
-	uv run ruff format --check hate_crack tests tools packaging
+	uv run ruff check hate_crack tests tools packaging hate_crack.py
+	uv run ruff format --check hate_crack tests tools packaging hate_crack.py
 
 # ty's scope is deliberately narrower than ruff's: it reports 48 pre-existing
 # diagnostics on hate_crack alone, so this target already fails. CI survives

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,13 @@ ruff:
 	uv run ruff check hate_crack tests tools packaging
 	uv run ruff format --check hate_crack tests tools packaging
 
+# ty's scope is deliberately narrower than ruff's: it reports 48 pre-existing
+# diagnostics on hate_crack alone, so this target already fails. CI survives
+# only because it passes --exit-zero-on-warning, which this does not. Widening
+# to tools/ and packaging/ would add 3 more (an unresolved setuptools import and
+# two in packaging/pypi-placeholder/verify_placeholder.py) without fixing any of
+# the 48. Clearing those is its own piece of work -- do not bundle it into a
+# lint-scope change. See issue #237.
 ty:
 	uv run ty check hate_crack
 

--- a/README.md
+++ b/README.md
@@ -396,13 +396,13 @@ Before pushing changes, run these checks locally. Use `make lint` for everything
 ```bash
 make ruff
 # or manually:
-uv run ruff check hate_crack
+uv run ruff check hate_crack tests tools packaging hate_crack.py
 ```
 
 Auto-fix issues:
 ```bash
-uv run ruff format hate_crack
-uv run ruff check --fix hate_crack
+uv run ruff format hate_crack tests tools packaging hate_crack.py
+uv run ruff check --fix hate_crack tests tools packaging hate_crack.py
 ```
 
 **ty (type checking):**

--- a/prek.toml
+++ b/prek.toml
@@ -4,7 +4,7 @@ repo = "local"
 [[repos.hooks]]
 id = "ruff"
 name = "ruff"
-entry = "uv run ruff check hate_crack"
+entry = "uv run ruff check hate_crack tests tools packaging"
 language = "system"
 stages = ["pre-push"]
 pass_filenames = false
@@ -13,7 +13,7 @@ always_run = true
 [[repos.hooks]]
 id = "ruff-format"
 name = "ruff-format"
-entry = "uv run ruff format --check hate_crack"
+entry = "uv run ruff format --check hate_crack tests tools packaging"
 language = "system"
 stages = ["pre-push"]
 pass_filenames = false

--- a/prek.toml
+++ b/prek.toml
@@ -4,7 +4,7 @@ repo = "local"
 [[repos.hooks]]
 id = "ruff"
 name = "ruff"
-entry = "uv run ruff check hate_crack tests tools packaging"
+entry = "uv run ruff check hate_crack tests tools packaging hate_crack.py"
 language = "system"
 stages = ["pre-push"]
 pass_filenames = false
@@ -13,7 +13,7 @@ always_run = true
 [[repos.hooks]]
 id = "ruff-format"
 name = "ruff-format"
-entry = "uv run ruff format --check hate_crack tests tools packaging"
+entry = "uv run ruff format --check hate_crack tests tools packaging hate_crack.py"
 language = "system"
 stages = ["pre-push"]
 pass_filenames = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,11 @@ local_scheme = "no-local-version"
 #   neither setuptools_scm nor any existing tooling recognises and would break
 #   continuity with every tag already published.
 #
-# The bump size is NOT inferred from commit messages. Each workflow forces it
-# with --increment, because in this repo the branch decides the bump: main is
-# MINOR (stable X.Y.0), nightly-dev is PATCH (rolling X.Y.1, X.Y.2, ...).
+# The bump size is derived from commit messages via tools/next_version.py
+# (see that module's docstring): any `feat` commit since the last release
+# means the batch is heading for MINOR (X.(Y+1).0), and a batch of only
+# fixes, docs and chores is heading for PATCH (X.Y.(Z+1)). Both tagging
+# workflows call that script rather than hand-rolling `cz bump --increment`.
 version_provider = "scm"
 tag_format = "v$version"
 # No CHANGELOG.md rewrite on bump; the changelog is maintained by hand.
@@ -77,6 +79,17 @@ exclude = [
 # behaviour-neutral. Broadening the ruleset is a separate cleanup, not
 # a dep-bump side effect.
 select = ["E4", "E7", "E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# hate_crack.py's `for _name, _value in _main.__dict__.items(): ...
+# globals().setdefault(...)` shim populates names like `_attacks` at import
+# time by copying them off hate_crack/main.py's module dict. Ruff's static
+# analysis can't see that runtime copy, so every use of those names below the
+# shim reads as undefined: 32 F821s total, 26 for `_attacks` and one each for
+# `show_results`, `show_readme`, `quit_hc`, `notifications_submenu`,
+# `hashview_api`, and `export_excel`. The shim is the point of this file;
+# silencing F821 here is honest, not a cover for a real bug.
+"hate_crack.py" = ["F821"]
 
 [tool.bandit]
 # hate_crack shells out to hashcat and its helper binaries extensively, so the

--- a/tests/test_lint_scope.py
+++ b/tests/test_lint_scope.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import re
 import subprocess
-import sys
 import tomllib
 from pathlib import Path
 
@@ -28,10 +27,15 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # fails until the four entry points are updated too.
 LINTED_DIRS = ("hate_crack", "tests", "tools", "packaging")
 
+# Root-level .py files (siblings of the directories above) that must be
+# linted too. hate_crack.py is the documented entry point (README.md) and was
+# missed entirely by the directory-only scan below -- the exact #237 failure
+# mode, still open for one file.
+LINTED_ROOT_FILES = ("hate_crack.py",)
+
 # Directories excluded on purpose, with the reason. Anything not in either list
 # trips test_no_first_party_python_is_unlinted.
 NOT_LINTED = {
-    ".venv": "third-party",
     "build": "generated",
     "dist": "generated",
     "hashcat-utils": "vendored submodule",
@@ -40,7 +44,7 @@ NOT_LINTED = {
     "pcfg_cracker": "vendored submodule",
     "princeprocessor": "vendored submodule",
     "PACK": "vendored, python2",
-    "hashcat_debug": "vendored submodule",
+    "hashcat_debug": "gitignored runtime debug-log directory (.gitignore), not tracked",
     "lima": "vm config, no first-party python",
     "masks": "data",
     "rules": "data",
@@ -48,35 +52,40 @@ NOT_LINTED = {
     "__pycache__": "generated",
 }
 
+# Root-level .py files excluded on purpose, with the reason. Same discipline
+# as NOT_LINTED, for the files LINTED_ROOT_FILES doesn't cover.
+NOT_LINTED_ROOT_FILES: dict[str, str] = {}
 
-def _ruff_commands() -> dict[str, list[str]]:
-    """Every ruff invocation in the repo's config, keyed by where it lives."""
-    found: dict[str, list[str]] = {}
+
+def _ruff_commands() -> dict[str, list[tuple[str, str]]]:
+    """Every ruff invocation in the repo's config, keyed by where it lives.
+
+    Each entry is a (verb, scope) pair, e.g. ("check", "hate_crack tests") or
+    ("format --check", "hate_crack tests"), so callers can check both which
+    scope is used and which verb was actually run.
+    """
+    found: dict[str, list[tuple[str, str]]] = {}
 
     makefile = (REPO_ROOT / "Makefile").read_text()
-    found["Makefile"] = re.findall(
-        r"uv run ruff (?:check|format[^\n]*?) ([^\n]+)", makefile
-    )
+    found["Makefile"] = [
+        (verb, scope.strip())
+        for verb, scope in re.findall(
+            r"uv run ruff (check|format(?: --check)?) ([^\n]+)", makefile
+        )
+    ]
 
     prek = tomllib.loads((REPO_ROOT / "prek.toml").read_text())
     entries = [
         hook["entry"]
-        for hook in prek.get("repos", [{}])[0].get("hooks", [])
+        for repo in prek.get("repos", [])
+        for hook in repo.get("hooks", [])
         if "ruff" in hook.get("entry", "")
     ]
-    # prek.toml uses [[repos.hooks]] tables; collect from wherever they landed.
-    if not entries:
-        entries = [
-            h["entry"]
-            for repo in prek.get("repos", [])
-            for h in repo.get("hooks", [])
-            if "ruff" in h.get("entry", "")
-        ]
     found["prek.toml"] = [
-        e.split("--check")[-1].strip()
-        if "--check" in e
-        else e.split("check")[-1].strip()
+        (m.group(1), m.group(2).strip())
         for e in entries
+        for m in [re.search(r"ruff (check|format(?: --check)?) (.+)", e)]
+        if m
     ]
 
     ci = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text())
@@ -87,10 +96,10 @@ def _ruff_commands() -> dict[str, list[str]]:
         if "run" in step and "ruff" in step["run"]
     ]
     found["ci.yml"] = [
-        r.split("--check")[-1].strip()
-        if "--check" in r
-        else r.split("check")[-1].strip()
+        (m.group(1), m.group(2).strip())
         for r in ci_runs
+        for m in [re.search(r"ruff (check|format(?: --check)?) (.+)", r)]
+        if m
     ]
     return found
 
@@ -99,7 +108,7 @@ def _normalize(scope: str) -> tuple[str, ...]:
     return tuple(sorted(part for part in scope.split() if not part.startswith("-")))
 
 
-EXPECTED = tuple(sorted(LINTED_DIRS))
+EXPECTED = tuple(sorted(LINTED_DIRS + LINTED_ROOT_FILES))
 
 
 @pytest.mark.parametrize("source", ["Makefile", "prek.toml", "ci.yml"])
@@ -107,7 +116,7 @@ def test_every_ruff_invocation_uses_the_same_scope(source):
     """A local gate narrower than CI means `make check` passing proves nothing."""
     commands = _ruff_commands()[source]
     assert commands, f"no ruff invocation found in {source}"
-    for scope in commands:
+    for _verb, scope in commands:
         assert _normalize(scope) == EXPECTED, (
             f"{source} lints {_normalize(scope)}, expected {EXPECTED}. All four "
             "entry points must agree or a finding slips through the narrow one."
@@ -117,40 +126,62 @@ def test_every_ruff_invocation_uses_the_same_scope(source):
 def test_both_lint_and_format_are_checked_everywhere():
     """The Makefile once ran `ruff check` but not `ruff format --check`, so a
     formatting-only problem passed locally and failed in CI."""
+    required = {"check", "format --check"}
     for source, commands in _ruff_commands().items():
         assert len(commands) >= 2, (
             f"{source} has {len(commands)} ruff invocation(s); both `check` and "
             "`format --check` are required"
         )
+        verbs = {verb for verb, _scope in commands}
+        missing = required - verbs
+        assert not missing, (
+            f"{source} is missing {missing}; found verbs {verbs}. Both `ruff "
+            "check` and `ruff format --check` must run, or a formatting-only "
+            "problem passes locally and fails in CI."
+        )
 
 
 def test_no_first_party_python_is_unlinted():
-    """The actual failure in #237: a directory nobody thought to mention.
+    """The actual failure in #237: a directory (or root module) nobody thought
+    to mention.
 
-    Any top-level directory containing .py files must be either linted or
-    explicitly excused, so a new package cannot be silently unlinted.
+    Any top-level directory or root-level .py file containing/being
+    first-party Python must be either linted or explicitly excused, so a new
+    package or module cannot be silently unlinted.
     """
     unaccounted = []
     for child in sorted(REPO_ROOT.iterdir()):
-        if not child.is_dir() or child.name.startswith("."):
+        if child.name.startswith("."):
             continue
-        if child.name in NOT_LINTED or child.name in LINTED_DIRS:
-            continue
-        if any(child.rglob("*.py")):
+        if child.is_dir():
+            if child.name in NOT_LINTED or child.name in LINTED_DIRS:
+                continue
+            if any(child.rglob("*.py")):
+                unaccounted.append(child.name)
+        elif child.suffix == ".py":
+            if child.name in NOT_LINTED_ROOT_FILES or child.name in LINTED_ROOT_FILES:
+                continue
             unaccounted.append(child.name)
     assert not unaccounted, (
-        f"these directories hold Python and are neither linted nor excused: "
-        f"{unaccounted}. Add them to LINTED_DIRS and to all four entry points, "
-        "or to NOT_LINTED with a reason."
+        f"these hold Python and are neither linted nor excused: {unaccounted}. "
+        "Add directories to LINTED_DIRS, root-level files to LINTED_ROOT_FILES, "
+        "and update all four entry points -- or add an excuse to NOT_LINTED / "
+        "NOT_LINTED_ROOT_FILES with a reason."
     )
 
 
 def test_the_declared_scope_actually_passes():
     """Belt and braces: run ruff over the declared scope and require success, so
-    the config cannot claim a scope that does not hold."""
+    the config cannot claim a scope that does not hold.
+
+    Invoked as `uv run ruff`, matching every real gate (Makefile, prek.toml,
+    ci.yml) -- a bare `python -m ruff` can resolve a different ruff than `uv`
+    manages, which would make this test's pass/fail disagree with the gates
+    it is meant to police.
+    """
     for args in (["check"], ["format", "--check"]):
         result = subprocess.run(
-            [sys.executable, "-m", "ruff", *args, *LINTED_DIRS],
+            ["uv", "run", "ruff", *args, *LINTED_DIRS, *LINTED_ROOT_FILES],
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,

--- a/tests/test_lint_scope.py
+++ b/tests/test_lint_scope.py
@@ -1,0 +1,161 @@
+"""The lint entry points must agree, and nothing may sit outside them.
+
+Issue #237: tools/ was linted by nothing at all -- the Makefile and both
+pre-push hooks scoped to hate_crack, CI added tests -- so an F541 and a
+formatting drift sat in tools/ollama_benchmark.py until someone ran ruff by
+hand. The failure mode is silence: a new top-level package is simply never
+mentioned, and nobody finds out.
+
+These tests read the real config files rather than a copy of the intended
+scope, so they fail when the files disagree with each other.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Every directory holding first-party Python that must be linted. Adding a new
+# top-level package means adding it here, which is the point: the test then
+# fails until the four entry points are updated too.
+LINTED_DIRS = ("hate_crack", "tests", "tools", "packaging")
+
+# Directories excluded on purpose, with the reason. Anything not in either list
+# trips test_no_first_party_python_is_unlinted.
+NOT_LINTED = {
+    ".venv": "third-party",
+    "build": "generated",
+    "dist": "generated",
+    "hashcat-utils": "vendored submodule",
+    "HashcatRosetta": "vendored submodule",
+    "omen": "vendored submodule",
+    "pcfg_cracker": "vendored submodule",
+    "princeprocessor": "vendored submodule",
+    "PACK": "vendored, python2",
+    "hashcat_debug": "vendored submodule",
+    "lima": "vm config, no first-party python",
+    "masks": "data",
+    "rules": "data",
+    "hate_crack.egg-info": "generated",
+    "__pycache__": "generated",
+}
+
+
+def _ruff_commands() -> dict[str, list[str]]:
+    """Every ruff invocation in the repo's config, keyed by where it lives."""
+    found: dict[str, list[str]] = {}
+
+    makefile = (REPO_ROOT / "Makefile").read_text()
+    found["Makefile"] = re.findall(
+        r"uv run ruff (?:check|format[^\n]*?) ([^\n]+)", makefile
+    )
+
+    prek = tomllib.loads((REPO_ROOT / "prek.toml").read_text())
+    entries = [
+        hook["entry"]
+        for hook in prek.get("repos", [{}])[0].get("hooks", [])
+        if "ruff" in hook.get("entry", "")
+    ]
+    # prek.toml uses [[repos.hooks]] tables; collect from wherever they landed.
+    if not entries:
+        entries = [
+            h["entry"]
+            for repo in prek.get("repos", [])
+            for h in repo.get("hooks", [])
+            if "ruff" in h.get("entry", "")
+        ]
+    found["prek.toml"] = [
+        e.split("--check")[-1].strip()
+        if "--check" in e
+        else e.split("check")[-1].strip()
+        for e in entries
+    ]
+
+    ci = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text())
+    ci_runs = [
+        step["run"]
+        for job in ci["jobs"].values()
+        for step in job.get("steps", [])
+        if "run" in step and "ruff" in step["run"]
+    ]
+    found["ci.yml"] = [
+        r.split("--check")[-1].strip()
+        if "--check" in r
+        else r.split("check")[-1].strip()
+        for r in ci_runs
+    ]
+    return found
+
+
+def _normalize(scope: str) -> tuple[str, ...]:
+    return tuple(sorted(part for part in scope.split() if not part.startswith("-")))
+
+
+EXPECTED = tuple(sorted(LINTED_DIRS))
+
+
+@pytest.mark.parametrize("source", ["Makefile", "prek.toml", "ci.yml"])
+def test_every_ruff_invocation_uses_the_same_scope(source):
+    """A local gate narrower than CI means `make check` passing proves nothing."""
+    commands = _ruff_commands()[source]
+    assert commands, f"no ruff invocation found in {source}"
+    for scope in commands:
+        assert _normalize(scope) == EXPECTED, (
+            f"{source} lints {_normalize(scope)}, expected {EXPECTED}. All four "
+            "entry points must agree or a finding slips through the narrow one."
+        )
+
+
+def test_both_lint_and_format_are_checked_everywhere():
+    """The Makefile once ran `ruff check` but not `ruff format --check`, so a
+    formatting-only problem passed locally and failed in CI."""
+    for source, commands in _ruff_commands().items():
+        assert len(commands) >= 2, (
+            f"{source} has {len(commands)} ruff invocation(s); both `check` and "
+            "`format --check` are required"
+        )
+
+
+def test_no_first_party_python_is_unlinted():
+    """The actual failure in #237: a directory nobody thought to mention.
+
+    Any top-level directory containing .py files must be either linted or
+    explicitly excused, so a new package cannot be silently unlinted.
+    """
+    unaccounted = []
+    for child in sorted(REPO_ROOT.iterdir()):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        if child.name in NOT_LINTED or child.name in LINTED_DIRS:
+            continue
+        if any(child.rglob("*.py")):
+            unaccounted.append(child.name)
+    assert not unaccounted, (
+        f"these directories hold Python and are neither linted nor excused: "
+        f"{unaccounted}. Add them to LINTED_DIRS and to all four entry points, "
+        "or to NOT_LINTED with a reason."
+    )
+
+
+def test_the_declared_scope_actually_passes():
+    """Belt and braces: run ruff over the declared scope and require success, so
+    the config cannot claim a scope that does not hold."""
+    for args in (["check"], ["format", "--check"]):
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", *args, *LINTED_DIRS],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"ruff {' '.join(args)} fails on the declared scope:\n"
+            f"{result.stdout}\n{result.stderr}"
+        )

--- a/tools/ollama_benchmark.py
+++ b/tools/ollama_benchmark.py
@@ -85,12 +85,14 @@ def filter_candidates(response_text):
 def benchmark_model(url, model, prompt, num_ctx):
     """Run the prompt against a single model at a given context size. Returns a results dict."""
     api_url = f"{url}/api/generate"
-    payload = json.dumps({
-        "model": model,
-        "prompt": prompt,
-        "stream": False,
-        "options": {"num_ctx": num_ctx},
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"num_ctx": num_ctx},
+        }
+    ).encode("utf-8")
 
     result = {
         "model": model,
@@ -116,7 +118,7 @@ def benchmark_model(url, model, prompt, num_ctx):
     except urllib.error.HTTPError as e:
         if e.code == 404:
             if not pull_model(url, model):
-                result["error"] = f"could not pull model"
+                result["error"] = "could not pull model"
                 return result
             # Retry after pull
             req = urllib.request.Request(
@@ -164,19 +166,30 @@ def benchmark_model(url, model, prompt, num_ctx):
 
 def print_table(results):
     """Print a formatted comparison table."""
-    headers = ["Model", "num_ctx", "Time (s)", "Tok/s", "Candidates", "Unique", "Refusal", "Error"]
+    headers = [
+        "Model",
+        "num_ctx",
+        "Time (s)",
+        "Tok/s",
+        "Candidates",
+        "Unique",
+        "Refusal",
+        "Error",
+    ]
     rows = []
     for r in results:
-        rows.append([
-            r["model"],
-            str(r["num_ctx"]),
-            str(r["response_time_s"] or "-"),
-            str(r["tokens_per_sec"] or "-"),
-            str(r["candidate_count"]),
-            str(r["unique_candidates"]),
-            "YES" if r["refusal"] else "no",
-            r["error"] or "",
-        ])
+        rows.append(
+            [
+                r["model"],
+                str(r["num_ctx"]),
+                str(r["response_time_s"] or "-"),
+                str(r["tokens_per_sec"] or "-"),
+                str(r["candidate_count"]),
+                str(r["unique_candidates"]),
+                "YES" if r["refusal"] else "no",
+                r["error"] or "",
+            ]
+        )
 
     # Calculate column widths
     col_widths = [len(h) for h in headers]
@@ -247,9 +260,11 @@ def main():
             if r["error"]:
                 print(f"  Error: {r['error']}")
             else:
-                print(f"  {r['response_time_s']}s, {r['tokens_per_sec']} tok/s, "
-                      f"{r['candidate_count']} candidates ({r['unique_candidates']} unique)"
-                      f"{', REFUSED' if r['refusal'] else ''}")
+                print(
+                    f"  {r['response_time_s']}s, {r['tokens_per_sec']} tok/s, "
+                    f"{r['candidate_count']} candidates ({r['unique_candidates']} unique)"
+                    f"{', REFUSED' if r['refusal'] else ''}"
+                )
                 if args.stdout:
                     print(f"\n--- Response from {model} (num_ctx={num_ctx}) ---")
                     print(r["response"])


### PR DESCRIPTION
Closes #237.

## The problem

`tools/` was linted by **nothing**. The `Makefile` and both prek pre-push hooks scoped to `hate_crack`; CI added `tests` plus the single file `tools/next_version.py` that #236 had introduced. `packaging/` was outside all four. So findings accumulated there until someone ran ruff by hand — an `F541` and a file with formatter drift, both in `tools/ollama_benchmark.py`.

The failure mode is silence. A directory nobody thought to mention is simply never checked, and nothing tells you.

## What this does

1. **Clears the two existing findings** (`fix(tools)`), in their own commit so the config change stays config-only and this one reads as the no-op it is. Formatted the single file rather than the directory — running the formatter over `tools/` has already pulled an unrelated 55-line diff into a commit here once.
2. **One shared scope in every entry point** (`ci`): `hate_crack tests tools packaging hate_crack.py`, byte-identical across `Makefile`, both `prek.toml` hooks, and both `ci.yml` steps. `ci.yml`'s per-file listing collapses into the directory, and the comment explaining that workaround goes with it. The `Makefile` also gains the `ruff format --check` it never ran — a formatting-only problem used to pass locally and fail in CI.
3. **A drift guard** (`test`): `tests/test_lint_scope.py` reads the real `Makefile`, `prek.toml` and `ci.yml` rather than a copy of the intended scope, so it fails when they disagree; asserts both `check` and `format --check` are present in each; and fails when any top-level directory *or root-level `.py` file* holding Python is neither linted nor explicitly excused, with a reason string per exclusion.
4. **Documents `ty`'s narrower scope** (`docs`) instead of leaving it looking like an oversight — which is exactly how `tools/` was missed.

## `ty` is deliberately untouched

Still `hate_crack` everywhere. It reports 48 pre-existing diagnostics and the `Makefile` target has no `--exit-zero-on-warning`, so `make ty` already fails; widening it would add 3 more (an unresolved `setuptools` import and two in `packaging/pypi-placeholder/verify_placeholder.py`) without fixing any of the 48. Clearing those is its own piece of work. The Makefile now says so.

## What review caught

The whole-branch review found the branch had left its own bug open: **`hate_crack.py`** — the documented entry point at the repo root — was covered by no scope (32 `F821`s while `ruff check` on the declared scope reported clean), and the guard's sweep skipped non-directories, so it could never have seen it. A guard certifying a repo it structurally cannot inspect is worse than no guard. Both halves are fixed: the file is in scope, its `F821`s are silenced by a documented `per-file-ignores` entry rather than silently (they come from the `globals().setdefault()` re-export shim, which ruff's static analysis cannot follow), and the sweep now covers root-level files.

Review also caught that `test_both_lint_and_format_are_checked_everywhere` asserted `len(commands) >= 2` while the parser discarded the verb — so two `check` lines and zero `format --check` lines passed. It now compares verb sets. Both of those I reproduced independently before dispatching a fix; both now fail correctly when the thing they guard is broken.

Also swept up: `README.md` still taught the narrow scope as the manual equivalent of `make ruff`, and `pyproject.toml`'s commitizen comment still claimed the bump size is "NOT inferred from commit messages", which `tools/next_version.py` has contradicted since earlier today.

## Verification

Full suite 2116 passed, 41 skipped (baseline 2110 + 6 new). `ruff check` and `ruff format --check` pass on the full scope. `make ty` still fails on the 48, as documented. `tools/next_version.py --channel stable` reports `v2.22.2` — a patch, since no commit here is a `feat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
