### PR TITLE
feat(hashview): list customer hashfiles in one request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+### Changed
+- **Listing a customer's hashfiles takes one request instead of 26.** Hashview
+  had no route to list a customer's files, so `get_all_customer_hashfiles`
+  approximated one by querying `/v1/hashfiles/hash_type/<N>` once per entry in a
+  26-entry table of common hashcat modes, pulling down every hashfile of each
+  type server-wide and discarding the ones belonging to other customers. Against
+  a live server a single one of those 26 requests measured 88 seconds. It was
+  also incomplete by construction: a hashfile of a type outside the table was
+  invisible, which is why the "no hashfiles" message had to hedge about whether
+  the server was old or the customer merely had nothing of a common type.
+
+  Hashview v0.8.3-dev added `GET /v1/customers/<id>/hashfiles`, which filters
+  server-side and covers every hash type. That route is used when present. Older
+  servers answer it with a 404 and fall back to the sweep unchanged, so nothing
+  regresses on them; passing `hash_types` explicitly still forces the sweep.
+
 ### Fixed
 - **Release versions now reflect what is in the batch.** `auto-tag.yml` forced
   `cz bump --increment MINOR` on every merge into `main`, so the second component

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -1455,18 +1455,66 @@ class HashviewAPI:
         22000,  # WPA-PBKDF2-PMKID+EAPOL
     )
 
-    def get_all_customer_hashfiles(self, customer_id, hash_types=None):
-        """Aggregate a customer's hashfiles across hash types (deduped by id).
+    def list_customer_hashfiles(self, customer_id):
+        """Return a customer's hashfiles via the customer-scoped listing route.
 
