### PR TITLE
release: integrate nightly-dev batch of 2026-08-02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
-## [Unreleased]
+## [2.24.0] - 2026-08-02
 
 ### Changed
 - **Listing a customer's hashfiles takes one request instead of 26.** Hashview
@@ -238,6 +238,17 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   line, blaming the invalid line while hiding that the cached hashes were
   actually fine. The graceful early return now fires whenever any hashes were
   cached, regardless of whether others were also invalid.
+- **A cracked NTLM (mode 1000) plaintext with a genuine multi-byte UTF-8
+  character (e.g. `£`) was rejected as "plaintext does not match hash under
+  mode 1000" and skipped during Hashview upload.** `_digest_for_type`
+  zero-extended each *UTF-8 byte* of the plaintext before UTF-16LE encoding —
+  correct only for raw bytes recovered from a `$HEX[...]` wrapper — instead of
+  encoding the actual Unicode codepoints, doubling every non-ASCII character
+  into two UTF-16 code units and producing the wrong digest. Mode 1000 now
+  prefers decoding the raw bytes as UTF-8 (exact for genuine text, a no-op for
+  the zero-extend path since `$HEX`-wrapped bytes are only ever non-UTF-8 by
+  construction), falling back to the existing latin-1 zero-extend only when
+  that decode fails.
 
 ## [2.20.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,9 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   The release pipeline can still produce the ambiguous state; that half is being
   addressed separately in the versioning-policy work (#221).
 
+### Added
+- Hashview uploads now skip hashes already uploaded in a previous run, tracked in `~/.hate_crack/hashview_uploaded_cache.txt` (`upload_cracked_hashes`, `upload_hashfile`).
+
 ## [2.20.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,29 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 ### Added
 - Hashview uploads now skip hashes already uploaded in a previous run, tracked in `~/.hate_crack/hashview_uploaded_cache.txt` (`upload_cracked_hashes`, `upload_hashfile`).
 
+### Fixed
+- **Uploading a hashfile and later uploading its cracked results silently
+  dropped the cracked-results upload.** Both `upload_hashfile` (send hashes to
+  be cracked) and `upload_cracked_hashes` (send plaintexts back) computed the
+  same cache key for a given `(hash, hash_type)` pair, so the two operations
+  collided: after uploading a hashfile, the follow-up upload of its cracked
+  results saw every hash as already "uploaded" and skipped all of them,
+  while still printing `✓ Success`. The cache key is now namespaced per
+  operation (`cracked` vs. `hashfile:<customer_id>`), so the two paths can no
+  longer collide, and re-uploading the same hashlist for a different
+  customer is no longer silently skipped either.
+- Two call sites in `main.py` checked `"hashfile_id" in result` (presence)
+  rather than truthiness, so `upload_hashfile`'s all-cached response
+  (`hashfile_id: None`) passed the guard as if a real hashfile was created —
+  the interactive menu offered to create a job against `None`, and the
+  `upload-hashfile-job` CLI subcommand called `create_job(None, ...)` instead
+  of reporting an error. Both now check `result.get("hashfile_id")`.
+- `upload_cracked_hashes` raised a misleading "No valid hashes to upload"
+  exception when a file mixed already-cached hashes with a genuinely invalid
+  line, blaming the invalid line while hiding that the cached hashes were
+  actually fine. The graceful early return now fires whenever any hashes were
+  cached, regardless of whether others were also invalid.
+
 ## [2.20.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   regresses on them; passing `hash_types` explicitly still forces the sweep.
 
 ### Fixed
+- **A cracked password with a leading or trailing space was flagged as a
+  hash/plaintext mismatch and skipped during Hashview upload.** Both
+  `upload_cracked_hashes` and `_read_found_pairs` used a bare `.strip()` on the
+  raw `hash:plain` line before splitting on `:`, which strips *all* whitespace,
+  not just the line terminator — so a password's own leading/trailing space was
+  eaten before validation or before the value reached the potfile/Hashview.
+  `upload_cracked_hashes` also had a second, redundant `.strip()` on the
+  already-split plaintext field. Both now use `rstrip(b"\r\n")` to drop only
+  the newline, mirroring the byte-preserving fix already applied for non-UTF-8
+  plaintexts in #216.
+
 - **Wordlist and rule pickers no longer list directories and dot-files as if
   they were files** (#233). `list_wordlist_files()` was a bare `os.listdir` with
   an extension blocklist and a one-off `.DS_Store` exclusion, so subdirectories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,39 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   regresses on them; passing `hash_types` explicitly still forces the sweep.
 
 ### Fixed
+- **Wordlist and rule pickers no longer list directories and dot-files as if
+  they were files** (#233). `list_wordlist_files()` was a bare `os.listdir` with
+  an extension blocklist and a one-off `.DS_Store` exclusion, so subdirectories
+  and dot-files were numbered in the pickers as wordlists, and several callers
+  joined those names onto a directory and handed the result to hashcat as a
+  *file* argument. The same pattern was repeated inline for rule listings.
+
+  Listing is now typed: `list_wordlist_entries()` returns `DirEntry(name,
+  is_dir)`, `list_wordlist_files()` and `list_rule_files()` return files only,
+  and dot-files are dropped wholesale rather than by name.
+
+  The policy follows what hashcat actually accepts, verified against the binary:
+  a straight-mode (`-a 0`) dictionary position takes a directory and consumes
+  every file inside it, while a `-r` rulefile and an `-a 1` operand must be
+  files. So Quick Crack, the standard Dictionary attack and rule generation keep
+  offering directories — marked with a trailing `/` and coloured — while OMEN
+  training, Markov training, the rules picker and the LLM attack's unattended
+  `-r` loop take files only. The LLM loop was the worst of these: it ran
+  `hashcat -r <entry>` over every entry with nobody watching, so one stray
+  subdirectory failed the run.
+
+  Also fixed: the rules re-listing after a Hashmob download dropped even the
+  `.DS_Store` filter; the rule tab-completer was the only one of six not marking
+  directories, and globbed inconsistently once you typed; the Hashmob
+  already-downloaded set could let a directory shadow a rule filename and skip a
+  real download; and `wordlist_optimize`'s "is this empty" test was defeated by
+  a stray `.DS_Store`.
+
+  Colour is passed parallel to the entries and applied after padding, because
+  `print_multicolumn_list` pads with `ljust` and truncates on `len()` — an
+  escape baked into an entry string would be counted as visible width, leaving
+  the grid ragged and a truncated name able to strand an unreset colour.
+
 - **`python -m hate_crack --help` no longer calls itself `__main__.py`.** The
   parser took its program name from whatever argparse inferred, which is the
   module filename under `-m`. The console script was unaffected, since argparse

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -28,6 +28,11 @@ from hate_crack.hashview_cache import append_to_cache, cache_key, load_cache
 _TORRENT_CLEANUP_REGISTERED = False
 _WEAKPASS_INERTIA_VERSION: str | None = None
 HASHVIEW_DEFAULT_TIMEOUT = 30
+# requests' scalar timeout caps connect time AND inter-byte read time, so a
+# bulk upload/import POST needs headroom beyond the metadata-call default --
+# a large payload can legitimately take the server longer than 30s to process
+# before it sends the first response byte.
+HASHVIEW_UPLOAD_TIMEOUT = 300
 
 
 class _RateLimiter:
@@ -1241,7 +1246,7 @@ class HashviewAPI:
         url = f"{self.base_url}/v1/wordlists/add/{wordlist_name}"
         headers = {"Content-Type": "text/plain"}
         resp = self.session.post(
-            url, data=file_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT
+            url, data=file_content, headers=headers, timeout=HASHVIEW_UPLOAD_TIMEOUT
         )
         resp.raise_for_status()
         return resp.json()
@@ -1661,7 +1666,7 @@ class HashviewAPI:
         )
         headers = {"Content-Type": "text/plain"}
         resp = self.session.post(
-            url, data=file_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT
+            url, data=file_content, headers=headers, timeout=HASHVIEW_UPLOAD_TIMEOUT
         )
         resp.raise_for_status()
         append_to_cache(new_keys)
@@ -1952,7 +1957,7 @@ class HashviewAPI:
             url,
             data=converted_content,
             headers=headers,
-            timeout=HASHVIEW_DEFAULT_TIMEOUT,
+            timeout=HASHVIEW_UPLOAD_TIMEOUT,
         )
         resp.raise_for_status()
         try:

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -27,6 +27,7 @@ from hate_crack.hashview_cache import append_to_cache, cache_key, load_cache
 
 _TORRENT_CLEANUP_REGISTERED = False
 _WEAKPASS_INERTIA_VERSION: str | None = None
+HASHVIEW_DEFAULT_TIMEOUT = 30
 
 
 class _RateLimiter:
@@ -1239,14 +1240,14 @@ class HashviewAPI:
             file_content = f.read()
         url = f"{self.base_url}/v1/wordlists/add/{wordlist_name}"
         headers = {"Content-Type": "text/plain"}
-        resp = self.session.post(url, data=file_content, headers=headers)
+        resp = self.session.post(url, data=file_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
 
     def list_wordlists(self):
         """List available wordlists from Hashview API."""
         endpoint = f"{self.base_url}/v1/wordlists"
-        response = self.session.get(endpoint, headers=self._auth_headers())
+        response = self.session.get(endpoint, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
         response.raise_for_status()
         try:
             data = response.json()
@@ -1311,7 +1312,7 @@ class HashviewAPI:
         Return all hashfiles of a given hash_type using the /v1/hashfiles/hash_type/<hash_type> endpoint.
         """
         url = f"{self.base_url}/v1/hashfiles/hash_type/{hash_type}"
-        resp = self.session.get(url, headers=self._auth_headers())
+        resp = self.session.get(url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         try:
             data = resp.json()
@@ -1330,7 +1331,7 @@ class HashviewAPI:
     def get_hashfile_details(self, hashfile_id):
         """Get hashfile details and hashtype for a given hashfile_id."""
         url = f"{self.base_url}/v1/getHashType/{hashfile_id}"
-        resp = self.session.get(url, headers=self._auth_headers())
+        resp = self.session.get(url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         try:
             data = resp.json()
@@ -1373,7 +1374,7 @@ class HashviewAPI:
 
     def list_customers(self):
         url = f"{self.base_url}/v1/customers"
-        resp = self.session.get(url)
+        resp = self.session.get(url, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         data = resp.json()
         if "users" in data:
@@ -1470,7 +1471,7 @@ class HashviewAPI:
         to swallow here.
         """
         url = f"{self.base_url}/v1/customers/{customer_id}/hashfiles"
-        resp = self.session.get(url, headers=self._auth_headers())
+        resp = self.session.get(url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         try:
             data = resp.json()
@@ -1649,7 +1650,7 @@ class HashviewAPI:
             f"{customer_id}/{file_format}/{hash_type}/{hashfile_name}"
         )
         headers = {"Content-Type": "text/plain"}
-        resp = self.session.post(url, data=file_content, headers=headers)
+        resp = self.session.post(url, data=file_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         append_to_cache(new_keys)
         result = resp.json()
@@ -1670,7 +1671,7 @@ class HashviewAPI:
         }
         if notify_email is not None:
             data["notify_email"] = bool(notify_email)
-        resp = self.session.post(url, json=data, headers=headers)
+        resp = self.session.post(url, json=data, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         try:
             return resp.json()
@@ -1688,7 +1689,7 @@ class HashviewAPI:
     def delete_job(self, job_id):
         # Hashview deletes via DELETE /v1/jobs/<id> (there is no /jobs/delete/).
         url = f"{self.base_url}/v1/jobs/{job_id}"
-        resp = self.session.delete(url)
+        resp = self.session.delete(url, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
 
@@ -1700,7 +1701,7 @@ class HashviewAPI:
         priority = int(priority)
         if priority < 1 or priority > 5:
             raise ValueError("priority must be an int between 1 and 5")
-        resp = self.session.post(url)
+        resp = self.session.post(url, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
 
@@ -1717,7 +1718,7 @@ class HashviewAPI:
         # ("left") ciphertexts for the hashfile (see v1_api_get_hashfile). The
         # older /v1/hashfiles/<id>/left route no longer exists and 404s.
         url = f"{self.base_url}/v1/hashfiles/{hashfile_id}"
-        resp = self.session.get(url, headers=self._auth_headers(), stream=True)
+        resp = self.session.get(url, headers=self._auth_headers(), stream=True, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         if output_file is None:
             output_file = f"left_{customer_id}_{hashfile_id}.txt"
@@ -1761,7 +1762,7 @@ class HashviewAPI:
             # remains for forks/versions that expose a per-hashfile found dump.
             found_url = f"{self.base_url}/v1/hashfiles/{hashfile_id}/found"
             found_resp = self.session.get(
-                found_url, headers=self._auth_headers(), stream=True, timeout=30
+                found_url, headers=self._auth_headers(), stream=True, timeout=HASHVIEW_DEFAULT_TIMEOUT
             )
 
             # Only proceed if we successfully downloaded the found file (ignore 404s)
@@ -1925,7 +1926,7 @@ class HashviewAPI:
         converted_content = b"\n".join(valid_lines)
         url = f"{self.base_url}/v1/hashes/import/{hash_type}"
         headers = {"Content-Type": "text/plain; charset=utf-8"}
-        resp = self.session.post(url, data=converted_content, headers=headers)
+        resp = self.session.post(url, data=converted_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         try:
             json_response = resp.json()
@@ -1953,7 +1954,7 @@ class HashviewAPI:
             update_url = f"{self.base_url}/v1/updateWordlist/{wordlist_id}"
             try:
                 update_resp = self.session.get(
-                    update_url, headers=self._auth_headers(), timeout=30
+                    update_url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT
                 )
                 update_resp.raise_for_status()
             except Exception as exc:
@@ -1963,7 +1964,7 @@ class HashviewAPI:
                     )
 
         url = f"{self.base_url}/v1/wordlists/{wordlist_id}"
-        resp = self.session.get(url, headers=self._auth_headers(), stream=True)
+        resp = self.session.get(url, headers=self._auth_headers(), stream=True, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
 
         if output_file is None:
@@ -1996,7 +1997,7 @@ class HashviewAPI:
     def list_rules(self):
         """List available rule files from the Hashview API (/v1/rules)."""
         endpoint = f"{self.base_url}/v1/rules"
-        response = self.session.get(endpoint, headers=self._auth_headers())
+        response = self.session.get(endpoint, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
         response.raise_for_status()
         try:
             data = response.json()
@@ -2024,7 +2025,7 @@ class HashviewAPI:
         import gzip
 
         url = f"{self.base_url}/v1/rules/{rules_id}"
-        resp = self.session.get(url, headers=self._auth_headers())
+        resp = self.session.get(url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
 
         content = resp.content
@@ -2048,7 +2049,7 @@ class HashviewAPI:
         url = f"{self.base_url}/v1/customers/add"
         headers = {"Content-Type": "application/json"}
         data = {"name": name}
-        resp = self.session.post(url, json=data, headers=headers)
+        resp = self.session.post(url, json=data, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         try:
             payload = resp.json()
@@ -2058,7 +2059,7 @@ class HashviewAPI:
         msg = str(payload.get("msg", ""))
         if "invalid keyword argument for Customers" in msg:
             # Fallback for older Hashview servers that choke on JSON body parsing.
-            resp = self.session.post(url, data={"name": name})
+            resp = self.session.post(url, data={"name": name}, timeout=HASHVIEW_DEFAULT_TIMEOUT)
             resp.raise_for_status()
             return resp.json()
         return payload
@@ -2071,7 +2072,7 @@ class HashviewAPI:
         (native JSON objects); we extract the ``id`` of each hashfile.
         """
         url = f"{self.base_url}/v1/hashfiles/hash_type/{hashtype_id}"
-        resp = self.session.get(url)
+        resp = self.session.get(url, timeout=HASHVIEW_DEFAULT_TIMEOUT)
         resp.raise_for_status()
         try:
             data = resp.json()

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -1911,7 +1911,12 @@ class HashviewAPI:
                 print(f"    ... and {len(skipped) - 10} more")
 
         if not valid_lines:
-            if skipped_cached and not skipped:
+            if skipped_cached:
+                # At least one line was already-uploaded-and-cached, so this
+                # is not "nothing valid" -- it's "nothing left to upload
+                # after skipping what's cached," even if other lines were
+                # also genuinely invalid. Return gracefully instead of
+                # raising and blaming the invalid lines for the whole file.
                 return {
                     "uploaded": 0,
                     "skipped": len(skipped),

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -23,6 +23,7 @@ from hate_crack.config_loader import (
 from hate_crack.config_schema import CONFIG_SCHEMA, ConfigValueError
 from hate_crack.formatting import print_multicolumn_list
 from hate_crack.plaintext import encode_hex_wrapper
+from hate_crack.hashview_cache import append_to_cache, cache_key, load_cache
 
 _TORRENT_CLEANUP_REGISTERED = False
 _WEAKPASS_INERTIA_VERSION: str | None = None
@@ -1823,6 +1824,9 @@ class HashviewAPI:
     def upload_cracked_hashes(self, file_path, hash_type="1000", *, validate=True):
         valid_lines = []
         skipped = []
+        skipped_cached = 0
+        new_keys = []
+        cache = load_cache()
         # Bytes, not a lossy text read: a plaintext with a non-UTF-8 byte must
         # reach Hashview intact (as $HEX[...]) rather than as a different
         # password -- see _read_found_pairs.
@@ -1841,6 +1845,12 @@ class HashviewAPI:
                 except UnicodeDecodeError:
                     skipped.append((lineno, "<undecodable>", "hash field is not UTF-8"))
                     continue
+
+                key = cache_key(hash_value, hash_type)
+                if key in cache:
+                    skipped_cached += 1
+                    continue
+
                 plaintext = encode_hex_wrapper(plain_raw)
                 if validate:
                     ok, reason = _validate_cracked_pair(
@@ -1854,6 +1864,10 @@ class HashviewAPI:
                     + b":"
                     + _wire_field_bytes(hash_type, plaintext)
                 )
+                new_keys.append(key)
+
+        if skipped_cached:
+            print(f"↷ Skipped {skipped_cached} hash(es) already uploaded previously")
 
         if skipped:
             print(
@@ -1866,6 +1880,12 @@ class HashviewAPI:
                 print(f"    ... and {len(skipped) - 10} more")
 
         if not valid_lines:
+            if skipped_cached and not skipped:
+                return {
+                    "uploaded": 0,
+                    "skipped": len(skipped),
+                    "skipped_cached": skipped_cached,
+                }
             raise Exception(
                 f"No valid hashes to upload for hash mode {hash_type} "
                 f"({len(skipped)} line(s) skipped by validation)."
@@ -1882,11 +1902,13 @@ class HashviewAPI:
                 raise Exception(
                     f"Hashview API Error: {json_response.get('msg', 'Unknown error')}"
                 )
+            append_to_cache(new_keys)
             # Surface what the client actually sent so the caller can report a
             # count even against a Hashview that returns a bare {"msg": "OK"}.
             if isinstance(json_response, dict):
                 json_response.setdefault("uploaded", len(valid_lines))
                 json_response.setdefault("skipped", len(skipped))
+                json_response.setdefault("skipped_cached", skipped_cached)
             return json_response
         except (json.JSONDecodeError, ValueError):
             raise Exception(f"Invalid API response: {resp.text[:200]}")

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -1240,14 +1240,18 @@ class HashviewAPI:
             file_content = f.read()
         url = f"{self.base_url}/v1/wordlists/add/{wordlist_name}"
         headers = {"Content-Type": "text/plain"}
-        resp = self.session.post(url, data=file_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.post(
+            url, data=file_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         resp.raise_for_status()
         return resp.json()
 
     def list_wordlists(self):
         """List available wordlists from Hashview API."""
         endpoint = f"{self.base_url}/v1/wordlists"
-        response = self.session.get(endpoint, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        response = self.session.get(
+            endpoint, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         response.raise_for_status()
         try:
             data = response.json()
@@ -1312,7 +1316,9 @@ class HashviewAPI:
         Return all hashfiles of a given hash_type using the /v1/hashfiles/hash_type/<hash_type> endpoint.
         """
         url = f"{self.base_url}/v1/hashfiles/hash_type/{hash_type}"
-        resp = self.session.get(url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.get(
+            url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         resp.raise_for_status()
         try:
             data = resp.json()
@@ -1331,7 +1337,9 @@ class HashviewAPI:
     def get_hashfile_details(self, hashfile_id):
         """Get hashfile details and hashtype for a given hashfile_id."""
         url = f"{self.base_url}/v1/getHashType/{hashfile_id}"
-        resp = self.session.get(url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.get(
+            url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         resp.raise_for_status()
         try:
             data = resp.json()
@@ -1471,7 +1479,9 @@ class HashviewAPI:
         to swallow here.
         """
         url = f"{self.base_url}/v1/customers/{customer_id}/hashfiles"
-        resp = self.session.get(url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.get(
+            url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         resp.raise_for_status()
         try:
             data = resp.json()
@@ -1650,7 +1660,9 @@ class HashviewAPI:
             f"{customer_id}/{file_format}/{hash_type}/{hashfile_name}"
         )
         headers = {"Content-Type": "text/plain"}
-        resp = self.session.post(url, data=file_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.post(
+            url, data=file_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         resp.raise_for_status()
         append_to_cache(new_keys)
         result = resp.json()
@@ -1671,7 +1683,9 @@ class HashviewAPI:
         }
         if notify_email is not None:
             data["notify_email"] = bool(notify_email)
-        resp = self.session.post(url, json=data, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.post(
+            url, json=data, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         resp.raise_for_status()
         try:
             return resp.json()
@@ -1718,7 +1732,12 @@ class HashviewAPI:
         # ("left") ciphertexts for the hashfile (see v1_api_get_hashfile). The
         # older /v1/hashfiles/<id>/left route no longer exists and 404s.
         url = f"{self.base_url}/v1/hashfiles/{hashfile_id}"
-        resp = self.session.get(url, headers=self._auth_headers(), stream=True, timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.get(
+            url,
+            headers=self._auth_headers(),
+            stream=True,
+            timeout=HASHVIEW_DEFAULT_TIMEOUT,
+        )
         resp.raise_for_status()
         if output_file is None:
             output_file = f"left_{customer_id}_{hashfile_id}.txt"
@@ -1762,7 +1781,10 @@ class HashviewAPI:
             # remains for forks/versions that expose a per-hashfile found dump.
             found_url = f"{self.base_url}/v1/hashfiles/{hashfile_id}/found"
             found_resp = self.session.get(
-                found_url, headers=self._auth_headers(), stream=True, timeout=HASHVIEW_DEFAULT_TIMEOUT
+                found_url,
+                headers=self._auth_headers(),
+                stream=True,
+                timeout=HASHVIEW_DEFAULT_TIMEOUT,
             )
 
             # Only proceed if we successfully downloaded the found file (ignore 404s)
@@ -1926,7 +1948,12 @@ class HashviewAPI:
         converted_content = b"\n".join(valid_lines)
         url = f"{self.base_url}/v1/hashes/import/{hash_type}"
         headers = {"Content-Type": "text/plain; charset=utf-8"}
-        resp = self.session.post(url, data=converted_content, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.post(
+            url,
+            data=converted_content,
+            headers=headers,
+            timeout=HASHVIEW_DEFAULT_TIMEOUT,
+        )
         resp.raise_for_status()
         try:
             json_response = resp.json()
@@ -1954,7 +1981,9 @@ class HashviewAPI:
             update_url = f"{self.base_url}/v1/updateWordlist/{wordlist_id}"
             try:
                 update_resp = self.session.get(
-                    update_url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT
+                    update_url,
+                    headers=self._auth_headers(),
+                    timeout=HASHVIEW_DEFAULT_TIMEOUT,
                 )
                 update_resp.raise_for_status()
             except Exception as exc:
@@ -1964,7 +1993,12 @@ class HashviewAPI:
                     )
 
         url = f"{self.base_url}/v1/wordlists/{wordlist_id}"
-        resp = self.session.get(url, headers=self._auth_headers(), stream=True, timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.get(
+            url,
+            headers=self._auth_headers(),
+            stream=True,
+            timeout=HASHVIEW_DEFAULT_TIMEOUT,
+        )
         resp.raise_for_status()
 
         if output_file is None:
@@ -1997,7 +2031,9 @@ class HashviewAPI:
     def list_rules(self):
         """List available rule files from the Hashview API (/v1/rules)."""
         endpoint = f"{self.base_url}/v1/rules"
-        response = self.session.get(endpoint, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        response = self.session.get(
+            endpoint, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         response.raise_for_status()
         try:
             data = response.json()
@@ -2025,7 +2061,9 @@ class HashviewAPI:
         import gzip
 
         url = f"{self.base_url}/v1/rules/{rules_id}"
-        resp = self.session.get(url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.get(
+            url, headers=self._auth_headers(), timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         resp.raise_for_status()
 
         content = resp.content
@@ -2049,7 +2087,9 @@ class HashviewAPI:
         url = f"{self.base_url}/v1/customers/add"
         headers = {"Content-Type": "application/json"}
         data = {"name": name}
-        resp = self.session.post(url, json=data, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT)
+        resp = self.session.post(
+            url, json=data, headers=headers, timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         resp.raise_for_status()
         try:
             payload = resp.json()
@@ -2059,7 +2099,9 @@ class HashviewAPI:
         msg = str(payload.get("msg", ""))
         if "invalid keyword argument for Customers" in msg:
             # Fallback for older Hashview servers that choke on JSON body parsing.
-            resp = self.session.post(url, data={"name": name}, timeout=HASHVIEW_DEFAULT_TIMEOUT)
+            resp = self.session.post(
+                url, data={"name": name}, timeout=HASHVIEW_DEFAULT_TIMEOUT
+            )
             resp.raise_for_status()
             return resp.json()
         return payload

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -1160,11 +1160,21 @@ def _digest_for_type(hash_type: str, raw: bytes) -> Optional[str]:
     if ht == "1700":
         return hashlib.sha512(raw).hexdigest()
     if ht in ("900", "1000"):
-        # MD4 over the raw bytes; NTLM is MD4 over UTF-16LE. hashcat forms the
-        # NTLM candidate by zero-extending each raw byte, which is exactly
-        # latin-1(bytes).encode("utf-16le") -- correct for arbitrary binary too.
+        # MD4 over the raw bytes; NTLM is MD4 over UTF-16LE. A $HEX[...]
+        # plaintext carries hashcat's raw candidate bytes, zero-extended one
+        # byte per UTF-16 code unit -- correct for arbitrary binary. But a
+        # plaintext hashcat printed as plain text is genuine Unicode (e.g. a
+        # potfile line holding "£"), and re-zero-extending its *UTF-8* bytes
+        # would double up every non-ASCII character. Prefer decoding as
+        # UTF-8 -- always exact for the plain-text case and a no-op for
+        # zero-extend when the raw bytes aren't valid UTF-8 -- falling back
+        # to the zero-extend rule only when that decode fails.
         if ht == "1000":
-            return _md4(raw.decode("latin-1").encode("utf-16le"))
+            try:
+                utf16 = raw.decode("utf-8").encode("utf-16le")
+            except UnicodeDecodeError:
+                utf16 = raw.decode("latin-1").encode("utf-16le")
+            return _md4(utf16)
         return _md4(raw)
     return None
 

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -1129,7 +1129,9 @@ def _read_found_pairs(path) -> Tuple[list, list]:
     undecodable: list = []
     with open(path, "rb") as fh:
         for raw_line in fh:
-            raw_line = raw_line.strip()
+            # rstrip only the line terminator -- a plain .strip() eats a
+            # leading/trailing space that belongs to the password itself.
+            raw_line = raw_line.rstrip(b"\r\n")
             if not raw_line or b":" not in raw_line:
                 continue
             hash_raw, plain_raw = raw_line.rsplit(b":", 1)
@@ -1826,7 +1828,9 @@ class HashviewAPI:
         # password -- see _read_found_pairs.
         with open(file_path, "rb") as f:
             for lineno, raw_line in enumerate(f, 1):
-                raw_line = raw_line.strip()
+                # rstrip only the line terminator -- a plain .strip() eats a
+                # leading/trailing space that belongs to the password itself.
+                raw_line = raw_line.rstrip(b"\r\n")
                 if b"31d6cfe0d16ae931b73c59d7e0c089c0" in raw_line:
                     continue
                 if not raw_line or b":" not in raw_line:
@@ -1837,7 +1841,7 @@ class HashviewAPI:
                 except UnicodeDecodeError:
                     skipped.append((lineno, "<undecodable>", "hash field is not UTF-8"))
                     continue
-                plaintext = encode_hex_wrapper(plain_raw.strip())
+                plaintext = encode_hex_wrapper(plain_raw)
                 if validate:
                     ok, reason = _validate_cracked_pair(
                         hash_type, hash_value, plaintext

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -1615,8 +1615,35 @@ class HashviewAPI:
     ):
         if hashfile_name is None:
             hashfile_name = os.path.basename(file_path)
+
+        cache = load_cache()
+        kept_lines = []
+        new_keys = []
+        skipped_cached = 0
         with open(file_path, "rb") as f:
-            file_content = f.read()
+            for raw_line in f:
+                line = raw_line.rstrip(b"\r\n")
+                if not line:
+                    continue
+                hash_value = line.decode("utf-8", errors="ignore")
+                key = cache_key(hash_value, hash_type)
+                if key in cache:
+                    skipped_cached += 1
+                    continue
+                kept_lines.append(line)
+                new_keys.append(key)
+
+        if skipped_cached:
+            print(f"↷ Skipped {skipped_cached} hash(es) already uploaded previously")
+
+        if not kept_lines:
+            return {
+                "uploaded": 0,
+                "skipped_cached": skipped_cached,
+                "hashfile_id": None,
+            }
+
+        file_content = b"\n".join(kept_lines)
         url = (
             f"{self.base_url}/v1/hashfiles/upload/"
             f"{customer_id}/{file_format}/{hash_type}/{hashfile_name}"
@@ -1624,7 +1651,11 @@ class HashviewAPI:
         headers = {"Content-Type": "text/plain"}
         resp = self.session.post(url, data=file_content, headers=headers)
         resp.raise_for_status()
-        return resp.json()
+        append_to_cache(new_keys)
+        result = resp.json()
+        if isinstance(result, dict):
+            result.setdefault("skipped_cached", skipped_cached)
+        return result
 
     def create_job(
         self, name, hashfile_id, customer_id, limit_recovered=False, notify_email=None

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -2570,6 +2570,22 @@ def list_and_download_official_wordlists():
         print(f"Error listing official wordlists: {e}")
 
 
+def _downloaded_rule_names(rules_dir):
+    """Names of rule files already present, for the download dedup check.
+
+    Files only: a directory whose name matches a wanted rule would otherwise
+    mark it as already downloaded and skip it.
+    """
+    try:
+        return {
+            name
+            for name in os.listdir(rules_dir)
+            if os.path.isfile(os.path.join(rules_dir, name))
+        }
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        return set()
+
+
 def list_and_download_hashmob_rules(rules_dir=None):
     """List rules via the Hashmob API, prompt for selection, and download."""
     rules = download_hashmob_rule_list()
@@ -2618,11 +2634,7 @@ def list_and_download_hashmob_rules(rules_dir=None):
         return sorted(i for i in indices if 1 <= i <= max_index)
 
     # Track already-downloaded rules to avoid duplicates
-    downloaded_rules = set()
-    # Scan rules_dir for existing files
-    if os.path.isdir(rules_dir):
-        for fname in os.listdir(rules_dir):
-            downloaded_rules.add(fname)
+    downloaded_rules = _downloaded_rule_names(rules_dir)
 
     def already_downloaded(file_name):
         sanitized = sanitize_filename(file_name)

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -1626,7 +1626,7 @@ class HashviewAPI:
                 if not line:
                     continue
                 hash_value = line.decode("utf-8", errors="ignore")
-                key = cache_key(hash_value, hash_type)
+                key = cache_key(hash_value, hash_type, scope=f"hashfile:{customer_id}")
                 if key in cache:
                     skipped_cached += 1
                     continue
@@ -1877,7 +1877,7 @@ class HashviewAPI:
                     skipped.append((lineno, "<undecodable>", "hash field is not UTF-8"))
                     continue
 
-                key = cache_key(hash_value, hash_type)
+                key = cache_key(hash_value, hash_type, scope="cracked")
                 if key in cache:
                     skipped_cached += 1
                     continue

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -840,12 +840,15 @@ def ollama_attack(ctx: Any) -> None:
 
 def _pick_training_wordlist(ctx: Any, title: str = "Training Wordlists"):
     """Show wordlist picker. Returns path or None (user cancelled with 'q')."""
-    wordlist_files = ctx.list_wordlist_files(ctx.hcatWordlists)
+    entries_meta = ctx.list_wordlist_entries(ctx.hcatWordlists)
     # Print the grid once, outside the retry loop: a wordlists directory can
     # hold dozens of entries, and repainting the whole thing after every typo
     # buries the error message.
-    if wordlist_files:
-        entries = [f"{i}) {f}" for i, f in enumerate(wordlist_files, start=1)]
+    if entries_meta:
+        entries = [
+            f"{i}) {entry.name}/" if entry.is_dir else f"{i}) {entry.name}"
+            for i, entry in enumerate(entries_meta, start=1)
+        ]
         max_len = max((len(e) for e in entries), default=24)
         print_multicolumn_list(
             title,
@@ -866,8 +869,18 @@ def _pick_training_wordlist(ctx: Any, title: str = "Training Wordlists"):
             return path.strip() if path else None
         try:
             idx = int(sel)
-            if 1 <= idx <= len(wordlist_files):
-                return os.path.join(ctx.hcatWordlists, wordlist_files[idx - 1])
+            if 1 <= idx <= len(entries_meta):
+                entry = entries_meta[idx - 1]
+                if entry.is_dir:
+                    # Training takes one corpus file. Refusing here beats
+                    # failing inside hcatOmenTrain/hcatMarkovTrain, where the
+                    # error names a path and not the mistake.
+                    print(
+                        f"\t[!] {entry.name}/ is a directory. "
+                        "Pick a single file, or use 'p' for a path."
+                    )
+                    continue
+                return os.path.join(ctx.hcatWordlists, entry.name)
         except (ValueError, IndexError):
             pass
         print("\t[!] Invalid selection.")
@@ -940,12 +953,15 @@ def _markov_pick_training_source(ctx: Any):
     out_path = f"{ctx.hcatHashFile}.out"
     has_cracked = os.path.isfile(out_path) and os.path.getsize(out_path) > 0
 
-    wordlist_files = ctx.list_wordlist_files(ctx.hcatWordlists)
+    entries_meta = ctx.list_wordlist_entries(ctx.hcatWordlists)
     # Print the grid once, outside the retry loop — see _pick_training_wordlist.
     entries = []
     if has_cracked:
         entries.append("0) Cracked passwords (current session)")
-    entries.extend([f"{i}) {f}" for i, f in enumerate(wordlist_files, start=1)])
+    entries.extend(
+        f"{i}) {entry.name}/" if entry.is_dir else f"{i}) {entry.name}"
+        for i, entry in enumerate(entries_meta, start=1)
+    )
     if entries:
         max_len = max((len(e) for e in entries), default=24)
         print_multicolumn_list(
@@ -969,8 +985,18 @@ def _markov_pick_training_source(ctx: Any):
             return path.strip() if path else None
         try:
             idx = int(sel)
-            if 1 <= idx <= len(wordlist_files):
-                return os.path.join(ctx.hcatWordlists, wordlist_files[idx - 1])
+            if 1 <= idx <= len(entries_meta):
+                entry = entries_meta[idx - 1]
+                if entry.is_dir:
+                    # Training takes one corpus file. Refusing here beats
+                    # failing inside hcatOmenTrain/hcatMarkovTrain, where the
+                    # error names a path and not the mistake.
+                    print(
+                        f"\t[!] {entry.name}/ is a directory. "
+                        "Pick a single file, or use 'p' for a path."
+                    )
+                    continue
+                return os.path.join(ctx.hcatWordlists, entry.name)
         except (ValueError, IndexError):
             pass
         print("\t[!] Invalid selection.")
@@ -1109,9 +1135,10 @@ def generate_rules_crack(ctx: Any) -> None:
         print("[!] Invalid rule count.")
         return
 
-    wordlist_files = ctx.list_wordlist_files(ctx.hcatWordlists)
+    entries_meta = ctx.list_wordlist_entries(ctx.hcatWordlists)
     wordlist_entries = [
-        f"{i}) {file}" for i, file in enumerate(wordlist_files, start=1)
+        f"{i}) {entry.name}/" if entry.is_dir else f"{i}) {entry.name}"
+        for i, entry in enumerate(entries_meta, start=1)
     ]
     max_entry_len = max((len(e) for e in wordlist_entries), default=24)
     print_multicolumn_list(
@@ -1151,11 +1178,19 @@ def generate_rules_crack(ctx: Any) -> None:
             raw_choice = raw_choice.strip()
             if raw_choice == "":
                 wordlist_choice = ctx.hcatWordlists
-            elif raw_choice.isdigit() and 1 <= int(raw_choice) <= len(wordlist_files):
+            elif raw_choice.isdigit() and 1 <= int(raw_choice) <= len(entries_meta):
                 chosen = os.path.join(
-                    ctx.hcatWordlists, wordlist_files[int(raw_choice) - 1]
+                    ctx.hcatWordlists, entries_meta[int(raw_choice) - 1].name
                 )
-                if os.path.exists(chosen):
+                if os.path.isdir(chosen):
+                    # Rule generation hands this path straight to hashcat as
+                    # its dictionary argument. Refusing a directory here beats
+                    # a hashcat error that names the path and not the mistake.
+                    print(
+                        f"[!] {chosen} is a directory; rule generation needs one file."
+                    )
+                    continue
+                if os.path.isfile(chosen):
                     wordlist_choice = chosen
                     print(wordlist_choice)
             elif os.path.exists(raw_choice):

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -38,7 +38,7 @@ def _select_rules(ctx) -> list[str] | None:
     selected_rules = []
 
     rules_dir = ctx.rulesDirectory
-    rule_files = sorted(f for f in os.listdir(rules_dir) if f != ".DS_Store")
+    rule_files = ctx.list_rule_files(rules_dir)
     if not rule_files:
         download_rules = (
             input("\nNo rules found. Download rules from Hashmob now? (Y/n): ")
@@ -47,7 +47,7 @@ def _select_rules(ctx) -> list[str] | None:
         )
         if download_rules in ("", "y", "yes"):
             download_hashmob_rules(print_fn=print, rules_dir=rules_dir)
-            rule_files = sorted(os.listdir(rules_dir))
+            rule_files = ctx.list_rule_files(rules_dir)
 
     if not rule_files:
         print("No rules available. Proceeding without rules.")

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -1150,12 +1150,14 @@ def generate_rules_crack(ctx: Any) -> None:
         f"{i}) {entry.name}/" if entry.is_dir else f"{i}) {entry.name}"
         for i, entry in enumerate(entries_meta, start=1)
     ]
+    entry_styles = ["\033[36m" if entry.is_dir else None for entry in entries_meta]
     max_entry_len = max((len(e) for e in wordlist_entries), default=24)
     print_multicolumn_list(
         "Wordlists",
         wordlist_entries,
         min_col_width=max_entry_len,
         max_col_width=max_entry_len,
+        styles=entry_styles,
     )
 
     def path_completer(text, state):
@@ -1192,17 +1194,11 @@ def generate_rules_crack(ctx: Any) -> None:
                 chosen = os.path.join(
                     ctx.hcatWordlists, entries_meta[int(raw_choice) - 1].name
                 )
-                if os.path.isdir(chosen):
-                    # Rule generation hands this path straight to hashcat as
-                    # its dictionary argument. Refusing a directory here beats
-                    # a hashcat error that names the path and not the mistake.
-                    print(
-                        f"[!] {chosen} is a directory; rule generation needs one file."
-                    )
-                    continue
-                if os.path.isfile(chosen):
+                if os.path.isdir(chosen) or os.path.isfile(chosen):
                     wordlist_choice = chosen
                     print(wordlist_choice)
+                else:
+                    print(f"[!] {chosen} no longer exists.")
             elif os.path.exists(raw_choice):
                 wordlist_choice = raw_choice
             else:

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -132,13 +132,18 @@ def quick_crack(ctx: Any) -> None:
     list_dir = ctx.hcatWordlists
     default_dir = ctx.hcatOptimizedWordlists
 
-    wordlist_files = ctx.list_wordlist_files(list_dir)
+    wordlist_entries_meta = ctx.list_wordlist_entries(list_dir)
+    # A trailing "/" is the marker, matching how the tab-completers already
+    # render a directory. Colour is applied by print_multicolumn_list, which
+    # pads on visible width; putting an escape sequence in the string here
+    # would break its ljust() and its truncation.
     wordlist_entries = [
-        f"{i}) {file}" for i, file in enumerate(wordlist_files, start=1)
+        f"{i}) {entry.name}/" if entry.is_dir else f"{i}) {entry.name}"
+        for i, entry in enumerate(wordlist_entries_meta, start=1)
     ]
     max_entry_len = max((len(e) for e in wordlist_entries), default=24)
     print_multicolumn_list(
-        "Wordlists",
+        "Wordlists (entries ending in / are directories: hashcat reads every file inside)",
         wordlist_entries,
         min_col_width=max_entry_len,
         max_col_width=max_entry_len,
@@ -173,8 +178,12 @@ def quick_crack(ctx: Any) -> None:
             raw_choice = raw_choice.strip()
             if raw_choice == "":
                 wordlist_choice = default_dir
-            elif raw_choice.isdigit() and 1 <= int(raw_choice) <= len(wordlist_files):
-                chosen = os.path.join(list_dir, wordlist_files[int(raw_choice) - 1])
+            elif raw_choice.isdigit() and 1 <= int(raw_choice) <= len(
+                wordlist_entries_meta
+            ):
+                chosen = os.path.join(
+                    list_dir, wordlist_entries_meta[int(raw_choice) - 1].name
+                )
                 if os.path.exists(chosen):
                     wordlist_choice = chosen
                     print(wordlist_choice)

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -141,12 +141,16 @@ def quick_crack(ctx: Any) -> None:
         f"{i}) {entry.name}/" if entry.is_dir else f"{i}) {entry.name}"
         for i, entry in enumerate(wordlist_entries_meta, start=1)
     ]
+    entry_styles = [
+        "\033[36m" if entry.is_dir else None for entry in wordlist_entries_meta
+    ]
     max_entry_len = max((len(e) for e in wordlist_entries), default=24)
     print_multicolumn_list(
         "Wordlists (entries ending in / are directories: hashcat reads every file inside)",
         wordlist_entries,
         min_col_width=max_entry_len,
         max_col_width=max_entry_len,
+        styles=entry_styles,
     )
 
     def path_completer(text, state):
@@ -849,12 +853,14 @@ def _pick_training_wordlist(ctx: Any, title: str = "Training Wordlists"):
             f"{i}) {entry.name}/" if entry.is_dir else f"{i}) {entry.name}"
             for i, entry in enumerate(entries_meta, start=1)
         ]
+        entry_styles = ["\033[36m" if entry.is_dir else None for entry in entries_meta]
         max_len = max((len(e) for e in entries), default=24)
         print_multicolumn_list(
             title,
             entries,
             min_col_width=max_len,
             max_col_width=max_len,
+            styles=entry_styles,
         )
     print("\tp. Enter a custom path")
     print("\tq. Cancel")
@@ -956,12 +962,15 @@ def _markov_pick_training_source(ctx: Any):
     entries_meta = ctx.list_wordlist_entries(ctx.hcatWordlists)
     # Print the grid once, outside the retry loop — see _pick_training_wordlist.
     entries = []
+    entry_styles = []
     if has_cracked:
         entries.append("0) Cracked passwords (current session)")
+        entry_styles.append(None)
     entries.extend(
         f"{i}) {entry.name}/" if entry.is_dir else f"{i}) {entry.name}"
         for i, entry in enumerate(entries_meta, start=1)
     )
+    entry_styles.extend("\033[36m" if entry.is_dir else None for entry in entries_meta)
     if entries:
         max_len = max((len(e) for e in entries), default=24)
         print_multicolumn_list(
@@ -969,6 +978,7 @@ def _markov_pick_training_source(ctx: Any):
             entries,
             min_col_width=max_len,
             max_col_width=max_len,
+            styles=entry_styles,
         )
     print("\tp. Enter a custom path")
     print("\tq. Cancel")

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -1325,14 +1325,32 @@ def _rule_select_file(ctx: Any, prompt: str = "Rule file: ") -> str:
     def rule_completer(text: str, state: int) -> str | None:
         base = ctx.rulesDirectory
         if not text:
-            pattern = os.path.join(base, "*.rule")
+            pattern = os.path.join(base, "*")
         else:
             text = os.path.expanduser(text)
             if text.startswith(("/", "./", "../", "~")):
                 pattern = text + "*"
             else:
                 pattern = os.path.join(base, text + "*")
-        matches = _glob.glob(pattern)
+        # Glob once per branch, on the same resolved pattern, then filter and
+        # mark from that single candidate list -- deriving directory markers
+        # from a separately hardcoded join broke the free-path branches
+        # (./..., ../...), since os.path.join only discards `base` when the
+        # second argument is absolute.
+        candidates = _glob.glob(pattern)
+        matches = [
+            entry + "/" if os.path.isdir(entry) else entry
+            for entry in candidates
+            # Directories are always offered -- you have to be able to walk
+            # into one. Files are limited to *.rule, matching the empty-input
+            # case, so typing a character does not surface notes or backups
+            # the empty prompt hides. Filtering post-glob (rather than baking
+            # ".rule" into the glob pattern) keeps incremental completion
+            # working once the typed text reaches the extension itself, e.g.
+            # "best64.r" still matches "best64.rule".
+            if os.path.isdir(entry) or entry.endswith(".rule")
+        ]
+        matches = sorted(set(matches))
         try:
             return matches[state]
         except IndexError:

--- a/hate_crack/formatting.py
+++ b/hate_crack/formatting.py
@@ -17,7 +17,9 @@ def _terminal_width(default: int = 120) -> int:
     return default
 
 
-def print_multicolumn_list(title, entries, min_col_width=20, max_col_width=None):
+def print_multicolumn_list(
+    title, entries, min_col_width=20, max_col_width=None, styles=None
+):
     if not entries:
         if title:
             print(f"\n{title}:\n  (none)")
@@ -48,8 +50,26 @@ def print_multicolumn_list(title, entries, min_col_width=20, max_col_width=None)
                         entry = entry[: max_entry_len - 3] + "..."
                     else:
                         entry = entry[:max_entry_len]
-                line_parts.append(entry.ljust(col_width))
-        print("".join(line_parts).rstrip())
+                padded = entry.ljust(col_width)
+                style = styles[idx] if styles and idx < len(styles) else None
+                # Style is applied to the already-padded, already-truncated
+                # text: ljust() and the truncation above both count characters,
+                # so an escape sequence inside `entry` would be measured as
+                # visible width and the grid would go ragged.
+                line_parts.append(f"{style}{padded}\033[0m" if style else padded)
+        line = "".join(line_parts)
+        # rstrip() alone would leave trailing padding spaces stranded in front
+        # of a reset code when the last populated column is styled (its last
+        # character is the "m" of "\033[0m", not whitespace, so a plain
+        # rstrip() no-ops there). Strip a trailing reset first, rstrip the
+        # remainder, then reattach it so the visible width still matches the
+        # unstyled render exactly.
+        reset_suffix = "\033[0m" if line.endswith("\033[0m") else ""
+        if reset_suffix:
+            line = line[: -len(reset_suffix)].rstrip() + reset_suffix
+        else:
+            line = line.rstrip()
+        print(line)
 
     if title:
         print("=" * terminal_width)

--- a/hate_crack/hashview_cache.py
+++ b/hate_crack/hashview_cache.py
@@ -3,6 +3,21 @@
 Tracks (hash, hash_type) pairs that have been successfully uploaded so
 repeat uploads (upload_cracked_hashes, upload_hashfile) can skip them
 before doing any verification or network work.
+
+``cache_key`` takes an explicit ``scope`` tag because the two upload paths
+represent different operations that must never collide in the cache:
+
+- ``upload_hashfile`` sends ciphertexts *to be cracked*. Its keys are scoped
+  as ``"hashfile:<customer_id>"`` so re-uploading the same hashlist for a
+  different customer/engagement is not silently skipped.
+- ``upload_cracked_hashes`` sends plaintexts back *as a cracked result*
+  (default scope ``"cracked"``).
+
+Without distinct scopes, uploading a hashfile and later uploading the
+cracked results for those same hashes would hash to the same cache key: the
+second (cracked-results) upload would see every hash as already "uploaded"
+and skip it entirely, silently dropping the results while still reporting
+success.
 """
 
 import hashlib
@@ -21,8 +36,8 @@ def _cache_path() -> Path:
     return Path(os.path.expanduser("~")) / ".hate_crack" / CACHE_FILENAME
 
 
-def cache_key(hash_value: str, hash_type) -> str:
-    return hashlib.sha256(f"{hash_value}:{hash_type}".encode()).hexdigest()
+def cache_key(hash_value: str, hash_type, scope: str = "cracked") -> str:
+    return hashlib.sha256(f"{scope}:{hash_value}:{hash_type}".encode()).hexdigest()
 
 
 def load_cache() -> set:

--- a/hate_crack/hashview_cache.py
+++ b/hate_crack/hashview_cache.py
@@ -1,0 +1,44 @@
+"""Cross-run cache of hashes already uploaded to Hashview.
+
+Tracks (hash, hash_type) pairs that have been successfully uploaded so
+repeat uploads (upload_cracked_hashes, upload_hashfile) can skip them
+before doing any verification or network work.
+"""
+
+import hashlib
+import os
+from pathlib import Path
+from typing import Iterable
+
+CACHE_FILENAME = "hashview_uploaded_cache.txt"
+
+
+def _cache_path() -> Path:
+    # Mirrors the inline ~/.hate_crack construction main.py's omen
+    # model_info.json cache uses (main.py ~line 4093). Deliberately NOT
+    # hate_crack.api._get_hate_path(), which resolves the bundled
+    # hashcat-utils/PACK assets directory -- a different thing entirely.
+    return Path(os.path.expanduser("~")) / ".hate_crack" / CACHE_FILENAME
+
+
+def cache_key(hash_value: str, hash_type) -> str:
+    return hashlib.sha256(f"{hash_value}:{hash_type}".encode()).hexdigest()
+
+
+def load_cache() -> set:
+    path = _cache_path()
+    if not path.exists():
+        return set()
+    with path.open("r", encoding="utf-8") as f:
+        return {line.strip() for line in f if line.strip()}
+
+
+def append_to_cache(keys: Iterable[str]) -> None:
+    keys = list(keys)
+    if not keys:
+        return
+    path = _cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        for key in keys:
+            f.write(key + "\n")

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -143,7 +143,10 @@ def _visible_entries(directory):
     """
     try:
         names = os.listdir(directory)
-    except (FileNotFoundError, NotADirectoryError, PermissionError):
+    except PermissionError:
+        print(f"[!] Cannot list {directory}: permission denied")
+        return []
+    except (FileNotFoundError, NotADirectoryError):
         return []
     entries = []
     for name in sorted(names):

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -4777,6 +4777,10 @@ def hashview_api():
                         if result.get("skipped"):
                             line += f" ({result['skipped']} skipped by validation)"
                         print(line)
+                    if result.get("skipped_cached"):
+                        print(
+                            f"  Skipped: {result['skipped_cached']} already uploaded previously"
+                        )
                     # What the server actually did (newer Hashview reports these).
                     if "verified" in result or "updated" in result or "count" in result:
                         updated = result.get("updated", result.get("count"))
@@ -5091,6 +5095,10 @@ def hashview_api():
                             print(f"  Hash count: {result['hash_count']}")
                         if "instacracked" in result:
                             print(f"  Insta-cracked: {result['instacracked']}")
+                        if result.get("skipped_cached"):
+                            print(
+                                f"  Skipped: {result['skipped_cached']} already uploaded previously"
+                            )
 
                         # Offer to create a job
                         create_job = (
@@ -6442,6 +6450,10 @@ def main():
             print(f"\n✓ Success: {result.get('msg', 'Cracked hashes uploaded')}")
             if "count" in result:
                 print(f"  Imported: {result['count']} hashes")
+            if result.get("skipped_cached"):
+                print(
+                    f"  Skipped: {result['skipped_cached']} already uploaded previously"
+                )
             sys.exit(0)
 
         if args.hashview_command == "upload-wordlist":
@@ -6487,6 +6499,10 @@ def main():
                 args.hashfile_name,
             )
             print(f"\n✓ Success: {upload_result.get('msg', 'Hashfile uploaded')}")
+            if upload_result.get("skipped_cached"):
+                print(
+                    f"  Skipped: {upload_result['skipped_cached']} already uploaded previously"
+                )
             if "hashfile_id" not in upload_result:
                 print("✗ Error: Hashfile upload did not return a hashfile_id.")
                 sys.exit(1)

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -5095,10 +5095,6 @@ def hashview_api():
                             print(f"  Hash count: {result['hash_count']}")
                         if "instacracked" in result:
                             print(f"  Insta-cracked: {result['instacracked']}")
-                        if result.get("skipped_cached"):
-                            print(
-                                f"  Skipped: {result['skipped_cached']} already uploaded previously"
-                            )
 
                         # Offer to create a job
                         create_job = (
@@ -5156,6 +5152,10 @@ def hashview_api():
                                     )
                             except Exception as e:
                                 print(f"\n✗ Error creating job: {str(e)}")
+                    if result.get("skipped_cached"):
+                        print(
+                            f"  Skipped: {result['skipped_cached']} already uploaded previously"
+                        )
                 except Exception as e:
                     print(f"\n✗ Error uploading hashfile: {str(e)}")
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -172,9 +172,13 @@ def list_wordlist_entries(directory):
 def list_wordlist_files(directory):
     """Wordlist filenames in *directory* -- files only, no directories.
 
-    Files only is the point: every caller of this joins the name onto
-    *directory* and hands the result to hashcat as a file argument, so a
-    subdirectory here becomes an argument hashcat rejects.
+    Not every caller of this hands the name straight to hashcat as a
+    dictionary-position argument -- hashcat accepts a directory there.
+    Its remaining callers need files specifically:
+    hcatYoloCombination builds an ``-a 1`` command, where hashcat rejects a
+    directory operand, and wordlist_optimize opens each path itself with
+    ``os.path.isfile``/``open()``, which needs a real file, not hashcat's
+    own directory handling.
     """
     return [
         entry.name for entry in list_wordlist_entries(directory) if not entry.is_dir
@@ -2076,7 +2080,8 @@ def hcatDictionary(hcatHashType, hcatHashFile):
     global hcatProcess
     rule_best66 = get_rule_path("best66.rule")
     optimized_lists = [
-        os.path.join(hcatWordlists, f) for f in list_wordlist_files(hcatWordlists)
+        os.path.join(hcatWordlists, entry.name)
+        for entry in list_wordlist_entries(hcatWordlists)
     ]
     if not optimized_lists:
         optimized_lists = [os.path.join(hcatWordlists, "*")]

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -4799,11 +4799,6 @@ def hashview_api():
                                 "  Unmatched (already cracked or not in Hashview): "
                                 f"{result['unmatched']}"
                             )
-                    else:
-                        print(
-                            "  (This Hashview did not report an import count; "
-                            "upgrade Hashview to see how many landed.)"
-                        )
                 except Exception as e:
                     print(f"\n✗ Error: {str(e)}")
                     import traceback

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -5540,6 +5540,19 @@ def wordlist_gate(infile: str, outfile: str, mod: int, offset: int) -> bool:
     return result.returncode == 0
 
 
+def _outdir_is_empty(outdir):
+    """Does *outdir* hold no split output yet?
+
+    Dot-files do not count. `not os.listdir(outdir)` is False as soon as macOS
+    drops a .DS_Store in there, which sent the first wordlist down the merge
+    path against an effectively empty directory.
+    """
+    try:
+        return not [name for name in os.listdir(outdir) if not name.startswith(".")]
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        return True
+
+
 def wordlist_optimize(input_wordlists: list[str], outdir: str) -> bool:
     """Consolidate wordlists into per-length deduplicated files in outdir."""
     os.makedirs(outdir, exist_ok=True)
@@ -5547,7 +5560,7 @@ def wordlist_optimize(input_wordlists: list[str], outdir: str) -> bool:
         if not os.path.isfile(wl):
             print(f"[!] Skipping missing wordlist: {wl}")
             continue
-        if not os.listdir(outdir):
+        if _outdir_is_empty(outdir):
             if not wordlist_splitlen(wl, outdir):
                 return False
             continue

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -5088,7 +5088,7 @@ def hashview_api():
                         hashfile_name,
                     )
                     print(f"\n✓ Success: {result.get('msg', 'Hashfile uploaded')}")
-                    if "hashfile_id" in result:
+                    if result.get("hashfile_id"):
                         print(f"  Hashfile ID: {result['hashfile_id']}")
                         # Hash count is not returned by the upload API, so we don't display it
                         if "hash_count" in result:
@@ -6503,7 +6503,7 @@ def main():
                 print(
                     f"  Skipped: {upload_result['skipped_cached']} already uploaded previously"
                 )
-            if "hashfile_id" not in upload_result:
+            if not upload_result.get("hashfile_id"):
                 print("✗ Error: Hashfile upload did not return a hashfile_id.")
                 sys.exit(1)
             job_result = api_harness.create_job(

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -5551,10 +5551,23 @@ def _outdir_is_empty(outdir):
     Dot-files do not count. `not os.listdir(outdir)` is False as soon as macOS
     drops a .DS_Store in there, which sent the first wordlist down the merge
     path against an effectively empty directory.
+
+    A missing or non-directory path really is "empty" (there is nothing to
+    merge with), so those cases return `True`. A `PermissionError` is
+    different: a directory that is write+execute but not readable (mode
+    `0333`) still lets files get created inside it even though listing it
+    raises. Reporting `True` ("empty") there would send every wordlist down
+    the caller's first-wordlist branch (write straight into outdir) instead
+    of the merge branch, silently overwriting earlier per-length output.
+    Returning `False` forces the merge branch instead, which only stats and
+    reads/writes specific filenames and works fine without read access to the
+    directory listing.
     """
     try:
         return not [name for name in os.listdir(outdir) if not name.startswith(".")]
-    except (FileNotFoundError, NotADirectoryError, PermissionError):
+    except PermissionError:
+        return False
+    except (FileNotFoundError, NotADirectoryError):
         return True
 
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -103,13 +103,6 @@ except ImportError as rosetta_import_error:
     DebugAnalyzer = None
 
 
-def _argv_requests_help_or_version(argv=None):
-    """True if argv asks for help/version -- these don't need the toolchain."""
-    if argv is None:
-        argv = sys.argv[1:]
-    return any(a in ("-h", "--help", "--version") for a in argv)
-
-
 def rosetta_unavailable_reason():
     """Return a human-readable explanation for HashcatRosetta being missing."""
     message = (
@@ -741,16 +734,15 @@ except _config_loader.ConfigFileUnreadableError as _exc:
     _config_loader.exit_unreadable_config(_exc)
 _env_missing_before_bootstrap = _env_path is None
 _json_missing_before_bootstrap = _legacy_json_path is None
-if not _argv_requests_help_or_version():
-    _env_path, _legacy_json_path = _bootstrap_config_files(_env_path, _legacy_json_path)
-    _print_config_sources(
-        _env_path,
-        _legacy_json_path,
-        env_created=_env_missing_before_bootstrap,
-        json_created=_json_missing_before_bootstrap,
-        env_detail=_config_bootstrap_detail.get("env"),
-        json_detail=_config_bootstrap_detail.get("json"),
-    )
+_env_path, _legacy_json_path = _bootstrap_config_files(_env_path, _legacy_json_path)
+_print_config_sources(
+    _env_path,
+    _legacy_json_path,
+    env_created=_env_missing_before_bootstrap,
+    json_created=_json_missing_before_bootstrap,
+    env_detail=_config_bootstrap_detail.get("env"),
+    json_detail=_config_bootstrap_detail.get("json"),
+)
 
 # The loader is the single definition of the precedence stack: for each key,
 # schema default < that key's own home file < os.environ. config_parser stays
@@ -778,6 +770,13 @@ hashview_api_key = config_parser["hashview_api_key"]
 logger = logging.getLogger("hate_crack")
 if not logger.handlers:
     logger.addHandler(logging.NullHandler())
+
+
+def _argv_requests_help_or_version(argv=None):
+    """True if argv asks for help/version -- these don't need the toolchain."""
+    if argv is None:
+        argv = sys.argv[1:]
+    return any(a in ("-h", "--help", "--version") for a in argv)
 
 
 def ensure_binary(binary_path, build_dir=None, name=None):

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -22,6 +22,7 @@ import shlex
 import time
 import argparse
 import contextlib
+import dataclasses
 import gzip
 import lzma
 import tempfile
@@ -115,14 +116,79 @@ def rosetta_unavailable_reason():
 EXCLUDED_WORDLIST_EXTENSIONS = frozenset({".7z", ".torrent", ".out"})
 
 
+@dataclasses.dataclass(frozen=True)
+class DirEntry:
+    """One listing entry, with enough type information for the caller to decide.
+
+    Pickers need to render directories differently and callers need to know
+    whether a name can be handed to hashcat as a file, so the type travels with
+    the name instead of every call site re-running os.path.isdir.
+    """
+
+    name: str
+    is_dir: bool
+
+
+def _visible_entries(directory):
+    """Sorted ``DirEntry`` list for *directory*, dot-files excluded.
+
+    Dot-files are dropped wholesale rather than by name: the previous code
+    special-cased ``.DS_Store`` and so still offered ``.gitkeep`` and ``.keep``
+    as wordlists. Nothing hate_crack reads is a dot-file.
+
+    A missing path, or a path that is a file, yields ``[]``. Both happen in the
+    field -- a wordlists directory that has not been created yet, and a
+    ``hcatWordlists`` pointed at a single file -- and neither should crash a
+    picker with a traceback.
+    """
+    try:
+        names = os.listdir(directory)
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        return []
+    entries = []
+    for name in sorted(names):
+        if name.startswith("."):
+            continue
+        entries.append(DirEntry(name, os.path.isdir(os.path.join(directory, name))))
+    return entries
+
+
+def list_wordlist_entries(directory):
+    """Wordlist-directory listing including subdirectories.
+
+    For pickers that can offer a directory: hashcat accepts one and consumes
+    every file in it, so a directory is a legitimate selection -- it just has to
+    be labelled as one. See :func:`list_wordlist_files` for callers that need
+    files only.
+    """
+    return [
+        entry
+        for entry in _visible_entries(directory)
+        if entry.is_dir
+        or not any(entry.name.endswith(ext) for ext in EXCLUDED_WORDLIST_EXTENSIONS)
+    ]
+
+
 def list_wordlist_files(directory):
-    """Return sorted list of filenames in *directory*, excluding non-wordlist artifacts."""
-    return sorted(
-        f
-        for f in os.listdir(directory)
-        if f != ".DS_Store"
-        and not any(f.endswith(ext) for ext in EXCLUDED_WORDLIST_EXTENSIONS)
-    )
+    """Wordlist filenames in *directory* -- files only, no directories.
+
+    Files only is the point: every caller of this joins the name onto
+    *directory* and hands the result to hashcat as a file argument, so a
+    subdirectory here becomes an argument hashcat rejects.
+    """
+    return [
+        entry.name for entry in list_wordlist_entries(directory) if not entry.is_dir
+    ]
+
+
+def list_rule_files(directory):
+    """Rule filenames in *directory* -- files only, no directories.
+
+    A rules directory grows subdirectories as soon as someone unpacks a rules
+    collection into it. ``-r <directory>`` is rejected by hashcat, and the LLM
+    attack loops over every entry without a human watching.
+    """
+    return [entry.name for entry in _visible_entries(directory) if not entry.is_dir]
 
 
 DEFAULT_OPTIMIZED_ATTACKS = frozenset(

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -103,6 +103,13 @@ except ImportError as rosetta_import_error:
     DebugAnalyzer = None
 
 
+def _argv_requests_help_or_version(argv=None):
+    """True if argv asks for help/version -- these don't need the toolchain."""
+    if argv is None:
+        argv = sys.argv[1:]
+    return any(a in ("-h", "--help", "--version") for a in argv)
+
+
 def rosetta_unavailable_reason():
     """Return a human-readable explanation for HashcatRosetta being missing."""
     message = (
@@ -734,15 +741,16 @@ except _config_loader.ConfigFileUnreadableError as _exc:
     _config_loader.exit_unreadable_config(_exc)
 _env_missing_before_bootstrap = _env_path is None
 _json_missing_before_bootstrap = _legacy_json_path is None
-_env_path, _legacy_json_path = _bootstrap_config_files(_env_path, _legacy_json_path)
-_print_config_sources(
-    _env_path,
-    _legacy_json_path,
-    env_created=_env_missing_before_bootstrap,
-    json_created=_json_missing_before_bootstrap,
-    env_detail=_config_bootstrap_detail.get("env"),
-    json_detail=_config_bootstrap_detail.get("json"),
-)
+if not _argv_requests_help_or_version():
+    _env_path, _legacy_json_path = _bootstrap_config_files(_env_path, _legacy_json_path)
+    _print_config_sources(
+        _env_path,
+        _legacy_json_path,
+        env_created=_env_missing_before_bootstrap,
+        json_created=_json_missing_before_bootstrap,
+        env_detail=_config_bootstrap_detail.get("env"),
+        json_detail=_config_bootstrap_detail.get("json"),
+    )
 
 # The loader is the single definition of the precedence stack: for each key,
 # schema default < that key's own home file < os.environ. config_parser stays
@@ -1116,7 +1124,7 @@ hcatGoodMeasureBaseList = _normalize_wordlist_setting(
     hcatGoodMeasureBaseList, wordlists_dir
 )
 hcatPrinceBaseList = _normalize_wordlist_setting(hcatPrinceBaseList, wordlists_dir)
-if not SKIP_INIT:
+if not SKIP_INIT and not _argv_requests_help_or_version():
     # Verify hashcat binary is available
     # hcatBin should be in PATH or be an absolute path (resolved from hcatPath + hcatBin if configured)
     try:

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2969,7 +2969,7 @@ def hcatOllama(hcatHashType, hcatHashFile, mode, context_data):
         return
 
     # Step D: hashcat with candidates against every rule in the rules directory.
-    rule_files = sorted(f for f in os.listdir(rulesDirectory) if f != ".DS_Store")
+    rule_files = list_rule_files(rulesDirectory)
     if not rule_files:
         print("No rule files found in rules directory. Skipping rule-based attacks.")
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,19 @@ def _isolate_notify_state():
     notify.clear_state_for_tests()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_hashview_cache(monkeypatch, tmp_path):
+    """Isolate hashview cache per test to avoid cross-test contamination.
+
+    The cache module reads from ``~/.hate_crack/hashview_cache.txt`` by default.
+    Without isolation, tests that populate the cache would affect subsequent
+    tests that don't explicitly set HOME to a temp directory, causing hashes
+    to be unexpectedly skipped as already-cached.
+    """
+    # Set HOME to a temp directory for each test, so cache operations are isolated
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
 def pytest_configure(config):
     """Spin up + seed a local Hashview docker stack for the live test suite.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,15 +111,28 @@ def _isolate_notify_state():
 
 @pytest.fixture(autouse=True)
 def _isolate_hashview_cache(monkeypatch, tmp_path):
-    """Isolate hashview cache per test to avoid cross-test contamination.
+    """Isolate the hashview upload cache per test to avoid cross-test
+    contamination.
 
-    The cache module reads from ``~/.hate_crack/hashview_cache.txt`` by default.
-    Without isolation, tests that populate the cache would affect subsequent
-    tests that don't explicitly set HOME to a temp directory, causing hashes
-    to be unexpectedly skipped as already-cached.
+    The cache module reads from
+    ``~/.hate_crack/hashview_uploaded_cache.txt`` by default (see
+    ``hate_crack.hashview_cache.CACHE_FILENAME``). Without isolation, tests
+    that populate the cache would affect subsequent tests, causing hashes to
+    be unexpectedly skipped as already-cached.
+
+    This patches ``hashview_cache._cache_path`` directly rather than
+    monkeypatching ``HOME`` for the whole process -- ``HOME`` affects far
+    more than this one cache (path expansion elsewhere in the suite), so
+    narrowing to the specific function keeps this fixture's blast radius to
+    exactly the thing it isolates.
     """
-    # Set HOME to a temp directory for each test, so cache operations are isolated
-    monkeypatch.setenv("HOME", str(tmp_path))
+    from hate_crack import hashview_cache
+
+    monkeypatch.setattr(
+        hashview_cache,
+        "_cache_path",
+        lambda: tmp_path / ".hate_crack" / hashview_cache.CACHE_FILENAME,
+    )
 
 
 def pytest_configure(config):

--- a/tests/test_adhoc_mask.py
+++ b/tests/test_adhoc_mask.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from hate_crack.main import DirEntry
+
 
 def _make_ctx(hash_type: str = "1000", hash_file: str = "/tmp/hashes.txt") -> MagicMock:
     ctx = MagicMock()
@@ -135,6 +137,7 @@ class TestMarkovBruteForceHandler:
         ctx.hcatHashFile = hash_file
         ctx.hcatMarkovTrain.return_value = True
         ctx.list_wordlist_files.return_value = ["test.txt"]
+        ctx.list_wordlist_entries.return_value = [DirEntry("test.txt", False)]
 
         with patch("builtins.input", side_effect=["1", "1", "6"]):
             markov_brute_force(ctx)
@@ -151,6 +154,7 @@ class TestMarkovBruteForceHandler:
         ctx.hcatHashFile = hash_file
         ctx.hcatMarkovTrain.return_value = False
         ctx.list_wordlist_files.return_value = ["test.txt"]
+        ctx.list_wordlist_entries.return_value = [DirEntry("test.txt", False)]
 
         with patch("builtins.input", side_effect=["1", "1"]):
             markov_brute_force(ctx)

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -32,6 +32,7 @@ class TestLoopbackAttack:
         ctx.hcatWordlists = str(tmp_path / "wordlists")
         ctx.rulesDirectory = str(tmp_path / "rules")
         os.makedirs(ctx.rulesDirectory, exist_ok=True)
+        ctx.list_rule_files.return_value = []
 
         # No rule files in directory -> prompts for download -> user says "n"
         # Then rule_choice becomes ["0"] via the "no rules" branch
@@ -52,6 +53,7 @@ class TestLoopbackAttack:
         rules_dir = tmp_path / "rules"
         rules_dir.mkdir()
         (rules_dir / "best66.rule").write_text("")
+        ctx.list_rule_files.return_value = ["best66.rule"]
 
         with patch("builtins.input", return_value="1"):
             loopback_attack(ctx)

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -16,6 +16,7 @@ from hate_crack.attacks import (
     top_mask_crack,
     yolo_combination,
 )
+from hate_crack.main import DirEntry
 
 
 def _make_ctx(hash_type: str = "1000", hash_file: str = "/tmp/hashes.txt") -> MagicMock:
@@ -407,6 +408,7 @@ class TestOllamaAttack:
     def test_wordlist_mode_calls_hcatOllama_with_path(self) -> None:
         ctx = _make_ctx()
         ctx.list_wordlist_files.return_value = ["rockyou.txt"]
+        ctx.list_wordlist_entries.return_value = [DirEntry("rockyou.txt", False)]
         ctx.hcatWordlists = "/tmp/wl"
 
         # mode "2" from interactive_menu, then pick wordlist "1" via input
@@ -438,6 +440,7 @@ class TestOllamaAttack:
         ctx = _make_ctx()
         # mode "2" from interactive_menu, then user cancels the file picker
         ctx.list_wordlist_files.return_value = []
+        ctx.list_wordlist_entries.return_value = []
         with (
             patch("hate_crack.attacks.interactive_menu", return_value="2"),
             patch("builtins.input", side_effect=["q"]),
@@ -556,7 +559,11 @@ class TestOmenPickTrainingWordlistReprompt:
 
     def _make_ctx(self, wordlist_files=None):
         ctx = MagicMock()
-        ctx.list_wordlist_files.return_value = wordlist_files or ["rockyou.txt"]
+        files = wordlist_files or ["rockyou.txt"]
+        ctx.list_wordlist_files.return_value = files
+        ctx.list_wordlist_entries.return_value = [
+            DirEntry(name, False) for name in files
+        ]
         ctx.hcatWordlists = "/tmp/wl"
         ctx.hcatHashFile = "/tmp/hashes.txt"
         return ctx
@@ -595,7 +602,11 @@ class TestMarkovPickTrainingSourceReprompt:
         ctx = MagicMock()
         hash_file = str(tmp_path / "hashes.txt")
         ctx.hcatHashFile = hash_file
-        ctx.list_wordlist_files.return_value = wordlist_files or ["rockyou.txt"]
+        files = wordlist_files or ["rockyou.txt"]
+        ctx.list_wordlist_files.return_value = files
+        ctx.list_wordlist_entries.return_value = [
+            DirEntry(name, False) for name in files
+        ]
         ctx.hcatWordlists = str(tmp_path / "wordlists")
         if has_cracked:
             (tmp_path / "hashes.txt.out").write_text("cracked_pw\n")

--- a/tests/test_formatting_colour.py
+++ b/tests/test_formatting_colour.py
@@ -1,0 +1,78 @@
+"""Colour in the multi-column grid, without breaking its alignment.
+
+print_multicolumn_list pads with ljust() and truncates on len(), so a
+pre-coloured entry string would be padded and truncated by its *byte* length
+including escape sequences: the grid goes ragged and a long name can be cut
+mid-escape, leaving the terminal coloured for everything after it.
+"""
+
+from __future__ import annotations
+
+import re
+
+from hate_crack.formatting import print_multicolumn_list
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def test_styles_do_not_change_the_visible_layout(capsys):
+    entries = [f"{i}) item{i}" for i in range(1, 7)]
+    print_multicolumn_list("T", entries, min_col_width=12, max_col_width=12)
+    plain = capsys.readouterr().out
+
+    print_multicolumn_list(
+        "T",
+        entries,
+        min_col_width=12,
+        max_col_width=12,
+        styles=["\x1b[36m", None, "\x1b[36m", None, "\x1b[36m", None],
+    )
+    coloured = capsys.readouterr().out
+
+    assert ANSI.sub("", coloured) == plain, (
+        "colour changed the visible layout; padding is not visible-width aware"
+    )
+
+
+def test_every_style_is_reset(capsys):
+    print_multicolumn_list("T", ["1) a"], styles=["\x1b[36m"])
+    out = capsys.readouterr().out
+    assert "\x1b[36m" in out
+    assert "\x1b[0m" in out, "an unreset colour leaks into the rest of the session"
+
+
+def test_no_styles_argument_emits_no_escapes(capsys):
+    print_multicolumn_list("T", ["1) a", "2) b"])
+    assert not ANSI.search(capsys.readouterr().out)
+
+
+def test_truncation_counts_visible_characters(capsys):
+    print_multicolumn_list(
+        "T",
+        ["1) a-very-long-entry-name"],
+        min_col_width=10,
+        max_col_width=10,
+        styles=["\x1b[36m"],
+    )
+    out = capsys.readouterr().out
+    visible = ANSI.sub("", out).splitlines()
+    row = next(line for line in visible if line.strip().startswith("1)"))
+    assert len(row.rstrip()) <= 10, f"truncated on byte length, not visible: {row!r}"
+    assert out.rstrip().endswith("\x1b[0m") or "\x1b[0m" in out
+
+
+def test_styled_last_column_does_not_strand_padding_before_reset(capsys):
+    # A styled entry that is the last populated column in its row needs
+    # padding to reach col_width; that padding must not survive as trailing
+    # whitespace in front of the reset code, or the visible-width comparison
+    # with an unstyled render would fail.
+    entries = ["1) short"]
+    print_multicolumn_list("T", entries, min_col_width=20, max_col_width=20)
+    plain = capsys.readouterr().out
+
+    print_multicolumn_list(
+        "T", entries, min_col_width=20, max_col_width=20, styles=["\x1b[36m"]
+    )
+    coloured = capsys.readouterr().out
+
+    assert ANSI.sub("", coloured) == plain

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -16,7 +16,12 @@ from unittest.mock import Mock, patch, MagicMock
 # Add the parent directory to the path to import hate_crack
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from hate_crack.api import HashviewAPI, HASHVIEW_DEFAULT_TIMEOUT, _digest_for_type
+from hate_crack.api import (
+    HashviewAPI,
+    HASHVIEW_DEFAULT_TIMEOUT,
+    HASHVIEW_UPLOAD_TIMEOUT,
+    _digest_for_type,
+)
 
 # Test configuration - these are mock values, not real credentials
 HASHVIEW_URL = "https://hashview.example.com"
@@ -1213,6 +1218,54 @@ class TestHashviewAPI:
 
         _, kwargs = api.session.get.call_args
         assert kwargs.get("timeout") == HASHVIEW_DEFAULT_TIMEOUT
+
+    def test_upload_wordlist_file_passes_upload_timeout(self, api, tmp_path):
+        """Bulk uploads need more headroom than metadata calls -- see #241."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"status": 200}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        wordlist_path = tmp_path / "words.txt"
+        wordlist_path.write_text("password\n")
+        api.upload_wordlist_file(str(wordlist_path))
+
+        _, kwargs = api.session.post.call_args
+        assert kwargs.get("timeout") == HASHVIEW_UPLOAD_TIMEOUT
+
+    def test_upload_hashfile_passes_upload_timeout(self, api, tmp_path, monkeypatch):
+        """Bulk uploads need more headroom than metadata calls -- see #241."""
+        monkeypatch.setattr("hate_crack.api.load_cache", lambda: set())
+        monkeypatch.setattr("hate_crack.api.append_to_cache", lambda keys: None)
+        mock_response = Mock()
+        mock_response.json.return_value = {"status": 200}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        hash_file = tmp_path / "hashes.txt"
+        hash_file.write_text("31d6cfe0d16ae931b73c59d7e0c089c0\n")
+        api.upload_hashfile(str(hash_file), customer_id=1, hash_type="1000")
+
+        _, kwargs = api.session.post.call_args
+        assert kwargs.get("timeout") == HASHVIEW_UPLOAD_TIMEOUT
+
+    def test_upload_cracked_hashes_passes_upload_timeout(
+        self, api, tmp_path, monkeypatch
+    ):
+        """Bulk uploads need more headroom than metadata calls -- see #241."""
+        monkeypatch.setattr("hate_crack.api.append_to_cache", lambda keys: None)
+        mock_response = Mock()
+        mock_response.json.return_value = {"status": 200, "msg": "OK"}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        cracked_file = tmp_path / "cracked.txt"
+        hash_value = _digest_for_type("1000", "password1".encode("utf-8"))
+        cracked_file.write_text(f"{hash_value}:password1\n")
+        api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+
+        _, kwargs = api.session.post.call_args
+        assert kwargs.get("timeout") == HASHVIEW_UPLOAD_TIMEOUT
 
     def test_create_job_workflow(self, api, test_hashfile):
         """Test creating a job in Hashview (option 2 complete workflow)"""

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -786,7 +786,7 @@ class TestHashviewAPI:
         monkeypatch.setenv("HOME", str(tmp_path))
         from hate_crack.hashview_cache import append_to_cache, cache_key
 
-        append_to_cache([cache_key(NTLM_A, "1000")])
+        append_to_cache([cache_key(NTLM_A, "1000", scope="cracked")])
 
         cracked_file = tmp_path / "cracked.txt"
         cracked_file.write_text(f"{NTLM_A}:{SYNTH_PLAIN_A}\n{NTLM_B}:{SYNTH_PLAIN_B}\n")
@@ -809,7 +809,7 @@ class TestHashviewAPI:
         monkeypatch.setenv("HOME", str(tmp_path))
         from hate_crack.hashview_cache import append_to_cache, cache_key
 
-        append_to_cache([cache_key(NTLM_A, "1000")])
+        append_to_cache([cache_key(NTLM_A, "1000", scope="cracked")])
 
         cracked_file = tmp_path / "cracked.txt"
         cracked_file.write_text(f"{NTLM_A}:{SYNTH_PLAIN_A}\n")
@@ -836,7 +836,7 @@ class TestHashviewAPI:
         with pytest.raises(requests.HTTPError):
             api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
 
-        assert cache_key(NTLM_A, "1000") not in load_cache()
+        assert cache_key(NTLM_A, "1000", scope="cracked") not in load_cache()
 
     def test_upload_cracked_hashes_success_populates_cache(
         self, api, tmp_path, monkeypatch
@@ -854,13 +854,13 @@ class TestHashviewAPI:
 
         api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
 
-        assert cache_key(NTLM_A, "1000") in load_cache()
+        assert cache_key(NTLM_A, "1000", scope="cracked") in load_cache()
 
     def test_upload_hashfile_skips_cached_hash(self, api, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         from hate_crack.hashview_cache import append_to_cache, cache_key
 
-        append_to_cache([cache_key(NTLM_A, "1000")])
+        append_to_cache([cache_key(NTLM_A, "1000", scope="hashfile:1")])
 
         hashfile = tmp_path / "hashes.txt"
         hashfile.write_text(f"{NTLM_A}\n{NTLM_B}\n")
@@ -882,7 +882,7 @@ class TestHashviewAPI:
         monkeypatch.setenv("HOME", str(tmp_path))
         from hate_crack.hashview_cache import append_to_cache, cache_key
 
-        append_to_cache([cache_key(NTLM_A, "1000")])
+        append_to_cache([cache_key(NTLM_A, "1000", scope="hashfile:1")])
 
         hashfile = tmp_path / "hashes.txt"
         hashfile.write_text(f"{NTLM_A}\n")
@@ -905,7 +905,7 @@ class TestHashviewAPI:
 
         api.upload_hashfile(str(hashfile), customer_id=1, hash_type="1000")
 
-        assert cache_key(NTLM_A, "1000") in load_cache()
+        assert cache_key(NTLM_A, "1000", scope="hashfile:1") in load_cache()
 
     def test_upload_hashfile_failed_post_does_not_populate_cache(
         self, api, tmp_path, monkeypatch
@@ -922,7 +922,40 @@ class TestHashviewAPI:
         with pytest.raises(requests.HTTPError):
             api.upload_hashfile(str(hashfile), customer_id=1, hash_type="1000")
 
-        assert cache_key(NTLM_A, "1000") not in load_cache()
+        assert cache_key(NTLM_A, "1000", scope="hashfile:1") not in load_cache()
+
+    def test_hashfile_upload_does_not_poison_cracked_results_cache(
+        self, api, tmp_path, monkeypatch
+    ):
+        """Regression test: uploading a hashfile (to be cracked) and later
+        uploading the cracked results for those same hashes must not collide
+        in the cache. Before the scope namespacing fix, both operations
+        hashed to the same cache key, so the cracked-results upload would
+        see every hash as already "uploaded" and silently skip it."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        hashfile = tmp_path / "hashes.txt"
+        hashfile.write_text(f"{NTLM_A}\n")
+        hashfile_response = Mock()
+        hashfile_response.json.return_value = {"hashfile_id": 456}
+        hashfile_response.raise_for_status = Mock()
+        api.session.post.return_value = hashfile_response
+
+        api.upload_hashfile(str(hashfile), customer_id=1, hash_type="1000")
+
+        cracked_file = tmp_path / "cracked.txt"
+        cracked_file.write_text(f"{NTLM_A}:{SYNTH_PLAIN_A}\n")
+        cracked_response = Mock()
+        cracked_response.json.return_value = {"imported": 1}
+        cracked_response.raise_for_status = Mock()
+        api.session.post.return_value = cracked_response
+
+        result = api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+
+        assert result["skipped_cached"] == 0
+        assert api.session.post.call_count == 2
+        posted_body = api.session.post.call_args.kwargs["data"]
+        assert NTLM_A.encode() in posted_body
 
     def test_create_customer_success(self, api):
         """create_customer returns the server's JSON body (mocked transport)."""

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -780,6 +780,82 @@ class TestHashviewAPI:
         )
         assert result["imported"] == 1
 
+    def test_upload_cracked_hashes_skips_cached_pair(self, api, tmp_path, monkeypatch):
+        """A hash already recorded in the cache is skipped, not re-validated
+        or re-uploaded, and does not count toward the upload."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from hate_crack.hashview_cache import append_to_cache, cache_key
+
+        append_to_cache([cache_key(NTLM_A, "1000")])
+
+        cracked_file = tmp_path / "cracked.txt"
+        cracked_file.write_text(f"{NTLM_A}:{SYNTH_PLAIN_A}\n{NTLM_B}:{SYNTH_PLAIN_B}\n")
+        mock_response = Mock()
+        mock_response.json.return_value = {"imported": 1}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        result = api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+
+        assert result["skipped_cached"] == 1
+        posted_body = api.session.post.call_args.kwargs["data"]
+        assert NTLM_A.encode() not in posted_body
+        assert NTLM_B.encode() in posted_body
+
+    def test_upload_cracked_hashes_all_cached_skips_network_call(
+        self, api, tmp_path, monkeypatch
+    ):
+        """If every line is already cached, no HTTP request is made."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from hate_crack.hashview_cache import append_to_cache, cache_key
+
+        append_to_cache([cache_key(NTLM_A, "1000")])
+
+        cracked_file = tmp_path / "cracked.txt"
+        cracked_file.write_text(f"{NTLM_A}:{SYNTH_PLAIN_A}\n")
+
+        result = api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+
+        assert result == {"uploaded": 0, "skipped": 0, "skipped_cached": 1}
+        api.session.post.assert_not_called()
+
+    def test_upload_cracked_hashes_failed_post_does_not_populate_cache(
+        self, api, tmp_path, monkeypatch
+    ):
+        """A failed upload must not mark hashes as cached -- a retry should
+        attempt them again."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from hate_crack.hashview_cache import load_cache, cache_key
+
+        cracked_file = tmp_path / "cracked.txt"
+        cracked_file.write_text(f"{NTLM_A}:{SYNTH_PLAIN_A}\n")
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock(side_effect=requests.HTTPError("boom"))
+        api.session.post.return_value = mock_response
+
+        with pytest.raises(requests.HTTPError):
+            api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+
+        assert cache_key(NTLM_A, "1000") not in load_cache()
+
+    def test_upload_cracked_hashes_success_populates_cache(
+        self, api, tmp_path, monkeypatch
+    ):
+        """A successful upload records the uploaded pair in the cache."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from hate_crack.hashview_cache import load_cache, cache_key
+
+        cracked_file = tmp_path / "cracked.txt"
+        cracked_file.write_text(f"{NTLM_A}:{SYNTH_PLAIN_A}\n")
+        mock_response = Mock()
+        mock_response.json.return_value = {"imported": 1}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+
+        assert cache_key(NTLM_A, "1000") in load_cache()
+
     def test_create_customer_success(self, api):
         """create_customer returns the server's JSON body (mocked transport)."""
         mock_response = Mock()

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -549,6 +549,33 @@ class TestHashviewAPI:
         assert result.get("uploaded") == 2, result
         assert result.get("skipped") == 0, result
 
+    def test_upload_cracked_hashes_preserves_leading_trailing_space(
+        self, api, tmp_path
+    ):
+        """A plaintext with a leading/trailing space must not be flagged as a
+        hash/plaintext mismatch.
+
+        A bare ``.strip()`` on the plaintext field before validation eats
+        whitespace that is part of the real password, desyncing it from the
+        hash it was validated against and causing a false-positive skip.
+        """
+        padded_plain = " " + SYNTH_PLAIN_A + " "
+        padded_ntlm = _synth_digest(1000, padded_plain)
+        cracked_file = tmp_path / "cracked.txt"
+        cracked_file.write_text(f"{padded_ntlm}:{padded_plain}\n")
+        mock_response = Mock()
+        mock_response.json.return_value = {"imported": 1}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        result = api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+
+        assert result["imported"] == 1
+        posted_body = api.session.post.call_args.kwargs["data"]
+        assert padded_plain.encode() in posted_body, (
+            "The padded plaintext must reach Hashview intact, not stripped"
+        )
+
     def test_upload_cracked_hashes_api_error(self, api, tmp_path):
         """Test uploading cracked hashes with API error response (mock only)."""
         cracked_file = tmp_path / "cracked.txt"
@@ -1403,6 +1430,46 @@ class TestHashviewAPI:
         )
         assert "abcdef" not in contents, (
             "The lossy decode of the plaintext must not reach the potfile"
+        )
+
+    def test_download_left_preserves_leading_trailing_space(
+        self, api, tmp_path, monkeypatch
+    ):
+        """A leading/trailing space in the plaintext must survive to the potfile.
+
+        A bare ``.strip()`` on the raw line before splitting on ``:`` eats
+        whitespace that belongs to the password itself, not just the line
+        terminator -- the same class of bug fixed for non-UTF-8 bytes above.
+        """
+        potfile = str(tmp_path / "hashcat.potfile")
+        monkeypatch.setattr("hate_crack.api.get_hcat_potfile_path", lambda: potfile)
+
+        found_line = b"found_hash1: " + SYNTH_PLAIN_A.encode() + b" \n"
+
+        mock_left = Mock()
+        mock_left.content = b"uncracked_hash1\n"
+        mock_left.raise_for_status = Mock()
+        mock_left.headers = {"content-length": "0"}
+        mock_left.iter_content = lambda chunk_size=8192: iter([mock_left.content])
+
+        mock_found = Mock()
+        mock_found.content = found_line
+        mock_found.raise_for_status = Mock()
+        mock_found.headers = {"content-length": "0"}
+        mock_found.iter_content = lambda chunk_size=8192: iter([mock_found.content])
+        mock_found.status_code = 200
+
+        api.session.get.side_effect = [mock_left, mock_found]
+
+        left_file = tmp_path / "left_1_2.txt"
+        api.download_left_hashes(1, 2, output_file=str(left_file))
+
+        with open(potfile, "r", encoding="utf-8") as f:
+            contents = f.read()
+
+        expected = "found_hash1: " + SYNTH_PLAIN_A + " "
+        assert expected in contents, (
+            "Leading/trailing space in the plaintext must not be stripped"
         )
 
     def test_download_left_potfile_path_param_overrides_config(self, api, tmp_path):

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -856,6 +856,74 @@ class TestHashviewAPI:
 
         assert cache_key(NTLM_A, "1000") in load_cache()
 
+    def test_upload_hashfile_skips_cached_hash(self, api, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from hate_crack.hashview_cache import append_to_cache, cache_key
+
+        append_to_cache([cache_key(NTLM_A, "1000")])
+
+        hashfile = tmp_path / "hashes.txt"
+        hashfile.write_text(f"{NTLM_A}\n{NTLM_B}\n")
+        mock_response = Mock()
+        mock_response.json.return_value = {"hashfile_id": 456}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        result = api.upload_hashfile(str(hashfile), customer_id=1, hash_type="1000")
+
+        assert result["skipped_cached"] == 1
+        posted_body = api.session.post.call_args.kwargs["data"]
+        assert NTLM_A.encode() not in posted_body
+        assert NTLM_B.encode() in posted_body
+
+    def test_upload_hashfile_all_cached_skips_network_call(
+        self, api, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from hate_crack.hashview_cache import append_to_cache, cache_key
+
+        append_to_cache([cache_key(NTLM_A, "1000")])
+
+        hashfile = tmp_path / "hashes.txt"
+        hashfile.write_text(f"{NTLM_A}\n")
+
+        result = api.upload_hashfile(str(hashfile), customer_id=1, hash_type="1000")
+
+        assert result == {"uploaded": 0, "skipped_cached": 1, "hashfile_id": None}
+        api.session.post.assert_not_called()
+
+    def test_upload_hashfile_success_populates_cache(self, api, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from hate_crack.hashview_cache import load_cache, cache_key
+
+        hashfile = tmp_path / "hashes.txt"
+        hashfile.write_text(f"{NTLM_A}\n")
+        mock_response = Mock()
+        mock_response.json.return_value = {"hashfile_id": 456}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        api.upload_hashfile(str(hashfile), customer_id=1, hash_type="1000")
+
+        assert cache_key(NTLM_A, "1000") in load_cache()
+
+    def test_upload_hashfile_failed_post_does_not_populate_cache(
+        self, api, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from hate_crack.hashview_cache import load_cache, cache_key
+
+        hashfile = tmp_path / "hashes.txt"
+        hashfile.write_text(f"{NTLM_A}\n")
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock(side_effect=requests.HTTPError("boom"))
+        api.session.post.return_value = mock_response
+
+        with pytest.raises(requests.HTTPError):
+            api.upload_hashfile(str(hashfile), customer_id=1, hash_type="1000")
+
+        assert cache_key(NTLM_A, "1000") not in load_cache()
+
     def test_create_customer_success(self, api):
         """create_customer returns the server's JSON body (mocked transport)."""
         mock_response = Mock()

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -16,7 +16,7 @@ from unittest.mock import Mock, patch, MagicMock
 # Add the parent directory to the path to import hate_crack
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from hate_crack.api import HashviewAPI, _digest_for_type
+from hate_crack.api import HashviewAPI, _digest_for_type, _md4
 
 # Test configuration - these are mock values, not real credentials
 HASHVIEW_URL = "https://hashview.example.com"
@@ -47,6 +47,16 @@ NTLM_C = _synth_digest(1000, SYNTH_PLAIN_C)
 MD5_A = _synth_digest(0, SYNTH_PLAIN_A)
 # The all-zero NTLM of the empty password; a marker Hashview must never import.
 NTLM_EMPTY = "31d6cfe0d16ae931b73c59d7e0c089c0"
+
+# A synthetic plaintext holding a genuine multi-byte UTF-8 character (£, not
+# ASCII/Latin-1-as-a-single-byte). Its NTLM digest is computed by encoding the
+# actual Unicode string as UTF-16LE directly -- the correct hashcat behaviour
+# for real text -- rather than through ``_synth_digest``/``_digest_for_type``,
+# which is exactly the code path under test (issue: potfile lines with
+# non-ASCII plaintexts were wrongly rejected as "would be rejected by
+# Hashview").
+SYNTH_PLAIN_UNICODE = "Synthetic-Example-£-Ddd"
+NTLM_UNICODE = _md4(SYNTH_PLAIN_UNICODE.encode("utf-16le"))
 
 
 class TestHashviewAPI:
@@ -573,6 +583,30 @@ class TestHashviewAPI:
         with pytest.raises(Exception) as excinfo:
             api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
         assert "Invalid API response" in str(excinfo.value)
+
+    def test_upload_cracked_hashes_unicode_plaintext_ntlm(self, api, tmp_path):
+        """A genuine multi-byte UTF-8 plaintext validates correctly for NTLM.
+
+        Regression test: ``_validate_cracked_pair`` used to zero-extend each
+        *UTF-8 byte* of a non-$HEX plaintext before UTF-16LE encoding, instead
+        of encoding the actual Unicode codepoints. That doubled up any
+        non-ASCII character (e.g. ``£`` became two UTF-16 code units instead
+        of one), producing the wrong NTLM digest and skipping an otherwise
+        valid cracked hash with "plaintext does not match hash under mode
+        1000".
+        """
+        cracked_file = tmp_path / "cracked.txt"
+        cracked_file.write_text(
+            f"{NTLM_UNICODE}:{SYNTH_PLAIN_UNICODE}\n", encoding="utf-8"
+        )
+        mock_response = Mock()
+        mock_response.json.return_value = {"imported": 1}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        result = api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+        assert result["uploaded"] == 1
+        assert result["skipped"] == 0
 
     def test_upload_skips_wrong_type_line(self, api, tmp_path, capsys):
         """An MD5 line mixed into an NTLM upload is filtered client-side."""

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -802,6 +802,31 @@ class TestHashviewAPI:
         assert NTLM_A.encode() not in posted_body
         assert NTLM_B.encode() in posted_body
 
+    def test_upload_cracked_hashes_cached_plus_invalid_does_not_raise(
+        self, api, tmp_path, monkeypatch
+    ):
+        """One cached hash plus one genuinely invalid line must not raise
+        "No valid hashes to upload" -- that exception should be reserved for
+        the case where NOTHING was cached and NOTHING was valid. Before this
+        fix, ``skipped_cached and not skipped`` meant any invalid line at all
+        (even alongside cached hits) fell through to the exception, blaming
+        the invalid line and hiding that the cached hashes were actually
+        fine."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from hate_crack.hashview_cache import append_to_cache, cache_key
+
+        append_to_cache([cache_key(NTLM_A, "1000", scope="cracked")])
+
+        cracked_file = tmp_path / "cracked.txt"
+        # NTLM_A is cached and skipped; MD5_A does not match hash mode 1000
+        # and is genuinely invalid.
+        cracked_file.write_text(f"{NTLM_A}:{SYNTH_PLAIN_A}\n{MD5_A}:{SYNTH_PLAIN_A}\n")
+        api.session.post.side_effect = AssertionError("should not POST")
+
+        result = api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+
+        assert result == {"uploaded": 0, "skipped": 1, "skipped_cached": 1}
+
     def test_upload_cracked_hashes_all_cached_skips_network_call(
         self, api, tmp_path, monkeypatch
     ):

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -16,7 +16,7 @@ from unittest.mock import Mock, patch, MagicMock
 # Add the parent directory to the path to import hate_crack
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from hate_crack.api import HashviewAPI, _digest_for_type
+from hate_crack.api import HashviewAPI, HASHVIEW_DEFAULT_TIMEOUT, _digest_for_type
 
 # Test configuration - these are mock values, not real credentials
 HASHVIEW_URL = "https://hashview.example.com"
@@ -1191,6 +1191,29 @@ class TestHashviewAPI:
         wordlists = real_api.list_wordlists()
         assert isinstance(wordlists, list)
 
+    def test_get_hashfiles_by_type_passes_default_timeout(self, api):
+        """Every self.session.* call must pass a timeout -- see #241."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        api.session.get.return_value = mock_response
+
+        api.get_hashfiles_by_type("1000")
+
+        _, kwargs = api.session.get.call_args
+        assert kwargs.get("timeout") == HASHVIEW_DEFAULT_TIMEOUT
+
+    def test_list_wordlists_passes_default_timeout(self, api):
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        api.session.get.return_value = mock_response
+
+        api.list_wordlists()
+
+        _, kwargs = api.session.get.call_args
+        assert kwargs.get("timeout") == HASHVIEW_DEFAULT_TIMEOUT
+
     def test_create_job_workflow(self, api, test_hashfile):
         """Test creating a job in Hashview (option 2 complete workflow)"""
         print("\n" + "=" * 60)
@@ -1267,7 +1290,9 @@ class TestHashviewAPI:
         result = api.start_job(42)
 
         assert result["msg"] == "Job started"
-        api.session.post.assert_called_once_with(f"{HASHVIEW_URL}/v1/jobs/start/42")
+        api.session.post.assert_called_once_with(
+            f"{HASHVIEW_URL}/v1/jobs/start/42", timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
         api.session.get.assert_not_called()
 
     def test_delete_job_uses_delete_verb(self, api):
@@ -1280,7 +1305,9 @@ class TestHashviewAPI:
         result = api.delete_job(7)
 
         assert result["msg"] == "Job deleted"
-        api.session.delete.assert_called_once_with(f"{HASHVIEW_URL}/v1/jobs/7")
+        api.session.delete.assert_called_once_with(
+            f"{HASHVIEW_URL}/v1/jobs/7", timeout=HASHVIEW_DEFAULT_TIMEOUT
+        )
 
     def test_stop_job_not_supported(self, api):
         """Hashview has no stop-job route, so stop_job raises NotImplementedError."""

--- a/tests/test_hashview_cache.py
+++ b/tests/test_hashview_cache.py
@@ -11,11 +11,28 @@ def _isolate_home(monkeypatch, tmp_path):
 
 
 def test_cache_key_matches_manual_sha256():
-    assert cache_key("deadbeef", "1000") == hashlib.sha256(b"deadbeef:1000").hexdigest()
+    assert cache_key("deadbeef", "1000") == hashlib.sha256(
+        b"cracked:deadbeef:1000"
+    ).hexdigest()
 
 
 def test_cache_key_coerces_int_hash_type():
     assert cache_key("deadbeef", 1000) == cache_key("deadbeef", "1000")
+
+
+def test_cache_key_defaults_to_cracked_scope():
+    assert cache_key("deadbeef", "1000") == cache_key(
+        "deadbeef", "1000", scope="cracked"
+    )
+
+
+def test_cache_key_different_scopes_do_not_collide():
+    """upload_hashfile and upload_cracked_hashes must never share a key for
+    the same (hash, hash_type) -- that collision is the data-loss bug this
+    scoping fixes."""
+    assert cache_key("deadbeef", "1000", scope="cracked") != cache_key(
+        "deadbeef", "1000", scope="hashfile:1"
+    )
 
 
 def test_load_cache_missing_file_returns_empty_set():

--- a/tests/test_hashview_cache.py
+++ b/tests/test_hashview_cache.py
@@ -1,0 +1,47 @@
+import hashlib
+
+import pytest
+
+from hate_crack.hashview_cache import append_to_cache, cache_key, load_cache
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+def test_cache_key_matches_manual_sha256():
+    assert cache_key("deadbeef", "1000") == hashlib.sha256(b"deadbeef:1000").hexdigest()
+
+
+def test_cache_key_coerces_int_hash_type():
+    assert cache_key("deadbeef", 1000) == cache_key("deadbeef", "1000")
+
+
+def test_load_cache_missing_file_returns_empty_set():
+    assert load_cache() == set()
+
+
+def test_append_then_load_round_trips():
+    keys = [cache_key("aaa", "1000"), cache_key("bbb", "1000")]
+    append_to_cache(keys)
+    assert load_cache() == set(keys)
+
+
+def test_append_is_additive_not_truncating():
+    append_to_cache([cache_key("aaa", "1000")])
+    append_to_cache([cache_key("bbb", "1000")])
+    assert load_cache() == {cache_key("aaa", "1000"), cache_key("bbb", "1000")}
+
+
+def test_append_empty_iterable_is_a_noop():
+    append_to_cache([])
+    assert load_cache() == set()
+
+
+def test_load_cache_ignores_blank_lines(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache_dir = tmp_path / ".hate_crack"
+    cache_dir.mkdir()
+    (cache_dir / "hashview_uploaded_cache.txt").write_text("abc123\n\n   \ndef456\n")
+    assert load_cache() == {"abc123", "def456"}

--- a/tests/test_hashview_cache.py
+++ b/tests/test_hashview_cache.py
@@ -11,9 +11,10 @@ def _isolate_home(monkeypatch, tmp_path):
 
 
 def test_cache_key_matches_manual_sha256():
-    assert cache_key("deadbeef", "1000") == hashlib.sha256(
-        b"cracked:deadbeef:1000"
-    ).hexdigest()
+    assert (
+        cache_key("deadbeef", "1000")
+        == hashlib.sha256(b"cracked:deadbeef:1000").hexdigest()
+    )
 
 
 def test_cache_key_coerces_int_hash_type():

--- a/tests/test_hashview_cli_subcommands.py
+++ b/tests/test_hashview_cli_subcommands.py
@@ -35,6 +35,14 @@ class DummyHashviewAPI:
             "size": 10,
         }
 
+    #: Overridden by DummyHashviewAPIAllCached to simulate every line already
+    #: being cached (upload_hashfile's early-return shape: hashfile_id=None).
+    upload_hashfile_result = {
+        "msg": "Hashfile uploaded",
+        "hashfile_id": 456,
+        "skipped_cached": 5,
+    }
+
     def upload_hashfile(
         self, file_path, customer_id, hash_type, file_format=5, hashfile_name=None
     ):
@@ -48,7 +56,7 @@ class DummyHashviewAPI:
                 hashfile_name,
             )
         )
-        return {"msg": "Hashfile uploaded", "hashfile_id": 456, "skipped_cached": 5}
+        return dict(self.upload_hashfile_result)
 
     def create_job(
         self, name, hashfile_id, customer_id, limit_recovered=False, notify_email=True
@@ -66,9 +74,37 @@ class DummyHashviewAPI:
         return {"msg": "Job created", "job_id": 789}
 
 
+class DummyHashviewAPIAllCached(DummyHashviewAPI):
+    """upload_hashfile's all-cached shape: no upload happened, so there is no
+    real hashfile_id -- everything was already uploaded previously."""
+
+    upload_hashfile_result = {
+        "msg": "Hashfile uploaded",
+        "uploaded": 0,
+        "skipped_cached": 5,
+        "hashfile_id": None,
+    }
+
+    #: Track every instance created so tests can assert on .calls after
+    #: main() constructs its own HashviewAPI internally.
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        DummyHashviewAPIAllCached.instances.append(self)
+
+
 @pytest.fixture
 def _patch_hashview(monkeypatch):
     monkeypatch.setattr(hc_main, "HashviewAPI", DummyHashviewAPI)
+    hc_main.hashview_api_key = "dummy"
+    hc_main.hashview_url = "https://hashview.example.com"
+
+
+@pytest.fixture
+def _patch_hashview_all_cached(monkeypatch):
+    DummyHashviewAPIAllCached.instances = []
+    monkeypatch.setattr(hc_main, "HashviewAPI", DummyHashviewAPIAllCached)
     hc_main.hashview_api_key = "dummy"
     hc_main.hashview_url = "https://hashview.example.com"
 
@@ -205,3 +241,36 @@ def test_hashview_cli_upload_hashfile_job_reports_skipped_cached(
     captured = capsys.readouterr()
     assert code == 0
     assert "5" in captured.out and "already uploaded" in captured.out
+
+
+def test_hashview_cli_upload_hashfile_job_all_cached_errors_without_job(
+    _patch_hashview_all_cached, monkeypatch, tmp_path, capsys
+):
+    """Regression test: when upload_hashfile returns its all-cached shape
+    (hashfile_id: None, nothing actually uploaded), the CLI must treat that
+    as an error and must NOT call create_job with a None hashfile_id."""
+    hashfile = tmp_path / "hashes.txt"
+    hashfile.write_text("hash1\n")
+    code = _run_main_with_args(
+        monkeypatch,
+        [
+            "hashview",
+            "upload-hashfile-job",
+            "--file",
+            str(hashfile),
+            "--customer-id",
+            "1",
+            "--hash-type",
+            "1000",
+            "--job-name",
+            "TestJob",
+        ],
+    )
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "did not return a hashfile_id" in captured.out
+    assert DummyHashviewAPIAllCached.instances, "HashviewAPI was never constructed"
+    all_calls = [
+        call for instance in DummyHashviewAPIAllCached.instances for call in instance.calls
+    ]
+    assert not any(call[0] == "create_job" for call in all_calls)

--- a/tests/test_hashview_cli_subcommands.py
+++ b/tests/test_hashview_cli_subcommands.py
@@ -271,6 +271,8 @@ def test_hashview_cli_upload_hashfile_job_all_cached_errors_without_job(
     assert "did not return a hashfile_id" in captured.out
     assert DummyHashviewAPIAllCached.instances, "HashviewAPI was never constructed"
     all_calls = [
-        call for instance in DummyHashviewAPIAllCached.instances for call in instance.calls
+        call
+        for instance in DummyHashviewAPIAllCached.instances
+        for call in instance.calls
     ]
     assert not any(call[0] == "create_job" for call in all_calls)

--- a/tests/test_hashview_cli_subcommands.py
+++ b/tests/test_hashview_cli_subcommands.py
@@ -13,7 +13,7 @@ class DummyHashviewAPI:
 
     def upload_cracked_hashes(self, file_path, hash_type="1000"):
         self.calls.append(("upload_cracked_hashes", file_path, hash_type))
-        return {"msg": "Cracked hashes uploaded", "count": 2}
+        return {"msg": "Cracked hashes uploaded", "count": 2, "skipped_cached": 3}
 
     def upload_wordlist_file(self, wordlist_path, wordlist_name=None):
         self.calls.append(("upload_wordlist_file", wordlist_path, wordlist_name))
@@ -48,7 +48,7 @@ class DummyHashviewAPI:
                 hashfile_name,
             )
         )
-        return {"msg": "Hashfile uploaded", "hashfile_id": 456}
+        return {"msg": "Hashfile uploaded", "hashfile_id": 456, "skipped_cached": 5}
 
     def create_job(
         self, name, hashfile_id, customer_id, limit_recovered=False, notify_email=True
@@ -97,6 +97,27 @@ def test_hashview_cli_upload_cracked(_patch_hashview, monkeypatch, tmp_path, cap
     captured = capsys.readouterr()
     assert code == 0
     assert "Cracked hashes uploaded" in captured.out
+
+
+def test_hashview_cli_upload_cracked_reports_skipped_cached(
+    _patch_hashview, monkeypatch, tmp_path, capsys
+):
+    cracked_file = tmp_path / "cracked.out"
+    cracked_file.write_text("hash:pass\n")
+    code = _run_main_with_args(
+        monkeypatch,
+        [
+            "hashview",
+            "upload-cracked",
+            "--file",
+            str(cracked_file),
+            "--hash-type",
+            "1000",
+        ],
+    )
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "3" in captured.out and "already uploaded" in captured.out
 
 
 def test_hashview_cli_upload_wordlist(_patch_hashview, monkeypatch, tmp_path, capsys):
@@ -159,3 +180,28 @@ def test_hashview_cli_upload_hashfile_job(
     assert code == 0
     assert "Hashfile uploaded" in captured.out
     assert "Job created" in captured.out
+
+
+def test_hashview_cli_upload_hashfile_job_reports_skipped_cached(
+    _patch_hashview, monkeypatch, tmp_path, capsys
+):
+    hashfile = tmp_path / "hashes.txt"
+    hashfile.write_text("hash1\n")
+    code = _run_main_with_args(
+        monkeypatch,
+        [
+            "hashview",
+            "upload-hashfile-job",
+            "--file",
+            str(hashfile),
+            "--customer-id",
+            "1",
+            "--hash-type",
+            "1000",
+            "--job-name",
+            "TestJob",
+        ],
+    )
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "5" in captured.out and "already uploaded" in captured.out

--- a/tests/test_help_before_build.py
+++ b/tests/test_help_before_build.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 
-def _load_main_module(monkeypatch, argv, force_missing_binary):
+def _load_main_module(monkeypatch, argv, force_missing_binary, tmp_path):
     """Reimport hate_crack.main fresh, without conftest's forced SKIP_INIT.
 
     conftest.py sets HATE_CRACK_SKIP_INIT=1 for the whole session so the
@@ -13,8 +13,12 @@ def _load_main_module(monkeypatch, argv, force_missing_binary):
     reimporting, and forces the expander binary to look missing via
     os.path.isfile regardless of whether hashcat-utils happens to be built
     on the machine running the test.
+
+    HOME is redirected to a temporary directory to prevent the test from
+    mutating ~/.hate_crack on the real machine during config initialization.
     """
     monkeypatch.delenv("HATE_CRACK_SKIP_INIT", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(sys, "argv", argv)
 
     if force_missing_binary:
@@ -37,10 +41,13 @@ def _load_main_module(monkeypatch, argv, force_missing_binary):
     return module
 
 
-def test_help_does_not_exit_when_hashcat_utils_missing(monkeypatch, capsys):
+def test_help_does_not_exit_when_hashcat_utils_missing(monkeypatch, capsys, tmp_path):
     """`--help` must not hit the expander.bin asset check at import time."""
     _module = _load_main_module(
-        monkeypatch, ["hate_crack", "--help"], force_missing_binary=True
+        monkeypatch,
+        ["hate_crack", "--help"],
+        force_missing_binary=True,
+        tmp_path=tmp_path,
     )
     out = capsys.readouterr().out
     assert "expander not found" not in out

--- a/tests/test_help_before_build.py
+++ b/tests/test_help_before_build.py
@@ -1,0 +1,56 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+def _load_main_module(monkeypatch, argv, force_missing_binary):
+    """Reimport hate_crack.main fresh, without conftest's forced SKIP_INIT.
+
+    conftest.py sets HATE_CRACK_SKIP_INIT=1 for the whole session so the
+    asset check never runs during collection. This test needs the real,
+    un-skipped startup path, so it explicitly deletes the env var before
+    reimporting, and forces the expander binary to look missing via
+    os.path.isfile regardless of whether hashcat-utils happens to be built
+    on the machine running the test.
+    """
+    monkeypatch.delenv("HATE_CRACK_SKIP_INIT", raising=False)
+    monkeypatch.setattr(sys, "argv", argv)
+
+    if force_missing_binary:
+        real_isfile = os.path.isfile
+
+        def fake_isfile(path):
+            if str(path).endswith("expander.bin"):
+                return False
+            return real_isfile(path)
+
+        monkeypatch.setattr(os.path, "isfile", fake_isfile)
+
+    module_path = Path(__file__).resolve().parents[1] / "hate_crack" / "main.py"
+    module_name = "hate_crack_main_help_test"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_help_does_not_exit_when_hashcat_utils_missing(monkeypatch, capsys):
+    """`--help` must not hit the expander.bin asset check at import time."""
+    _module = _load_main_module(
+        monkeypatch, ["hate_crack", "--help"], force_missing_binary=True
+    )
+    out = capsys.readouterr().out
+    assert "expander not found" not in out
+
+
+def test_argv_requests_help_or_version_true_for_help():
+    import hate_crack.main as hc_main
+
+    assert hc_main._argv_requests_help_or_version(["--help"]) is True
+    assert hc_main._argv_requests_help_or_version(["-h"]) is True
+    assert hc_main._argv_requests_help_or_version(["--version"]) is True
+    assert hc_main._argv_requests_help_or_version(["hashes.txt", "1000"]) is False
+    assert hc_main._argv_requests_help_or_version([]) is False

--- a/tests/test_markov_e2e.py
+++ b/tests/test_markov_e2e.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hate_crack.main import DirEntry
+
 
 class TestMarkovE2E:
     """End-to-end tests for complete markov attack workflow."""
@@ -114,6 +116,7 @@ class TestMarkovE2E:
         ctx.hcatHashFile = hash_file
         ctx.hcatHashType = "1000"
         ctx.list_wordlist_files.return_value = ["rockyou.txt"]
+        ctx.list_wordlist_entries.return_value = [DirEntry("rockyou.txt", False)]
         ctx.hcatWordlists = str(tmp_path / "wordlists")
 
         # Create existing .hcstat2 file
@@ -145,6 +148,7 @@ class TestMarkovE2E:
         ctx.hcatHashType = "1000"
         ctx.hcatMarkovTrain.return_value = True
         ctx.list_wordlist_files.return_value = ["rockyou.txt"]
+        ctx.list_wordlist_entries.return_value = [DirEntry("rockyou.txt", False)]
         ctx.hcatWordlists = str(tmp_path / "wordlists")
 
         # Create existing .hcstat2 file
@@ -177,6 +181,7 @@ class TestMarkovE2E:
         ctx.hcatHashType = "1000"
         ctx.hcatMarkovTrain.return_value = True
         ctx.list_wordlist_files.return_value = ["rockyou.txt"]
+        ctx.list_wordlist_entries.return_value = [DirEntry("rockyou.txt", False)]
         ctx.hcatWordlists = str(tmp_path / "wordlists")
 
         # Create .out file with cracked passwords
@@ -228,6 +233,7 @@ class TestMarkovE2E:
         ctx.hcatHashType = "1000"
         ctx.hcatMarkovTrain.return_value = True
         ctx.list_wordlist_files.return_value = ["rockyou.txt"]
+        ctx.list_wordlist_entries.return_value = [DirEntry("rockyou.txt", False)]
         ctx.hcatWordlists = str(tmp_path / "wordlists")
 
         # No .hcstat2 file exists
@@ -259,6 +265,7 @@ class TestMarkovE2E:
         ctx.hcatHashType = "1000"
         ctx.hcatMarkovTrain.return_value = False  # Training fails
         ctx.list_wordlist_files.return_value = ["rockyou.txt"]
+        ctx.list_wordlist_entries.return_value = [DirEntry("rockyou.txt", False)]
         ctx.hcatWordlists = str(tmp_path / "wordlists")
 
         # No existing table

--- a/tests/test_notify_name_alignment.py
+++ b/tests/test_notify_name_alignment.py
@@ -14,6 +14,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hate_crack.main import DirEntry
+
 
 @pytest.fixture
 def main_module(hc_module):
@@ -257,6 +259,8 @@ class TestHandlersPassThroughPromptName:
         wordlist.write_text("password\n")
         ctx.hcatOptimizedWordlists = str(wordlist_dir)
         ctx.list_wordlist_files.return_value = ["rockyou.txt"]
+        ctx.list_wordlist_entries.return_value = [DirEntry("rockyou.txt", False)]
+        ctx.list_rule_files.return_value = ["best66.rule"]
         with patch("builtins.input", side_effect=[str(wordlist), "1"]):
             quick_crack(ctx)
         ctx.hcatQuickDictionary.assert_called_once()
@@ -271,6 +275,7 @@ class TestHandlersPassThroughPromptName:
         rules_dir = tmp_path / "rules"
         rules_dir.mkdir()
         (rules_dir / "best66.rule").write_text("")
+        ctx.list_rule_files.return_value = ["best66.rule"]
         with patch("builtins.input", return_value="1"):
             loopback_attack(ctx)
         ctx.hcatQuickDictionary.assert_called_once()

--- a/tests/test_omen_attack.py
+++ b/tests/test_omen_attack.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hate_crack.main import DirEntry
+
 
 @pytest.fixture
 def main_module(hc_module):
@@ -269,6 +271,10 @@ class TestOmenAttackHandler:
         ctx._omen_model_dir.return_value = str(tmp_path / "model")
         ctx.hcatOmenTrain.return_value = True
         ctx.list_wordlist_files.return_value = ["rockyou.txt", "custom.txt"]
+        ctx.list_wordlist_entries.return_value = [
+            DirEntry("rockyou.txt", False),
+            DirEntry("custom.txt", False),
+        ]
         return ctx
 
     def _setup_rules_dir(self, tmp_path, rule_names=None):

--- a/tests/test_omen_attack.py
+++ b/tests/test_omen_attack.py
@@ -277,17 +277,18 @@ class TestOmenAttackHandler:
         ]
         return ctx
 
-    def _setup_rules_dir(self, tmp_path, rule_names=None):
+    def _setup_rules_dir(self, ctx, tmp_path, rule_names=None):
         rules_dir = tmp_path / "rules"
         rules_dir.mkdir(exist_ok=True)
         if rule_names:
             for name in rule_names:
                 (rules_dir / name).write_text(":")
+        ctx.list_rule_files.return_value = list(rule_names) if rule_names else []
         return rules_dir
 
     def test_use_existing_model(self, tmp_path):
         ctx = self._make_ctx(tmp_path, model_valid=True)
-        self._setup_rules_dir(tmp_path)
+        self._setup_rules_dir(ctx, tmp_path)
         with (
             patch("os.path.isfile", return_value=True),
             patch("hate_crack.attacks.interactive_menu", return_value="1"),
@@ -301,7 +302,7 @@ class TestOmenAttackHandler:
 
     def test_train_new_model_with_wordlist_pick(self, tmp_path):
         ctx = self._make_ctx(tmp_path, model_valid=True)
-        self._setup_rules_dir(tmp_path)
+        self._setup_rules_dir(ctx, tmp_path)
         with (
             patch("os.path.isfile", return_value=True),
             patch("hate_crack.attacks.interactive_menu", return_value="2"),
@@ -342,7 +343,7 @@ class TestOmenAttackHandler:
 
     def test_no_model_goes_straight_to_training(self, tmp_path):
         ctx = self._make_ctx(tmp_path, model_valid=False)
-        self._setup_rules_dir(tmp_path)
+        self._setup_rules_dir(ctx, tmp_path)
         with (
             patch("os.path.isfile", return_value=True),
             patch("builtins.input", side_effect=["1", "", "0"]),
@@ -367,7 +368,7 @@ class TestOmenAttackHandler:
 
     def test_custom_path_for_training(self, tmp_path):
         ctx = self._make_ctx(tmp_path, model_valid=False)
-        self._setup_rules_dir(tmp_path)
+        self._setup_rules_dir(ctx, tmp_path)
         ctx.select_file_with_autocomplete.return_value = "/custom/wordlist.txt"
         with (
             patch("os.path.isfile", return_value=True),
@@ -381,7 +382,7 @@ class TestOmenAttackHandler:
 
     def test_rules_passed_to_hcatOmen(self, tmp_path):
         ctx = self._make_ctx(tmp_path, model_valid=True)
-        self._setup_rules_dir(tmp_path, ["best64.rule"])
+        self._setup_rules_dir(ctx, tmp_path, ["best64.rule"])
         with (
             patch("os.path.isfile", return_value=True),
             patch("hate_crack.attacks.interactive_menu", return_value="1"),
@@ -396,7 +397,7 @@ class TestOmenAttackHandler:
 
     def test_multiple_rule_chains_spawn_multiple_calls(self, tmp_path):
         ctx = self._make_ctx(tmp_path, model_valid=True)
-        self._setup_rules_dir(tmp_path, ["best64.rule", "dive.rule"])
+        self._setup_rules_dir(ctx, tmp_path, ["best64.rule", "dive.rule"])
         with (
             patch("os.path.isfile", return_value=True),
             patch("hate_crack.attacks.interactive_menu", return_value="1"),
@@ -409,7 +410,7 @@ class TestOmenAttackHandler:
 
     def test_cancel_from_rules_aborts(self, tmp_path):
         ctx = self._make_ctx(tmp_path, model_valid=True)
-        self._setup_rules_dir(tmp_path, ["best64.rule"])
+        self._setup_rules_dir(ctx, tmp_path, ["best64.rule"])
         with (
             patch("os.path.isfile", return_value=True),
             patch("hate_crack.attacks.interactive_menu", return_value="1"),
@@ -422,7 +423,7 @@ class TestOmenAttackHandler:
 
     def test_no_rules_passes_empty_chain(self, tmp_path):
         ctx = self._make_ctx(tmp_path, model_valid=True)
-        self._setup_rules_dir(tmp_path, ["best64.rule"])
+        self._setup_rules_dir(ctx, tmp_path, ["best64.rule"])
         with (
             patch("os.path.isfile", return_value=True),
             patch("hate_crack.attacks.interactive_menu", return_value="1"),

--- a/tests/test_release_versioning.py
+++ b/tests/test_release_versioning.py
@@ -1,24 +1,38 @@
 """Guards on the release-versioning wiring.
 
-The scheme is: ``main`` is stable at ``X.Y.0`` (a MINOR bump per merge) and
-``nightly-dev`` rolls through patch numbers ``X.Y.1``, ``X.Y.2`` (a PATCH bump
-per validated push). The arithmetic is commitizen's job, not this repo's.
+The scheme is ordinary semver with the bump derived from the batch: any ``feat``
+since the last release targets ``X.(Y+1).0``, a batch of only fixes, docs and
+chores targets ``X.Y.(Z+1)``. ``nightly-dev`` tags release candidates for that
+target (``v2.20.1rc1``, ``v2.20.1rc2``, ...) and merging down to ``main``
+promotes the same target to its final release. The policy itself lives in
+tools/next_version.py and is unit-tested in tests/test_next_version.py; nothing
+here re-implements it.
 
-These tests do not re-test commitizen's arithmetic -- that is the tool's job, and
-re-encoding it here would resurrect the assumptions this setup removed. They
-guard two other things:
+An earlier scheme forced the increment per branch -- MINOR on every merge to
+``main``, PATCH on every nightly push -- with commitizen doing the arithmetic.
+It was removed on 2026-07-31 for cutting a minor release per bugfix merge. Do
+not restore it, and do not read a claim that ``main`` is always ``X.Y.0``
+anywhere as current.
+
+What this file guards, given the policy is tested elsewhere:
 
 * **Configuration coherence**, which breaks silently: a lost ``tag_format``, a
-  dropped ``version_provider``, a drifted version pin.
-* **The behaviour of the shell that remains.** The two load-bearing guards (tag
-  idempotency and the empty-tag check) are tested by *extracting the step script
-  from the YAML and running it* -- against a real git repository with a real bare
-  remote, and against a stub ``uvx`` on ``PATH``. An earlier version of this file
-  asserted those two by literal substring and a reviewer defeated both without
-  any test failing: replacing the whole ``if``/``else`` with an unconditional
-  ``git tag && git push`` still matched, because the substring lived elsewhere in
-  the file. Substring assertions here are sensitive to formatting and blind to
-  behaviour, which is exactly backwards. Do not convert these back.
+  dropped ``version_provider``, a drifted commitizen pin.
+* **That the policy module remains the only thing producing a version**, stated
+  as a positive invariant (exactly one ``next_version.py`` call, and the pushed
+  tag read back from its output) with a denylist of shell version-math as a
+  second line of defence. The denylist alone was defeatable -- see
+  ``test_the_policy_module_is_the_only_thing_that_produces_a_version``.
+* **The behaviour of the shell that remains.** The load-bearing guards (the
+  computed tag's value, tag idempotency, and the empty-batch path) are tested by
+  *extracting the step script from the YAML and running it* against a real git
+  repository, a real bare remote, and a real copy of the policy module. An
+  earlier version of this file asserted those by literal substring and a
+  reviewer defeated them without any test failing: replacing the whole
+  ``if``/``else`` with an unconditional ``git tag && git push`` still matched,
+  because the substring lived elsewhere in the file. Substring assertions here
+  are sensitive to formatting and blind to behaviour, which is exactly
+  backwards. Do not convert these back.
 """
 
 from __future__ import annotations
@@ -44,9 +58,9 @@ BOTH_WORKFLOWS = [
     pytest.param(NIGHTLY_TAG, id="nightly-tag"),
 ]
 
-# The version commitizen is pinned to. Asserted to agree across the dev
-# dependency group and both workflow invocations; see
-# test_commitizen_pin_agrees_everywhere for why that matters.
+# The version commitizen is pinned to in the dev group. The workflows no longer
+# install or invoke it, so this is asserted in one place only; see
+# test_commitizen_pin_is_still_coherent for what remains worth guarding.
 COMMITIZEN_PIN = "4.17.0"
 
 
@@ -463,8 +477,8 @@ def test_create_tag_step_tags_nothing_when_the_tag_is_empty(
 def test_workflow_checks_out_the_validated_commit_with_full_history(path: Path) -> None:
     """``workflow_run`` defaults to the default-branch tip, not the tested commit.
 
-    ``fetch-depth: 0`` is equally load-bearing: commitizen resolves the current
-    version from tags and a shallow clone has none.
+    ``fetch-depth: 0`` is equally load-bearing: tools/next_version.py derives the
+    baseline from the repository's tags, and a shallow clone has none.
     """
     checkouts = [
         s for s in _run_steps(path) if "actions/checkout" in str(s.get("uses"))

--- a/tests/test_upload_wordlist.py
+++ b/tests/test_upload_wordlist.py
@@ -39,10 +39,11 @@ def test_upload_wordlist_api_mocked(monkeypatch):
                 "wordlist_id": 123,
             }
 
-    def fake_post(url, data=None, headers=None):
+    def fake_post(url, data=None, headers=None, timeout=None):
         assert url.endswith(f"/v1/wordlists/add/{wordlist_name}")
         assert headers and headers.get("Content-Type") == "text/plain"
         assert data is not None
+        assert timeout is not None
         return DummyResponse()
 
     monkeypatch.setattr(api.session, "post", fake_post)

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -97,3 +97,69 @@ def hc_module():
 
     os.environ["HATE_CRACK_SKIP_INIT"] = "1"
     return importlib.import_module("hate_crack.main")
+
+
+def _quick_crack_ctx(hc_module, wordlist_dir, tmp_path):
+    """A ctx just complete enough to drive quick_crack's picker."""
+    from types import SimpleNamespace
+
+    calls = []
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.write_text("aad3b435b51404eeaad3b435b51404ee\n")
+    return SimpleNamespace(
+        hcatWordlists=str(wordlist_dir),
+        hcatOptimizedWordlists=str(wordlist_dir),
+        hcatHashType="1000",
+        hcatHashFile=str(hash_file),
+        rulesDirectory=str(tmp_path / "rules"),
+        list_wordlist_files=hc_module.list_wordlist_files,
+        list_wordlist_entries=hc_module.list_wordlist_entries,
+        list_rule_files=hc_module.list_rule_files,
+        hcatQuickDictionary=lambda *a, **k: calls.append((a, k)),
+    ), calls
+
+
+def test_quick_crack_marks_directories_in_the_grid(
+    hc_module, wordlist_dir, tmp_path, capsys, monkeypatch
+):
+    """A directory expands to every file inside it, so the user has to be able
+    to tell it apart from a single wordlist at a glance."""
+    from hate_crack import attacks
+
+    ctx, _calls = _quick_crack_ctx(hc_module, wordlist_dir, tmp_path)
+    monkeypatch.setattr("builtins.input", lambda *a: (_ for _ in ()).throw(EOFError))
+    monkeypatch.setattr(attacks._notify, "prompt_notify_for_attack", lambda *a: None)
+
+    with pytest.raises((EOFError, SystemExit)):
+        attacks.quick_crack(ctx)
+
+    out = capsys.readouterr().out
+    assert "hibp/" in out, f"directory not marked as one:\n{out}"
+    assert "rockyou.txt" in out
+    assert ".gitkeep" not in out
+    assert ".DS_Store" not in out
+
+
+def test_quick_crack_passes_a_selected_directory_through_as_a_directory(
+    hc_module, wordlist_dir, tmp_path, monkeypatch
+):
+    """hashcat consumes every file in a directory, so selecting one must hand
+    the directory itself to hcatQuickDictionary, not a file inside it."""
+    from hate_crack import attacks
+
+    ctx, calls = _quick_crack_ctx(hc_module, wordlist_dir, tmp_path)
+    entries = hc_module.list_wordlist_entries(str(wordlist_dir))
+    choice = str(1 + [e.name for e in entries].index("hibp"))
+
+    answers = iter([choice])
+    monkeypatch.setattr("builtins.input", lambda *a: next(answers))
+    monkeypatch.setattr(attacks._notify, "prompt_notify_for_attack", lambda *a: None)
+    monkeypatch.setattr(attacks, "_select_rules", lambda ctx: [""])
+
+    attacks.quick_crack(ctx)
+
+    assert calls, "hcatQuickDictionary was never called"
+    passed = calls[0][0][3]
+    assert passed == str(wordlist_dir / "hibp"), (
+        f"expected the directory itself, got {passed!r}"
+    )

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -32,7 +32,9 @@ def wordlist_dir(tmp_path):
 
 def test_files_listing_excludes_directories(hc_module, wordlist_dir):
     """The regression: a directory in this list gets joined onto the wordlists
-    path and passed to hashcat as a file by hcatDictionary and the yolo path."""
+    path and handed off where a file is required -- hcatYoloCombination's
+    ``-a 1`` position (hashcat rejects a directory there) and
+    wordlist_optimize (which opens each path itself)."""
     got = hc_module.list_wordlist_files(str(wordlist_dir))
     assert got == ["custom.dict", "rockyou.txt"]
     assert "hibp" not in got
@@ -360,6 +362,62 @@ def test_generate_rules_picker_colours_directory_entries(
     assert styles == expected, (
         f"expected directory entries highlighted in cyan, got {styles!r}"
     )
+
+
+def test_generate_rules_picker_reprompts_on_toctou_disappearance(
+    hc_module, wordlist_dir, tmp_path, monkeypatch, capsys
+):
+    """The numbered shortcut re-stats the chosen entry right before use
+    (os.path.isdir / os.path.isfile) instead of trusting the listing snapshot.
+    If both come back False -- the entry vanished between listing and
+    selection -- the picker must print a "no longer exists" message and
+    re-prompt rather than proceed with a phantom path."""
+    from types import SimpleNamespace
+
+    from hate_crack import attacks
+
+    calls = []
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.write_text("x\n")
+    ctx = SimpleNamespace(
+        hcatWordlists=str(wordlist_dir),
+        hcatHashType="1000",
+        hcatHashFile=str(hash_file),
+        list_wordlist_entries=hc_module.list_wordlist_entries,
+        hcatGenerateRules=lambda *a, **k: calls.append((a, k)),
+    )
+    entries = hc_module.list_wordlist_entries(str(wordlist_dir))
+    vanished_choice = str(1 + [e.name for e in entries].index("rockyou.txt"))
+    vanished_path = str(wordlist_dir / "rockyou.txt")
+    file_choice = str(1 + [e.name for e in entries].index("custom.dict"))
+
+    real_isdir = attacks.os.path.isdir
+    real_isfile = attacks.os.path.isfile
+    monkeypatch.setattr(
+        attacks.os.path,
+        "isdir",
+        lambda p: False if p == vanished_path else real_isdir(p),
+    )
+    monkeypatch.setattr(
+        attacks.os.path,
+        "isfile",
+        lambda p: False if p == vanished_path else real_isfile(p),
+    )
+
+    # "" answers the rule-count prompt (default). Then the vanished entry is
+    # picked, gets refused, and a second, valid entry is picked to let the
+    # loop terminate instead of hanging on further input.
+    answers = iter(["", vanished_choice, file_choice])
+    monkeypatch.setattr("builtins.input", lambda *a: next(answers))
+    monkeypatch.setattr(attacks._notify, "prompt_notify_for_attack", lambda *a: None)
+
+    attacks.generate_rules_crack(ctx)
+
+    out = capsys.readouterr().out
+    assert f"{vanished_path} no longer exists." in out
+    assert calls, "hcatGenerateRules was never called"
+    passed_wordlist = calls[0][0][3]
+    assert passed_wordlist == str(wordlist_dir / "custom.dict")
 
 
 def _capture_rule_completer(ctx):

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -99,6 +99,52 @@ def hc_module():
     return importlib.import_module("hate_crack.main")
 
 
+def test_rule_picker_offers_no_directories_or_dot_files(
+    hc_module, tmp_path, monkeypatch, capsys
+):
+    from types import SimpleNamespace
+
+    from hate_crack import attacks
+
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "best64.rule").write_text(":\n")
+    (rules / "OneRuleToRuleThemStill").mkdir()
+    (rules / ".DS_Store").write_text("")
+
+    ctx = SimpleNamespace(
+        rulesDirectory=str(rules), list_rule_files=hc_module.list_rule_files
+    )
+    monkeypatch.setattr("builtins.input", lambda *a: "99")
+
+    attacks._select_rules(ctx)
+
+    out = capsys.readouterr().out
+    assert "best64.rule" in out
+    assert "OneRuleToRuleThemStill" not in out, "a directory was offered as a rule"
+    assert ".DS_Store" not in out
+
+
+def test_llm_rule_loop_skips_directories(hc_module, tmp_path):
+    """main.py:2906 iterates every entry and runs `hashcat -r <entry>`
+    unattended, so one subdirectory fails the run with nobody watching. This is
+    the highest-severity site in #233 because the user cannot steer around it.
+    """
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "best64.rule").write_text(":\n")
+    (rules / "subdir").mkdir()
+    (rules / ".gitkeep").write_text("")
+
+    got = hc_module.list_rule_files(str(rules))
+
+    assert got == ["best64.rule"]
+    for name in got:
+        assert os.path.isfile(os.path.join(str(rules), name)), (
+            f"{name} would be passed to hashcat as -r and is not a file"
+        )
+
+
 def _quick_crack_ctx(hc_module, wordlist_dir, tmp_path):
     """A ctx just complete enough to drive quick_crack's picker."""
     from types import SimpleNamespace

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -163,3 +163,89 @@ def test_quick_crack_passes_a_selected_directory_through_as_a_directory(
     assert passed == str(wordlist_dir / "hibp"), (
         f"expected the directory itself, got {passed!r}"
     )
+
+
+@pytest.mark.parametrize(
+    "picker",
+    ["_pick_training_wordlist", "_markov_pick_training_source"],
+)
+def test_training_pickers_refuse_a_directory(
+    hc_module, wordlist_dir, tmp_path, monkeypatch, capsys, picker
+):
+    """OMEN and Markov training take one file. A directory reached
+    hcatOmenTrain / hcatMarkovTrain and failed there instead of at selection.
+
+    Note the asymmetry this fixes: the "p. Enter a custom path" branch of both
+    pickers already validated, so only the numbered shortcut was exposed.
+    """
+    from types import SimpleNamespace
+
+    from hate_crack import attacks
+
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.write_text("x\n")
+    ctx = SimpleNamespace(
+        hcatWordlists=str(wordlist_dir),
+        hcatHashFile=str(hash_file),
+        list_wordlist_files=hc_module.list_wordlist_files,
+        list_wordlist_entries=hc_module.list_wordlist_entries,
+        select_file_with_autocomplete=lambda *a, **k: "",
+    )
+    entries = hc_module.list_wordlist_entries(str(wordlist_dir))
+    dir_choice = str(1 + [e.name for e in entries].index("hibp"))
+
+    answers = iter([dir_choice, "q"])
+    monkeypatch.setattr("builtins.input", lambda *a: next(answers))
+
+    result = getattr(attacks, picker)(ctx)
+
+    assert result is None, f"a directory was accepted as a training file: {result!r}"
+    assert "directory" in capsys.readouterr().out.lower(), (
+        "the rejection must say why, or the menu looks like it ignored the key"
+    )
+
+
+def test_generate_rules_picker_refuses_a_directory(
+    hc_module, wordlist_dir, tmp_path, monkeypatch, capsys
+):
+    """Rule generation hands its wordlist argument straight to hashcat. The
+    numbered shortcut used `os.path.exists(chosen)` as its guard, which a
+    directory passes -- so a directory picked here reached hashcat instead of
+    being refused at selection, unlike the "enter a path" and default-Enter
+    branches this test does not touch.
+    """
+    from types import SimpleNamespace
+
+    from hate_crack import attacks
+
+    calls = []
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.write_text("x\n")
+    ctx = SimpleNamespace(
+        hcatWordlists=str(wordlist_dir),
+        hcatHashType="1000",
+        hcatHashFile=str(hash_file),
+        list_wordlist_entries=hc_module.list_wordlist_entries,
+        hcatGenerateRules=lambda *a, **k: calls.append((a, k)),
+    )
+    entries = hc_module.list_wordlist_entries(str(wordlist_dir))
+    dir_choice = str(1 + [e.name for e in entries].index("hibp"))
+    file_choice = str(1 + [e.name for e in entries].index("rockyou.txt"))
+
+    # "" answers the rule-count prompt (default). Then a directory is picked
+    # and must be refused -- looping back for a second, valid pick.
+    answers = iter(["", dir_choice, file_choice])
+    monkeypatch.setattr("builtins.input", lambda *a: next(answers))
+    monkeypatch.setattr(attacks._notify, "prompt_notify_for_attack", lambda *a: None)
+
+    attacks.generate_rules_crack(ctx)
+
+    out = capsys.readouterr().out.lower()
+    assert "directory" in out, (
+        "the rejection must say why, or the menu looks like it ignored the key"
+    )
+    assert calls, "hcatGenerateRules was never called -- the picker did not loop"
+    passed_wordlist = calls[0][0][3]
+    assert passed_wordlist == str(wordlist_dir / "rockyou.txt"), (
+        f"expected the second, valid pick to go through, got {passed_wordlist!r}"
+    )

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -251,15 +251,15 @@ def test_training_pickers_refuse_a_directory(
     )
 
 
-def test_generate_rules_picker_refuses_a_directory(
-    hc_module, wordlist_dir, tmp_path, monkeypatch, capsys
+def test_generate_rules_picker_passes_a_selected_directory_through_as_a_directory(
+    hc_module, wordlist_dir, tmp_path, monkeypatch
 ):
-    """Rule generation hands its wordlist argument straight to hashcat. The
-    numbered shortcut used `os.path.exists(chosen)` as its guard, which a
-    directory passes -- so a directory picked here reached hashcat instead of
-    being refused at selection, unlike the "enter a path" and default-Enter
-    branches this test does not touch.
-    """
+    """Rule generation hands its wordlist argument straight to hashcat as a
+    straight-mode (`-a 0`) dictionary position, and hashcat itself accepts a
+    directory there (`-a 0 -r r.rule <dir>` works). The numbered shortcut must
+    agree with the Enter-default and typed-path branches, which already pass a
+    directory through untouched -- mirroring
+    test_quick_crack_passes_a_selected_directory_through_as_a_directory."""
     from types import SimpleNamespace
 
     from hate_crack import attacks
@@ -276,24 +276,66 @@ def test_generate_rules_picker_refuses_a_directory(
     )
     entries = hc_module.list_wordlist_entries(str(wordlist_dir))
     dir_choice = str(1 + [e.name for e in entries].index("hibp"))
-    file_choice = str(1 + [e.name for e in entries].index("rockyou.txt"))
 
     # "" answers the rule-count prompt (default). Then a directory is picked
-    # and must be refused -- looping back for a second, valid pick.
-    answers = iter(["", dir_choice, file_choice])
+    # and must be accepted immediately -- no second prompt.
+    answers = iter(["", dir_choice])
     monkeypatch.setattr("builtins.input", lambda *a: next(answers))
     monkeypatch.setattr(attacks._notify, "prompt_notify_for_attack", lambda *a: None)
 
     attacks.generate_rules_crack(ctx)
 
-    out = capsys.readouterr().out.lower()
-    assert "directory" in out, (
-        "the rejection must say why, or the menu looks like it ignored the key"
-    )
-    assert calls, "hcatGenerateRules was never called -- the picker did not loop"
+    assert calls, "hcatGenerateRules was never called"
     passed_wordlist = calls[0][0][3]
-    assert passed_wordlist == str(wordlist_dir / "rockyou.txt"), (
-        f"expected the second, valid pick to go through, got {passed_wordlist!r}"
+    assert passed_wordlist == str(wordlist_dir / "hibp"), (
+        f"expected the directory itself, got {passed_wordlist!r}"
+    )
+
+
+def test_generate_rules_picker_colours_directory_entries(
+    hc_module, wordlist_dir, tmp_path, monkeypatch
+):
+    """Quick Crack, OMEN, and Markov all highlight directory entries in cyan
+    via a `styles=` list passed to print_multicolumn_list. The rule-generation
+    picker built the same directory markers but never built or passed the
+    matching styles list, so its directories rendered uncoloured."""
+    from types import SimpleNamespace
+
+    from hate_crack import attacks
+
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.write_text("x\n")
+    ctx = SimpleNamespace(
+        hcatWordlists=str(wordlist_dir),
+        hcatHashType="1000",
+        hcatHashFile=str(hash_file),
+        list_wordlist_entries=hc_module.list_wordlist_entries,
+        hcatGenerateRules=lambda *a, **k: None,
+    )
+    entries = hc_module.list_wordlist_entries(str(wordlist_dir))
+    file_choice = str(1 + [e.name for e in entries].index("rockyou.txt"))
+
+    captured = {}
+    original = attacks.print_multicolumn_list
+
+    def spy(*args, **kwargs):
+        captured["styles"] = kwargs.get("styles")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(attacks, "print_multicolumn_list", spy)
+
+    answers = iter(["", file_choice])
+    monkeypatch.setattr("builtins.input", lambda *a: next(answers))
+    monkeypatch.setattr(attacks._notify, "prompt_notify_for_attack", lambda *a: None)
+
+    attacks.generate_rules_crack(ctx)
+
+    styles = captured.get("styles")
+    assert styles, "print_multicolumn_list was not given a styles list"
+    is_dir_by_position = [e.is_dir for e in entries]
+    expected = ["\033[36m" if is_dir else None for is_dir in is_dir_by_position]
+    assert styles == expected, (
+        f"expected directory entries highlighted in cyan, got {styles!r}"
     )
 
 

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -476,3 +476,39 @@ def test_optimize_emptiness_check_ignores_dot_files(hc_module, tmp_path):
 
     (outdir / "len8.txt").write_text("password\n")
     assert hc_module._outdir_is_empty(str(outdir)) is False
+
+
+def test_hcatDictionary_includes_subdirectories_in_dictionary_args(
+    hc_module, wordlist_dir, tmp_path, monkeypatch
+):
+    """Issue #233 follow-up: hcatDictionary built its dictionary arguments from
+    list_wordlist_files (files only), so a subdirectory like wordlists/hibp/
+    was silently dropped from the standard Dictionary attack even though
+    hashcat itself enumerates every file inside it in this straight-mode
+    dictionary position (verified against the real binary: `-a 0 w1.txt sub`
+    enumerates both). Quick Crack already treats a directory as a legitimate
+    dictionary argument; hcatDictionary must match that policy.
+    """
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.write_text("aad3b435b51404eeaad3b435b51404ee\n")
+    (tmp_path / "hashes.txt.out").write_text("")
+
+    captured_cmds = []
+
+    def fake_run_hcat_cmd(cmd, **kwargs):
+        captured_cmds.append(list(cmd))
+
+    monkeypatch.setattr(hc_module, "hcatWordlists", str(wordlist_dir))
+    monkeypatch.setattr(hc_module, "hcatDictionaryWordlist", [])
+    monkeypatch.setattr(hc_module, "hcatBruteCount", 0)
+    monkeypatch.setattr(hc_module, "hcatHashFile", str(hash_file))
+    monkeypatch.setattr(hc_module, "_run_hcat_cmd", fake_run_hcat_cmd)
+
+    hc_module.hcatDictionary("1000", str(hash_file))
+
+    assert captured_cmds, "hcatDictionary never invoked _run_hcat_cmd"
+    dictionary_cmd = captured_cmds[0]
+    assert str(wordlist_dir / "hibp") in dictionary_cmd, (
+        "the wordlists subdirectory was dropped from the Dictionary attack's "
+        f"arguments: {dictionary_cmd}"
+    )

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -91,6 +91,29 @@ def test_a_file_where_a_directory_was_expected_is_empty(hc_module, tmp_path):
     assert hc_module.list_wordlist_files(str(f)) == []
 
 
+def test_visible_entries_warns_on_permission_error(hc_module, tmp_path, capsys):
+    """Issue #233 follow-up: a PermissionError on the wordlists/rules directory
+    was swallowed identically to a routine missing-directory case. Silently
+    returning [] here makes hcatDictionary fall through to a literal '*' glob
+    argument, and makes hcatYoloCombination's random.choice() raise an
+    uncaught IndexError on an empty list. Only PermissionError should warn --
+    a missing directory or a file-where-directory-expected are routine."""
+    if os.geteuid() == 0:
+        pytest.skip("root ignores permission bits; PermissionError would never fire")
+
+    unreadable = tmp_path / "unreadable"
+    unreadable.mkdir()
+    os.chmod(unreadable, 0o333)
+    try:
+        got = hc_module.list_wordlist_files(str(unreadable))
+    finally:
+        os.chmod(unreadable, 0o755)
+
+    assert got == []
+    captured = capsys.readouterr()
+    assert str(unreadable) in captured.out or "permission" in captured.out.lower()
+
+
 @pytest.fixture
 def hc_module():
     import importlib

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -446,3 +446,33 @@ def test_rule_completer_ordering_stable_across_repeated_state_calls(tmp_path):
     assert first == second, (
         f"match ordering was not stable across repeated calls: {first} != {second}"
     )
+
+
+def test_hashmob_dedup_set_ignores_directories(tmp_path):
+    """A directory name could shadow a rule filename and skip a real download."""
+    from hate_crack import api
+
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "best64.rule").write_text(":\n")
+    (rules / "wanted.rule").mkdir()  # a directory sharing a wanted filename
+
+    already = api._downloaded_rule_names(str(rules))
+
+    assert "best64.rule" in already
+    assert "wanted.rule" not in already, (
+        "a directory shadowed a rule filename and would skip its download"
+    )
+
+
+def test_optimize_emptiness_check_ignores_dot_files(hc_module, tmp_path):
+    """`if not os.listdir(outdir)` is defeated by a stray .DS_Store, so the
+    first wordlist takes the slow merge path against an empty directory."""
+    outdir = tmp_path / "optimized"
+    outdir.mkdir()
+    (outdir / ".DS_Store").write_text("")
+
+    assert hc_module._outdir_is_empty(str(outdir)) is True
+
+    (outdir / "len8.txt").write_text("password\n")
+    assert hc_module._outdir_is_empty(str(outdir)) is False

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -520,6 +520,24 @@ def test_optimize_emptiness_check_ignores_dot_files(hc_module, tmp_path):
     assert hc_module._outdir_is_empty(str(outdir)) is False
 
 
+def test_outdir_is_empty_returns_false_on_permission_error(hc_module, tmp_path):
+    """A write+execute-but-not-readable directory (mode 0333) can still have
+    files created in it while os.listdir raises PermissionError. Returning
+    True there ("empty") would send every wordlist down the first-wordlist
+    branch in wordlist_optimize instead of merging, silently destroying
+    earlier per-length outputs."""
+    if os.geteuid() == 0:
+        pytest.skip("root ignores permission bits; PermissionError would never fire")
+
+    outdir = tmp_path / "unreadable"
+    outdir.mkdir()
+    os.chmod(outdir, 0o333)
+    try:
+        assert hc_module._outdir_is_empty(str(outdir)) is False
+    finally:
+        os.chmod(outdir, 0o755)
+
+
 def test_hcatDictionary_includes_subdirectories_in_dictionary_args(
     hc_module, wordlist_dir, tmp_path, monkeypatch
 ):

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -1,0 +1,99 @@
+"""The listing layer under hate_crack's pickers.
+
+Issue #233: `list_wordlist_files()` was a bare `os.listdir` with an extension
+blocklist and a one-off `.DS_Store` exclusion, so subdirectories and dot-files
+were numbered in the pickers as if they were wordlists, and several callers
+joined those names onto a directory and handed the result to hashcat as a file.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def wordlist_dir(tmp_path):
+    """A wordlists directory with one of everything that has caused trouble."""
+    d = tmp_path / "wordlists"
+    d.mkdir()
+    (d / "rockyou.txt").write_text("password\n")
+    (d / "custom.dict").write_text("hunter2\n")
+    (d / "hibp").mkdir()  # a directory: valid for hashcat, not a file
+    (d / "hibp" / "part1.txt").write_text("a\n")
+    (d / ".gitkeep").write_text("")  # dot-files: never wordlists
+    (d / ".DS_Store").write_text("")
+    (d / "archive.7z").write_text("")  # excluded extension
+    (d / "hashes.out").write_text("")  # excluded extension
+    (d / "list.torrent").write_text("")  # excluded extension
+    return d
+
+
+def test_files_listing_excludes_directories(hc_module, wordlist_dir):
+    """The regression: a directory in this list gets joined onto the wordlists
+    path and passed to hashcat as a file by hcatDictionary and the yolo path."""
+    got = hc_module.list_wordlist_files(str(wordlist_dir))
+    assert got == ["custom.dict", "rockyou.txt"]
+    assert "hibp" not in got
+
+
+def test_files_listing_excludes_all_dot_files(hc_module, wordlist_dir):
+    """Replaces the one-off .DS_Store special case: .gitkeep and friends are
+    not wordlists either."""
+    got = hc_module.list_wordlist_files(str(wordlist_dir))
+    assert not [name for name in got if name.startswith(".")]
+
+
+def test_entries_listing_includes_directories_and_marks_them(hc_module, wordlist_dir):
+    entries = hc_module.list_wordlist_entries(str(wordlist_dir))
+    assert [(e.name, e.is_dir) for e in entries] == [
+        ("custom.dict", False),
+        ("hibp", True),
+        ("rockyou.txt", False),
+    ]
+
+
+def test_entries_listing_excludes_dot_files(hc_module, wordlist_dir):
+    entries = hc_module.list_wordlist_entries(str(wordlist_dir))
+    assert not [e for e in entries if e.name.startswith(".")]
+
+
+def test_rule_listing_excludes_directories_and_dot_files(hc_module, tmp_path):
+    """A rules directory picks up subdirectories when someone drops in a cloned
+    rules repo or hashcat's own rules tree. `-r <directory>` is rejected by
+    hashcat, and the LLM attack iterates every entry unattended."""
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "best64.rule").write_text(":\n")
+    (rules / "toggles.rule").write_text(":\n")
+    (rules / "OneRuleToRuleThemStill").mkdir()
+    (rules / ".DS_Store").write_text("")
+    (rules / ".gitkeep").write_text("")
+
+    got = hc_module.list_rule_files(str(rules))
+
+    assert got == ["best64.rule", "toggles.rule"]
+
+
+@pytest.mark.parametrize(
+    "func", ["list_wordlist_files", "list_rule_files", "list_wordlist_entries"]
+)
+def test_missing_directory_is_empty_not_an_exception(hc_module, tmp_path, func):
+    """A wordlists path that does not exist yet must not crash a picker."""
+    assert getattr(hc_module, func)(str(tmp_path / "nope")) == []
+
+
+def test_a_file_where_a_directory_was_expected_is_empty(hc_module, tmp_path):
+    """os.listdir raises NotADirectoryError here; the pickers must survive it."""
+    f = tmp_path / "not-a-dir"
+    f.write_text("x\n")
+    assert hc_module.list_wordlist_files(str(f)) == []
+
+
+@pytest.fixture
+def hc_module():
+    import importlib
+
+    os.environ["HATE_CRACK_SKIP_INIT"] = "1"
+    return importlib.import_module("hate_crack.main")

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -115,10 +115,10 @@ def test_visible_entries_warns_on_permission_error(hc_module, tmp_path, capsys):
 
 
 @pytest.fixture
-def hc_module():
+def hc_module(monkeypatch):
     import importlib
 
-    os.environ["HATE_CRACK_SKIP_INIT"] = "1"
+    monkeypatch.setenv("HATE_CRACK_SKIP_INIT", "1")
     return importlib.import_module("hate_crack.main")
 
 

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -295,3 +295,154 @@ def test_generate_rules_picker_refuses_a_directory(
     assert passed_wordlist == str(wordlist_dir / "rockyou.txt"), (
         f"expected the second, valid pick to go through, got {passed_wordlist!r}"
     )
+
+
+def _capture_rule_completer(ctx):
+    """Drive `_rule_select_file` with a stubbed input/readline just far enough
+    to capture the `rule_completer` closure it registers, then hand it back
+    so tests can call it directly with arbitrary (text, state) pairs.
+    """
+    from hate_crack import attacks
+
+    captured = {}
+
+    def fake_configure(completer):
+        captured["completer"] = completer
+
+    original = attacks._configure_readline
+    attacks._configure_readline = fake_configure
+    try:
+        import builtins
+
+        original_input = builtins.input
+        builtins.input = lambda *a: ""
+        try:
+            attacks._rule_select_file(ctx, "rule: ")
+        finally:
+            builtins.input = original_input
+    finally:
+        attacks._configure_readline = original
+
+    return captured["completer"]
+
+
+def _all_rule_matches(completer, text):
+    matches = []
+    state = 0
+    while (m := completer(text, state)) is not None:
+        matches.append(m)
+        state += 1
+    return matches
+
+
+def test_rule_completer_marks_directories_and_globs_consistently(tmp_path):
+    """The odd one out: five of the six tab-completers add a trailing / for a
+    directory and this one does not. It also globs *.rule when the input is
+    empty but <text>* once you type, so typing one character surfaces non-rule
+    files the empty prompt hides.
+    """
+    from types import SimpleNamespace
+
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "best64.rule").write_text(":\n")
+    (rules / "notes.txt").write_text("x\n")
+    (rules / "collection").mkdir()
+
+    ctx = SimpleNamespace(rulesDirectory=str(rules))
+    completer = _capture_rule_completer(ctx)
+    matches = _all_rule_matches(completer, "")
+
+    assert any(m.endswith("collection/") for m in matches), (
+        f"directory not marked with a trailing slash: {matches}"
+    )
+    assert not any(m.endswith("notes.txt") for m in matches), (
+        f"a non-rule file was offered: {matches}"
+    )
+
+
+def test_rule_completer_incremental_typing_still_completes_past_the_dot(tmp_path):
+    """Filtering on `.rule` must happen after the glob, not by baking
+    `*.rule` into the glob pattern -- otherwise typing past the base name
+    (into the extension itself) stops matching anything.
+    """
+    from types import SimpleNamespace
+
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "best64.rule").write_text(":\n")
+    (rules / "best64.rule.bak").write_text(":\n")
+    (rules / "notes.txt").write_text("x\n")
+
+    ctx = SimpleNamespace(rulesDirectory=str(rules))
+    completer = _capture_rule_completer(ctx)
+
+    for typed in ("best", "best64", "best64.", "best64.r", "best64.rule"):
+        matches = _all_rule_matches(completer, typed)
+        assert any(m.endswith("best64.rule") for m in matches), (
+            f"typing {typed!r} lost the completion: {matches}"
+        )
+        assert not any(m.endswith("best64.rule.bak") for m in matches), (
+            f"typing {typed!r} surfaced a backup file: {matches}"
+        )
+        assert not any(m.endswith("notes.txt") for m in matches), (
+            f"typing {typed!r} surfaced a non-rule file: {matches}"
+        )
+
+
+def test_rule_completer_marks_directories_in_base_and_relative_branches(tmp_path):
+    """A directory must get its trailing slash in both the base-directory
+    branch and the `./`-relative free-path branch -- deriving the marker
+    from a separately hardcoded `os.path.join(base, ...)` only worked for
+    the base branch (and, by accident, absolute paths).
+    """
+    from types import SimpleNamespace
+
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "collection").mkdir()
+
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    (other / "extra").mkdir()
+
+    ctx = SimpleNamespace(rulesDirectory=str(rules))
+    completer = _capture_rule_completer(ctx)
+
+    base_matches = _all_rule_matches(completer, "coll")
+    assert any(m.endswith("collection/") for m in base_matches), (
+        f"base-directory branch did not mark the directory: {base_matches}"
+    )
+
+    cwd = os.getcwd()
+    os.chdir(str(tmp_path))
+    try:
+        rel_matches = _all_rule_matches(completer, "./elsewhere/ext")
+    finally:
+        os.chdir(cwd)
+    assert any(m.endswith("extra/") for m in rel_matches), (
+        f"./-relative branch did not mark the directory: {rel_matches}"
+    )
+
+
+def test_rule_completer_ordering_stable_across_repeated_state_calls(tmp_path):
+    """The completer recomputes its match list on every call; repeated calls
+    for the same `text` must still yield the same list, or completion
+    (which walks `state` up from 0) behaves erratically.
+    """
+    from types import SimpleNamespace
+
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "best64.rule").write_text(":\n")
+    (rules / "dive.rule").write_text(":\n")
+    (rules / "collection").mkdir()
+
+    ctx = SimpleNamespace(rulesDirectory=str(rules))
+    completer = _capture_rule_completer(ctx)
+
+    first = _all_rule_matches(completer, "")
+    second = _all_rule_matches(completer, "")
+    assert first == second, (
+        f"match ordering was not stable across repeated calls: {first} != {second}"
+    )


### PR DESCRIPTION
## Summary
Batch integration of `nightly-dev` into `main` — 41 commits since the last integration (`v2.20.0`), spanning:
- Hashview upload cache (skip already-uploaded hashes), namespaced by operation to fix a cross-operation collision
- Hashview `hashfile_id` truthiness fix, and the "blame invalid lines" false-exception fix
- NTLM (mode 1000) UTF-8 validation fix — a genuine multi-byte plaintext (e.g. `£`) was wrongly rejected as a hash/plaintext mismatch during cracked-hash upload (PR #247, no prior CHANGELOG entry — added here)
- Directory/dot-file-aware wordlist and rule pickers (closes #233)
- `--help`/`--version` fast path before the hashcat-utils asset check
- Release-versioning policy overhaul (semver-correct nightly/stable tagging, moved out of YAML into `tools/next_version.py`)
- Stale-migration completion for `.env`/`config.json` split, lint-scope drift guard, backup-collision fix, update-check infinite-loop fix

CHANGELOG's `[Unreleased]` section is renamed to `[2.24.0] - 2026-08-02` per `tools/next_version.py --channel stable`.

**Known gap, not addressed by this PR:** `CHANGELOG.md` jumps from `[Unreleased]` directly to `[2.20.0]` — the "rename `[Unreleased]` to the version being cut" step was apparently skipped on every batch integration since 2.20.0 (`v2.21.0`, `v2.22.0`, `v2.22.1`, `v2.22.2`, `v2.23.0` all shipped with no dedicated section). That history is not reconstructed here; flagging so it isn't mistaken for an oversight of this PR.

Closes #233

## Test plan
- [x] Full suite: 2187 passed, 39 skipped (release worktree with submodules built)
- [x] `ruff check hate_crack tests` clean
- [x] `ruff format --check hate_crack tests` clean
- [x] `ty check --exit-zero-on-warning hate_crack` — pre-existing warning baseline only
- [x] `bandit -r hate_crack` clean vs. baseline
- [x] `pip-audit --ignore-vuln PYSEC-2026-2447` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)