### PR TITLE
fix(cli): name the parser so `-m` invocation reports hate_crack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 ## [Unreleased]
 
 ### Fixed
+- **`python -m hate_crack --help` no longer calls itself `__main__.py`.** The
+  parser took its program name from whatever argparse inferred, which is the
+  module filename under `-m`. The console script was unaffected, since argparse
+  derives the name from the script basename there, so the wrong name only ever
+  showed up on the module invocation path. The name is now stated explicitly.
+
+  The existing coverage in `test_installed_tool_execution.py` could not catch
+  this: it invoked the tool through a bare `hate_crack` on `PATH`, which resolves
+  to the console script and therefore reads correctly either way. Worse, `PATH`
+  is not guaranteed to point at this checkout — an unrelated install elsewhere on
+  the machine would silently become the thing under test, and did. Those tests now
+  run the console script belonging to the interpreter running them, and a new test
+  covers the `-m` path that actually regressed.
+
 - **Release versions now reflect what is in the batch.** `auto-tag.yml` forced
   `cz bump --increment MINOR` on every merge into `main`, so the second component
   moved regardless of content and `main` could never produce an `X.Y.Z` with a

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -6002,7 +6002,8 @@ def main():
 
     def _build_parser(include_positional, include_subcommands):
         parser = argparse.ArgumentParser(
-            description="hate_crack - Hashcat automation and wordlist management tool"
+            prog="hate_crack",
+            description="hate_crack - Hashcat automation and wordlist management tool",
         )
         if include_positional:
             parser.add_argument(

--- a/tests/test_installed_tool_execution.py
+++ b/tests/test_installed_tool_execution.py
@@ -5,14 +5,21 @@ Verifies that the tool can find assets from any working directory.
 
 import subprocess
 import os
+import sys
 import tempfile
-import shutil
 import pytest
 
 
+# Resolve the console script belonging to the interpreter running the tests
+# rather than taking whatever "hate_crack" is first on PATH: an unrelated
+# install elsewhere on the system would otherwise be the thing under test.
+ENTRY_POINT = os.path.join(os.path.dirname(sys.executable), "hate_crack")
+
+
 @pytest.mark.skipif(
-    not shutil.which("hate_crack"),
-    reason="hate_crack not installed as a tool (run 'make install' first)",
+    not os.path.exists(ENTRY_POINT),
+    reason=f"hate_crack console script not present at {ENTRY_POINT} "
+    "(run 'make install' first)",
 )
 class TestInstalledToolExecution:
     """Test suite for execution of installed hate_crack tool."""
@@ -21,7 +28,7 @@ class TestInstalledToolExecution:
         """Test that --help works when run from home directory."""
         home_dir = os.path.expanduser("~")
         result = subprocess.run(
-            ["hate_crack", "--help"],
+            [ENTRY_POINT, "--help"],
             cwd=home_dir,
             capture_output=True,
             text=True,
@@ -34,7 +41,7 @@ class TestInstalledToolExecution:
     def test_help_from_tmp_directory(self):
         """Test that --help works when run from /tmp directory."""
         result = subprocess.run(
-            ["hate_crack", "--help"],
+            [ENTRY_POINT, "--help"],
             cwd="/tmp",
             capture_output=True,
             text=True,
@@ -47,7 +54,7 @@ class TestInstalledToolExecution:
         """Test that --help works when run from a temporary directory."""
         with tempfile.TemporaryDirectory() as tmpdir:
             result = subprocess.run(
-                ["hate_crack", "--help"],
+                [ENTRY_POINT, "--help"],
                 cwd=tmpdir,
                 capture_output=True,
                 text=True,
@@ -59,7 +66,7 @@ class TestInstalledToolExecution:
     def test_help_from_root_directory(self):
         """Test that --help works when run from root directory."""
         result = subprocess.run(
-            ["hate_crack", "--help"], cwd="/", capture_output=True, text=True, timeout=5
+            [ENTRY_POINT, "--help"], cwd="/", capture_output=True, text=True, timeout=5
         )
         assert result.returncode == 0
         assert "usage: hate_crack" in result.stdout
@@ -68,7 +75,7 @@ class TestInstalledToolExecution:
         """Test that --debug flag works from home directory."""
         home_dir = os.path.expanduser("~")
         result = subprocess.run(
-            ["hate_crack", "--debug", "--help"],
+            [ENTRY_POINT, "--debug", "--help"],
             cwd=home_dir,
             capture_output=True,
             text=True,
@@ -81,7 +88,7 @@ class TestInstalledToolExecution:
         """Test that there are no error messages on startup from home."""
         home_dir = os.path.expanduser("~")
         result = subprocess.run(
-            ["hate_crack", "--help"],
+            [ENTRY_POINT, "--help"],
             cwd=home_dir,
             capture_output=True,
             text=True,
@@ -101,7 +108,7 @@ class TestInstalledToolExecution:
         with tempfile.TemporaryDirectory() as tmpdir:
             # Run from temp directory (not a repo)
             result = subprocess.run(
-                ["hate_crack", "--help"],
+                [ENTRY_POINT, "--help"],
                 cwd=tmpdir,
                 capture_output=True,
                 text=True,
@@ -121,7 +128,7 @@ class TestInstalledToolExecution:
 
         for directory in directories:
             result = subprocess.run(
-                ["hate_crack", "--help"],
+                [ENTRY_POINT, "--help"],
                 cwd=directory,
                 capture_output=True,
                 text=True,
@@ -145,7 +152,7 @@ class TestInstalledToolExecution:
                 continue
 
             result = subprocess.run(
-                ["hate_crack", "--help"],
+                [ENTRY_POINT, "--help"],
                 cwd=directory,
                 capture_output=True,
                 text=True,
@@ -156,3 +163,22 @@ class TestInstalledToolExecution:
                 f"Tool failed from {directory}. "
                 f"stdout: {result.stdout}, stderr: {result.stderr}"
             )
+
+
+def test_module_invocation_reports_tool_name_in_usage():
+    """`python -m hate_crack` must not advertise itself as `__main__.py`.
+
+    The console script gets the right name for free, because argparse derives
+    it from the script basename; only module invocation needs an explicit
+    prog=, so only this path guards against regressing it.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "hate_crack", "--help"],
+        cwd=os.path.expanduser("~"),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "usage: hate_crack" in result.stdout
+    assert "__main__.py" not in result.stdout


### PR DESCRIPTION
## What

`python -m hate_crack --help` printed `usage: __main__.py`. argparse infers the program name from the module filename on that path, so the parser now states `prog="hate_crack"` explicitly.

The console script was never affected — argparse takes the name from the script basename there, which is already `hate_crack`.

## Why the tests didn't catch it

`tests/test_installed_tool_execution.py` shelled out to a bare `hate_crack`, resolved from `PATH`. Two problems:

1. **It tested the wrong thing.** `PATH` resolves to the console script, which reads correctly with or without this fix. Every assertion in that file passes either way, so the `-m` path had no coverage at all.
2. **It didn't necessarily test this checkout.** Whatever `hate_crack` wins the `PATH` lookup becomes the thing under test. On my machine that was an unrelated install pointing at a different clone, which produced seven failures that had nothing to do with this tree and disappeared under `uv run` purely because that puts `.venv/bin` first.

Those tests now resolve the console script next to `sys.executable` and skip on its absence, so they test the interpreter's own install regardless of how pytest was invoked. `test_module_invocation_reports_tool_name_in_usage` covers the `-m` path that actually regressed; I verified it fails when `prog=` is removed and passes when it's restored.

## Verification

- Full suite: 2117 passed, 41 skipped.
- The target file passes under both `uv run pytest` and plain `.venv/bin/python -m pytest`; previously the latter gave 7 failures.
- `ruff check hate_crack tests tools` clean, both touched files already formatted.
- `ty` reports 48 diagnostics, byte-identical to `main` before this branch — pre-existing and untouched here.

## Noted, not fixed

`--help` currently requires built hashcat-utils: without `HATE_CRACK_SKIP_INIT=1` it exits early on `Error: expander not found at .../hashcat-utils/bin/expander.bin` and never reaches argparse. The test suite only gets past this because `tests/conftest.py` sets that variable and the subprocess inherits it. A help flag shouldn't need compiled binaries, but that's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)