-        Hashview has no list-all route, so this sweeps the per-type listing
-        endpoint (:meth:`get_hashfiles_by_type`) over ``hash_types`` and keeps
-        the files belonging to ``customer_id``. Defaults to
-        :attr:`COMMON_HASH_TYPES`; a file of an uncommon type not in the sweep
-        won't appear. The first hash type a file is seen under is retained as
-        its ``hash_type`` (mixed-type files are rare).
+        ``GET /v1/customers/<id>/hashfiles`` filters server-side and covers
+        every hash type in one request. Added in Hashview v0.8.3-dev; servers
+        predating it have no such route, which surfaces as a 404 and is the
+        caller's cue to fall back to the per-type sweep.
+
+        Raises whatever ``requests`` raises; a 404 is meaningful, not an error
+        to swallow here.
+        """
+        url = f"{self.base_url}/v1/customers/{customer_id}/hashfiles"
+        resp = self.session.get(url, headers=self._auth_headers())
+        resp.raise_for_status()
+        try:
+            data = resp.json()
+        except Exception:
+            return []
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            files = data.get("hashfiles")
+            if isinstance(files, list):
+                return files
+        return []
+
+    def get_all_customer_hashfiles(self, customer_id, hash_types=None):
+        """Return a customer's hashfiles, preferring the direct listing route.
+
+        Tries :meth:`list_customer_hashfiles` first: one request, filtered
+        server-side, complete across hash types. Servers without that route
+        404, and we fall back to sweeping the per-type listing endpoint
+        (:meth:`get_hashfiles_by_type`) over ``hash_types`` — 26 requests by
+        default, each returning every hashfile of that type server-wide, and
+        blind to any type outside :attr:`COMMON_HASH_TYPES`.
+
+        Passing ``hash_types`` explicitly forces the sweep, since it asks for
+        specific types rather than everything.
         """
         if hash_types is None:
+            try:
+                direct = self.list_customer_hashfiles(customer_id)
+            except Exception as e:
+                status = getattr(getattr(e, "response", None), "status_code", None)
+                if status != 404:
+                    raise
+                if self.debug:
+                    print(
+                        "[DEBUG] get_all_customer_hashfiles: customer-scoped route "
+                        "absent (404); falling back to per-type sweep"
+                    )
+            else:
+                if self.debug:
+                    print(
+                        f"[DEBUG] get_all_customer_hashfiles({customer_id}): "
+                        f"{len(direct)} hashfiles from customer-scoped route"
+                    )
+                return direct
             hash_types = self.COMMON_HASH_TYPES
+
         seen = {}
         for ht in hash_types:
             try:

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -5129,16 +5129,13 @@ def hashview_api():
                                 continue
 
                         # Try to list the customer's hashfiles for convenience.
-                        # This only works on Hashview servers that expose the
-                        # /v1/hashfiles/hash_type endpoint (v0.8.3-dev, added
-                        # 2026-06-08); on `main` or older builds there is no
-                        # hashfile-listing API, so we fall back to entering the
-                        # hashfile ID directly (look it up in the web UI).
+                        # Servers with the customer-scoped route answer in one
+                        # request; older ones fall back to a per-type sweep, and
+                        # ones with neither leave the list empty, so the hashfile
+                        # ID has to be entered directly (look it up in the web UI).
                         hashfile_map = {}
                         try:
-                            print(
-                                "\nScanning customer hashfiles across common hash types..."
-                            )
+                            print("\nRetrieving customer hashfiles...")
                             customer_hashfiles = api_harness.get_all_customer_hashfiles(
                                 customer_id
                             )
@@ -5174,11 +5171,11 @@ def hashview_api():
                             print(f"Total: {len(hashfile_map)} hashfile(s)")
                         else:
                             print(
-                                "\nThis Hashview server has no hashfile-listing API "
-                                "(it lacks the /v1/hashfiles/hash_type endpoint), or "
-                                f"customer {customer_id} has no hashfiles of a common "
-                                "type. Look up the hashfile ID in the Hashview web UI "
-                                "and enter it below."
+                                f"\nNo hashfiles listed for customer {customer_id}. "
+                                "Either the customer has none, or this Hashview "
+                                "server predates the hashfile-listing API. Look up "
+                                "the hashfile ID in the Hashview web UI and enter "
+                                "it below."
                             )
 
                         while True:

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -261,6 +261,82 @@ class TestHashviewAPI:
         result = api.get_all_customer_hashfiles(1, hash_types=[1000, 5600])
         assert [hf["id"] for hf in result] == [9]
 
+    def test_get_all_customer_hashfiles_prefers_customer_scoped_route(self, api):
+        """The one-request route answers it; the 26-type sweep never runs."""
+        files = [
+            {"id": 1, "customer_id": 1, "name": "ntlm.txt", "hash_type": 1000},
+            {"id": 4, "customer_id": 1, "name": "exotic.txt", "hash_type": 99999},
+        ]
+        api.list_customer_hashfiles = Mock(return_value=files)
+        api.get_hashfiles_by_type = Mock()
+
+        result = api.get_all_customer_hashfiles(1)
+
+        assert result == files
+        api.list_customer_hashfiles.assert_called_once_with(1)
+        api.get_hashfiles_by_type.assert_not_called()
+        # A type outside COMMON_HASH_TYPES survives; the sweep would have missed it.
+        assert 99999 not in api.COMMON_HASH_TYPES
+        assert 4 in [hf["id"] for hf in result]
+
+    def test_get_all_customer_hashfiles_falls_back_when_route_absent(self, api):
+        """Servers predating the customer-scoped route 404; the sweep covers them."""
+        import requests
+
+        resp = Mock()
+        resp.status_code = 404
+        api.list_customer_hashfiles = Mock(
+            side_effect=requests.exceptions.HTTPError("404 Not Found", response=resp)
+        )
+        api.get_hashfiles_by_type = Mock(
+            side_effect=lambda ht: (
+                [{"id": 7, "customer_id": 1, "name": "ntlm.txt", "hash_type": 1000}]
+                if int(ht) == 1000
+                else []
+            )
+        )
+
+        result = api.get_all_customer_hashfiles(1)
+
+        assert [hf["id"] for hf in result] == [7]
+        assert api.get_hashfiles_by_type.call_count == len(api.COMMON_HASH_TYPES)
+
+    def test_get_all_customer_hashfiles_does_not_sweep_on_non_404(self, api):
+        """A 500 is a real failure, not a missing route.
+
+        Falling back would spend 26 requests against an already-unhealthy server
+        to produce a list that silently omits whatever the errors hid.
+        """
+        import requests
+
+        resp = Mock()
+        resp.status_code = 500
+        api.list_customer_hashfiles = Mock(
+            side_effect=requests.exceptions.HTTPError("500 Server Error", response=resp)
+        )
+        api.get_hashfiles_by_type = Mock()
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            api.get_all_customer_hashfiles(1)
+        api.get_hashfiles_by_type.assert_not_called()
+
+    def test_list_customer_hashfiles_unwraps_response(self, api):
+        """The route returns {"hashfiles": [...]}; bare lists are tolerated too."""
+        resp = Mock()
+        resp.raise_for_status = Mock()
+        resp.json = Mock(return_value={"status": 200, "hashfiles": [{"id": 3}]})
+        api.session.get = Mock(return_value=resp)
+
+        assert api.list_customer_hashfiles(5) == [{"id": 3}]
+        url = api.session.get.call_args[0][0]
+        assert url.endswith("/v1/customers/5/hashfiles")
+
+        resp.json = Mock(return_value=[{"id": 8}])
+        assert api.list_customer_hashfiles(5) == [{"id": 8}]
+
+        resp.json = Mock(side_effect=ValueError("not json"))
+        assert api.list_customer_hashfiles(5) == []
+
     def test_get_customer_hashfiles(self, api):
         """Filter the type-scoped hashfile list by customer_id (mocked transport)."""
         api.get_hashfiles_by_type = Mock(


### PR DESCRIPTION
Refs #242.

## What

`get_all_customer_hashfiles` now calls `GET /v1/customers/<id>/hashfiles` — one request, filtered server-side, covering every hash type — and falls back to the existing 26-request sweep only when the server 404s that route.

## Why

The sweep queried `/v1/hashfiles/hash_type/<N>` once per entry in a 26-entry table of common hashcat modes. Each response contained every hashfile of that type **server-wide**, and the client discarded everything not matching the customer. Measured against a live Hashview server, a single one of those requests took **88 seconds** to return 73 hashfiles.

It was incomplete by construction too: a hashfile whose type wasn't in the table simply never appeared. That's why the empty-result message had to hedge between "this server has no listing API" and "this customer has no files of a common type" — the code couldn't tell those apart.

## Behavior

- **New servers** (Hashview v0.8.3-dev and later, which merged the route in hashview#347): one request, complete across hash types.
- **Older servers**: 404 on the new route, fall back to the sweep exactly as before. No regression.
- **Explicit `hash_types=`**: still takes the sweep, since that's a request for specific types rather than for everything. The pre-existing tests exercise this path and are untouched.
- **Non-404 errors now propagate** instead of being swallowed. Previously a failing server meant silently spending 26 requests to build a list that omitted whatever the errors hid.

The two user-facing strings changed to match: the progress line no longer claims to be scanning hash types when it usually won't be, and the empty-result message no longer hedges about a distinction the fast path can make.

## Verification

- Full suite: 2121 passed, 41 skipped (4 new tests).
- New coverage: fast path taken and sweep not called; 404 falls back and sweeps all 26 types; non-404 raises without sweeping; response unwrapping for `{"hashfiles": [...]}`, bare lists, and non-JSON.
- The fast-path test asserts a hash type outside `COMMON_HASH_TYPES` survives — the case the sweep structurally could not return.
- `ruff check hate_crack tests tools` clean; touched files already formatted.

## Not verified live

The new route is merged to Hashview's `v0.8.3-dev` but is not on `main`/`master`, and neither `hashview.trustedsec.net` nor `hashview-beta.trustedsec.net` serves it yet — both return a generic 404, while registered routes on beta return a 302 to `/v1/not_authorized`, so this is route absence rather than an auth artifact. Hashview's own 8 unit tests for the endpoint pass against its source, so the contract is confirmed there. The fallback means this is safe to merge before those servers are redeployed, but the fast path won't actually execute until they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)