### PR TITLE
release: integrate nightly-dev batch of 2026-08-04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ hashcat.potfile
 *.rosetta/
 *.spoonman/
 *.llm_patterns/
-# hashcat --debug-mode 4 output. hate_crack writes one of these for every
+# hashcat --debug-mode 5 output. hate_crack writes one of these for every
 # rule-based attack without being asked (see _add_debug_mode_for_rules), and
 # each line pairs a rule with the plaintext it cracked. The default
 # hcatDebugLogPath is the relative "./hashcat_debug", so on any run launched

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   session artifacts.
 
 ### Fixed
+- **`rosetta_derive` misparsed a batch mixing `--debug-mode` 4 and 5 logs,
+  logging one file's lines as `Skipping malformed mode-5 line (missing
+  wordlist field)` and dropping them.** It merged every selected log's raw
+  lines into one list before handing them to HashcatRosetta, whose format/mode
+  detection samples only the start of whatever it's given -- so whichever
+  file's lines landed first decided the mode for the whole batch. It now calls
+  HashcatRosetta's `analyze_debug_files()`, which detects each file's format
+  and mode independently (requires HashcatRosetta >= the commit adding that
+  method; bumped alongside this fix).
 - **`rosetta_derive` stopped reading debug logs after 1,000,000 lines and
   printed `[!] Stopped at 1000000 debug lines`, silently discarding the
   remainder of large captures.** The cap and its `max_lines` parameter are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,21 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   to know about, not mask grammar.
 
 ### Fixed
+- **Rule-based attacks no longer die outright against a hashcat build that
+  predates `--debug-mode` 5 support.** `_add_debug_mode_for_rules` always
+  requested mode 5, so a hashcat older than the one that introduced it
+  rejected every `-r` attack with `Invalid --debug-mode value specified.`
+  (exit 255) before any cracking started. `_run_hcat_cmd` now captures stderr
+  for debug-mode invocations, detects that specific rejection, retries the
+  same attack at mode 4, and drops the request to mode 4 for the rest of the
+  run so later rule-based attacks ask for it directly instead of failing and
+  retrying every time.
+- **Added `--rule-debug-mode`/`--no-rule-debug-mode`** (persisted default:
+  `rule_debug_mode_enabled` in config.json, `true`) to fully disable the
+  `--debug-mode`/`--debug-file` flags rule-based attacks otherwise always add.
+  This is unrelated to the existing `--debug`/`--no-debug` flag, which only
+  controls hate_crack's own verbose logging and never touched hashcat's
+  debug-mode flags.
 - **`rosetta_derive` misparsed a batch mixing `--debug-mode` 4 and 5 logs,
   logging one file's lines as `Skipping malformed mode-5 line (missing
   wordlist field)` and dropping them.** It merged every selected log's raw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,32 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   `maskgen.py` — previously these generated mask files were left behind after a
   session for re-use or inspection; they are now cleaned up along with other
   session artifacts.
+- **`llm.generate_masks` now delegates entirely to
+  `hashcat_rosetta.nlmask.generate_masks`** instead of a second, hand-maintained
+  Atomic Agents prompt (`_MASK_PROMPT`/`MaskAttackOutput`, both removed). The LLM
+  Mask Attack's prompt, output schema, hcmask syntax validation, and the
+  one-retry-on-failure behavior all now come from HashcatRosetta itself, so this
+  feature can't silently drift from that project's own SYSTEM_PROMPT fixes the
+  way it had (HashcatRosetta had already independently fixed a `[...]`
+  bracket-syntax hallucination, an arbitrary "always pick 6" category cap, and a
+  word-decomposition bug that this module's own prompt never guarded against).
+  The practical result is that the LLM Mask Attack now supports custom charsets
+  (`?1`-`?8`, up to 8 per HashcatRosetta's own hashcat-verified limit) for the
+  first time — every generated mask combines its custom charsets (if any) into
+  one canonical hcmask line (e.g. `aeiou,?1?1?1?1?d?d`) via
+  `hashcat_rosetta.mask.format_hcmask_line`.
+- **`_valid_hcmask` now delegates its grammar check to
+  `hashcat_rosetta.mask.parse_hcmask_line`** instead of a hand-rolled
+  placeholder-letter scanner, and no longer blanket-rejects a `,` or `\`. Both
+  are legitimate hcmask syntax (a custom-charset separator and an escape
+  character respectively) that the old checker couldn't tell apart from a
+  malformed mask — it had no concept of custom charsets at all. The old
+  32-character length cap (a runaway-output guard, not a real hashcat limit) is
+  also gone, replaced by hashcat's own real 256-position limit, which
+  HashcatRosetta's `parse_hcmask_line` now enforces directly. Embedded
+  newline/carriage-return/tab and a leading `#` are still rejected locally —
+  those are `.hcmask` *file*-safety concerns `parse_hcmask_line` has no reason
+  to know about, not mask grammar.
 
 ### Fixed
 - **`rosetta_derive` misparsed a batch mixing `--debug-mode` 4 and 5 logs,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   batch's own successful POST, so a later batch's failure still leaves
   earlier batches deduped for a retry — a re-run resumes instead of
   resending everything. `upload_hashfile` is unchanged.
+- **The Rosetta menu (`23`) gained a fourth choice, an LLM Mask Attack**: describe
+  the passwords you expect in plain English and a local Ollama model
+  (`llm.generate_masks`) turns that description into hashcat brute-force
+  masks, which are written to `<hashfile>.hcmask` and run immediately with
+  `-a 3` (`hcatRosettaMask`). No corpus statistics are sent to the model —
+  this mode is driven entirely by the operator's description, unlike the
+  existing rule-mining choices `1`-`3`.
 
 ## [2.24.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   session artifacts.
 
 ### Fixed
+- **`rosetta_derive` stopped reading debug logs after 1,000,000 lines and
+  printed `[!] Stopped at 1000000 debug lines`, silently discarding the
+  remainder of large captures.** The cap and its `max_lines` parameter are
+  removed; every line of every selected log is now read.
 - **A cracked NTLM plaintext that hashcat `$HEX[...]`-wraps for a reason
   unrelated to encoding (an embedded colon, a control character) was
   corrupted before reaching Hashview, which then rejected it with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+## [2.25.0] - 2026-08-04
+
 ### Added
 - **`upload_cracked_hashes` now batches uploads into 10,000-line chunks per
   POST to Hashview's `/v1/hashes/import/<hash_type>` endpoint, instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   this mode is driven entirely by the operator's description, unlike the
   existing rule-mining choices `1`-`3`.
 
+### Changed
+- **`.hcmask` files are now removed by `cleanup()` when the session ends.** This
+  affects the existing Top Mask attack, which generates `.hcmask` files via PACK's
+  `maskgen.py` — previously these generated mask files were left behind after a
+  session for re-use or inspection; they are now cleaned up along with other
+  session artifacts.
+
 ### Fixed
 - **A cracked NTLM plaintext that hashcat `$HEX[...]`-wraps for a reason
   unrelated to encoding (an embedded colon, a control character) was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ Dates are omitted for releases predating this file; see the git tags for exact t
   this mode is driven entirely by the operator's description, unlike the
   existing rule-mining choices `1`-`3`.
 
+### Fixed
+- **A cracked NTLM plaintext that hashcat `$HEX[...]`-wraps for a reason
+  unrelated to encoding (an embedded colon, a control character) was
+  corrupted before reaching Hashview, which then rejected it with
+  `Plaintext for hash <hash>, was found to be invalid` even though
+  hate_crack's own local validation had accepted the pair.** `_wire_field_bytes`
+  always reconstructed `$HEX[...]`-wrapped bytes for UTF-16LE modes (900,
+  1000, 1731) as latin-1 code points needing zero-extend repair — correct
+  when hashcat wrapped genuinely non-UTF-8 bytes, but wrong when the wrapped
+  bytes were already valid UTF-8 text, which double-encoded them (e.g.
+  `café:` became `cafÃ©:`) into a plaintext that no longer hashed to the
+  claimed digest. It now mirrors `_digest_for_type`'s UTF-8-first check:
+  valid UTF-8 is sent as-is, and the latin-1 zero-extend path is used only
+  when the wrapped bytes fail to decode as UTF-8.
+
 ## [2.24.0] - 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Added
+- **`upload_cracked_hashes` now batches uploads into 10,000-line chunks per
+  POST to Hashview's `/v1/hashes/import/<hash_type>` endpoint, instead of
+  sending the whole file as one single request.** Large submissions (e.g.
+  800k hashes) were failing outright, with no partial progress retained on
+  failure. Each batch's cache keys are recorded immediately after that
+  batch's own successful POST, so a later batch's failure still leaves
+  earlier batches deduped for a retry — a re-run resumes instead of
+  resending everything. `upload_hashfile` is unchanged.
+
 ## [2.24.0] - 2026-08-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1186,11 +1186,14 @@ No setup is needed to feed it: `_add_debug_mode_for_rules` appends `--debug-mode
 
 The value is in the cross product rather than the recorded pairs. A pair present in a log has already cracked its hash and will not crack another, but a rule that worked on one baseword has usually never been tried against the others — so N basewords and M rules yield close to N x M untried candidates.
 
-* Lists the logs found in `hcatDebugLogPath` newest-first with their sizes; pick one, pick all of them (up to 20), or type a path to a log from elsewhere
+The menu first asks how to rank rules — choices 1-3 below, plus a fourth, unrelated mode:
+
 * Rules can be ranked by application frequency, by how many distinct basewords each one worked on, or by how many unique candidates each one generated. Frequency is the default; baseword spread is the better choice when the goal is a rule set that generalizes past the specific words it was learned from
+* Only after one of those three is picked does hate_crack list the logs found in `hcatDebugLogPath` newest-first with their sizes; pick one, pick all of them (up to 20), or type a path to a log from elsewhere
 * Prompts for how many top rules to keep (default 100) and how many top basewords (default all). Zero means unlimited for either. The keyspace is the product of the two and is printed before hashcat starts
 * Output is written beside the hash file in `<hash file>.rosetta/` as `basewords.txt` and `rules.rule`, alongside the other ephemeral wordlists, and the directory is removed on exit by the temp-file cleanup
 * Reading stops at 1,000,000 debug lines, since the analyzer needs the whole batch in memory at once. Truncation is reported on the console rather than assumed harmless — logs from a long run routinely exceed this, in which case the newest log is the one worth selecting
+* **LLM Mask Attack** (4) - a different mode entirely, and the only one that needs no debug logs. Prompts for a natural-language description of the passwords you expect (length, character patterns, symbols, etc.), sends it to the locally configured Ollama model, writes the returned masks to `<hash file>.hcmask`, and runs a `-a 3` hashcat mask attack against them
 
 #### Wordlist Tools (option 80)
 A submenu of wordlist preprocessing utilities using hashcat-utils binaries. All tools read from and write to files on disk. All file and directory path prompts support tab completion.

--- a/config.json.example
+++ b/config.json.example
@@ -25,11 +25,11 @@
   "check_for_updates": true,
   "optimizedKernelAttacks": [
     "hcatDictionary", "hcatQuickDictionary", "hcatBandrel", "hcatGoodMeasure",
-    "hcatRecycle", "hcatBruteForce", "hcatTopMask", "hcatPathwellBruteForce",
-    "hcatAdHocMask", "hcatMarkovBruteForce", "hcatFingerprint", "hcatCombination",
-    "hcatCombinator3", "hcatCombinatorX", "hcatHybrid", "hcatYoloCombination",
-    "hcatMiddleCombinator", "hcatThoroughCombinator", "hcatCombipow", "hcatPrince",
-    "hcatPermute", "hcatPCFG"
+    "hcatRecycle", "hcatBruteForce", "hcatTopMask", "hcatRosettaMask",
+    "hcatPathwellBruteForce", "hcatAdHocMask", "hcatMarkovBruteForce", "hcatFingerprint",
+    "hcatCombination", "hcatCombinator3", "hcatCombinatorX", "hcatHybrid",
+    "hcatYoloCombination", "hcatMiddleCombinator", "hcatThoroughCombinator",
+    "hcatCombipow", "hcatPrince", "hcatPermute", "hcatPCFG"
   ],
   "notify_enabled": false,
   "notify_per_crack_enabled": false,

--- a/config.json.example
+++ b/config.json.example
@@ -40,5 +40,6 @@
   "debug": false,
   "weakpass_min_rank": -1,
   "update_channel": "main",
-  "restore_potfile_on_start": false
+  "restore_potfile_on_start": false,
+  "rule_debug_mode_enabled": true
 }

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -33,6 +33,7 @@ HASHVIEW_DEFAULT_TIMEOUT = 30
 # a large payload can legitimately take the server longer than 30s to process
 # before it sends the first response byte.
 HASHVIEW_UPLOAD_TIMEOUT = 300
+HASHVIEW_CRACKED_BATCH_SIZE = 10_000
 
 
 class _RateLimiter:
@@ -1965,32 +1966,75 @@ class HashviewAPI:
                 f"({len(skipped)} line(s) skipped by validation)."
             )
 
-        converted_content = b"\n".join(valid_lines)
         url = f"{self.base_url}/v1/hashes/import/{hash_type}"
         headers = {"Content-Type": "text/plain; charset=utf-8"}
-        resp = self.session.post(
-            url,
-            data=converted_content,
-            headers=headers,
-            timeout=HASHVIEW_UPLOAD_TIMEOUT,
-        )
-        resp.raise_for_status()
-        try:
-            json_response = resp.json()
-            if "type" in json_response and json_response["type"] == "Error":
+
+        batches = [
+            valid_lines[i : i + HASHVIEW_CRACKED_BATCH_SIZE]
+            for i in range(0, len(valid_lines), HASHVIEW_CRACKED_BATCH_SIZE)
+        ]
+        key_batches = [
+            new_keys[i : i + HASHVIEW_CRACKED_BATCH_SIZE]
+            for i in range(0, len(new_keys), HASHVIEW_CRACKED_BATCH_SIZE)
+        ]
+
+        aggregated = {}
+        summable_fields = ("verified", "updated", "count")
+        list_fields = ("unmatched",)
+        for batch_num, (line_batch, key_batch) in enumerate(
+            zip(batches, key_batches), start=1
+        ):
+            if len(batches) > 1:
+                print(
+                    f"Uploading batch {batch_num}/{len(batches)} "
+                    f"({len(line_batch)} hashes)..."
+                )
+            converted_content = b"\n".join(line_batch)
+            resp = self.session.post(
+                url,
+                data=converted_content,
+                headers=headers,
+                timeout=HASHVIEW_UPLOAD_TIMEOUT,
+            )
+            resp.raise_for_status()
+            try:
+                json_response = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                raise Exception(f"Invalid API response: {resp.text[:200]}")
+            if not isinstance(json_response, dict):
+                if len(batches) == 1:
+                    # Matches today's single-request behavior: a non-dict
+                    # response (rare, but Hashview's contract doesn't forbid
+                    # it) is returned as-is rather than merged.
+                    append_to_cache(key_batch)
+                    return json_response
+                raise Exception(
+                    f"Hashview API returned a non-object response for batch "
+                    f"{batch_num}/{len(batches)}: {json_response!r}"
+                )
+            if json_response.get("type") == "Error":
                 raise Exception(
                     f"Hashview API Error: {json_response.get('msg', 'Unknown error')}"
                 )
-            append_to_cache(new_keys)
-            # Surface what the client actually sent so the caller can report a
-            # count even against a Hashview that returns a bare {"msg": "OK"}.
+            append_to_cache(key_batch)
             if isinstance(json_response, dict):
-                json_response.setdefault("uploaded", len(valid_lines))
-                json_response.setdefault("skipped", len(skipped))
-                json_response.setdefault("skipped_cached", skipped_cached)
-            return json_response
-        except (json.JSONDecodeError, ValueError):
-            raise Exception(f"Invalid API response: {resp.text[:200]}")
+                for field in summable_fields:
+                    if isinstance(json_response.get(field), (int, float)):
+                        aggregated[field] = (
+                            aggregated.get(field, 0) + json_response[field]
+                        )
+                for field in list_fields:
+                    if isinstance(json_response.get(field), list):
+                        aggregated.setdefault(field, [])
+                        aggregated[field].extend(json_response[field])
+                for key, value in json_response.items():
+                    if key not in summable_fields and key not in list_fields:
+                        aggregated.setdefault(key, value)
+
+        aggregated.setdefault("uploaded", len(valid_lines))
+        aggregated["skipped"] = len(skipped)
+        aggregated["skipped_cached"] = skipped_cached
+        return aggregated
 
     def download_wordlist(
         self, wordlist_id, output_file=None, *, update_dynamic: bool = False

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -1235,9 +1235,19 @@ def _wire_field_bytes(hash_type, plaintext: str) -> bytes:
         return plaintext.encode("utf-8", "surrogateescape")
     ht = str(hash_type)
     if ht in _UTF16LE_MODES:
-        # hashcat zero-extends raw bytes; send the latin-1 code points as UTF-8
-        # so the server reconstructs them before its own UTF-16LE encoding.
-        return raw.decode("latin-1").encode("utf-8")
+        # hashcat $HEX-wraps for reasons unrelated to encoding (an embedded
+        # colon, a control character, leading/trailing whitespace) as well as
+        # for genuine zero-extended raw bytes. When the wrapped bytes are
+        # already valid UTF-8 they ARE the real password text -- ship them
+        # as-is. Only bytes that fail to decode as UTF-8 are the zero-extend
+        # case, where each byte is a code point to reconstruct as latin-1
+        # before the server's own UTF-16LE encoding. Mirrors the same
+        # utf-8-first choice _digest_for_type makes when validating.
+        try:
+            raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return raw.decode("latin-1").encode("utf-8")
+        return raw
     if ht in _RAW_BYTE_MODES:
         return raw
     return plaintext.encode("utf-8", "surrogateescape")

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -534,7 +534,7 @@ def _prompt_positive_int(prompt: str, default: int | None) -> int | None:
 
 
 def _select_debug_logs(ctx) -> list[str] | None:
-    """Pick the hashcat --debug-mode 4 logs to mine. None if cancelled."""
+    """Pick the hashcat --debug-mode 5 logs to mine. None if cancelled."""
     logs = ctx.rosetta_debug_logs()
     items = []
     for idx, path in enumerate(logs[:20], 1):
@@ -608,7 +608,7 @@ def rosetta_attack(ctx: Any) -> None:
         ctx.hcatRosettaMask(ctx.hcatHashType, ctx.hcatHashFile, description)
         return
 
-    print("Mines hashcat --debug-mode 4 logs, which hate_crack writes for every")
+    print("Mines hashcat --debug-mode 5 logs, which hate_crack writes for every")
     print("rule-based attack, for the basewords and rules that actually cracked")
     print("something. Those are then run as a full cross product: each winning")
     print("rule gets tried against every winning baseword, not just the one it")

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -601,6 +601,9 @@ def rosetta_attack(ctx: Any) -> None:
             "\n[*] Describe the passwords you expect (patterns, length, "
             "symbols, etc.): "
         ).strip()
+        if not description:
+            print("[!] Description cannot be empty.")
+            return
         _notify.prompt_notify_for_attack("Rosetta Mask")
         ctx.hcatRosettaMask(ctx.hcatHashType, ctx.hcatHashFile, description)
         return

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -580,15 +580,9 @@ def _select_debug_logs(ctx) -> list[str] | None:
 
 
 def rosetta_attack(ctx: Any) -> None:
-    """Mine hashcat --debug-mode 4 logs for winning basewords and rules."""
+    """Mine debug-mode logs for winning rules/basewords, or run an LLM mask attack."""
     print("\n" + "=" * 60)
     print("ROSETTA ATTACK")
-    print("=" * 60)
-    print("Mines hashcat --debug-mode 4 logs, which hate_crack writes for every")
-    print("rule-based attack, for the basewords and rules that actually cracked")
-    print("something. Those are then run as a full cross product: each winning")
-    print("rule gets tried against every winning baseword, not just the one it")
-    print("was originally paired with.")
     print("=" * 60)
 
     items = [
@@ -598,7 +592,7 @@ def rosetta_attack(ctx: Any) -> None:
         ("4", "LLM Mask Attack (natural language -> hcmask)"),
         ("99", "Back to Main Menu"),
     ]
-    choice = interactive_menu(items, title="\nRank rules by:")
+    choice = interactive_menu(items, title="\nSelect Rosetta mode:")
     if choice is None or choice == "99":
         return
 
@@ -610,6 +604,13 @@ def rosetta_attack(ctx: Any) -> None:
         _notify.prompt_notify_for_attack("Rosetta Mask")
         ctx.hcatRosettaMask(ctx.hcatHashType, ctx.hcatHashFile, description)
         return
+
+    print("Mines hashcat --debug-mode 4 logs, which hate_crack writes for every")
+    print("rule-based attack, for the basewords and rules that actually cracked")
+    print("something. Those are then run as a full cross product: each winning")
+    print("rule gets tried against every winning baseword, not just the one it")
+    print("was originally paired with.")
+    print("=" * 60)
 
     metric = {"1": "frequency", "2": "basewords", "3": "candidates"}.get(choice)
     if metric is None:

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -591,10 +591,6 @@ def rosetta_attack(ctx: Any) -> None:
     print("was originally paired with.")
     print("=" * 60)
 
-    debug_files = _select_debug_logs(ctx)
-    if not debug_files:
-        return
-
     items = [
         ("1", "Application frequency (rules applied most often)"),
         ("2", "Baseword spread (rules that worked across the most basewords)"),
@@ -618,6 +614,10 @@ def rosetta_attack(ctx: Any) -> None:
     metric = {"1": "frequency", "2": "basewords", "3": "candidates"}.get(choice)
     if metric is None:
         print("[!] Invalid selection.")
+        return
+
+    debug_files = _select_debug_logs(ctx)
+    if not debug_files:
         return
 
     top_rules = _prompt_positive_int(

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -599,11 +599,22 @@ def rosetta_attack(ctx: Any) -> None:
         ("1", "Application frequency (rules applied most often)"),
         ("2", "Baseword spread (rules that worked across the most basewords)"),
         ("3", "Candidate variety (rules producing the most unique candidates)"),
+        ("4", "LLM Mask Attack (natural language -> hcmask)"),
         ("99", "Back to Main Menu"),
     ]
     choice = interactive_menu(items, title="\nRank rules by:")
     if choice is None or choice == "99":
         return
+
+    if choice == "4":
+        description = input(
+            "\n[*] Describe the passwords you expect (patterns, length, "
+            "symbols, etc.): "
+        ).strip()
+        _notify.prompt_notify_for_attack("Rosetta Mask")
+        ctx.hcatRosettaMask(ctx.hcatHashType, ctx.hcatHashFile, description)
+        return
+
     metric = {"1": "frequency", "2": "basewords", "3": "candidates"}.get(choice)
     if metric is None:
         print("[!] Invalid selection.")

--- a/hate_crack/config_schema.py
+++ b/hate_crack/config_schema.py
@@ -321,6 +321,7 @@ CONFIG_SCHEMA: tuple[ConfigKey, ...] = (
         choices=("main", "nightly-dev"),
     ),
     ConfigKey("RESTORE_POTFILE_ON_START", "restore_potfile_on_start", "bool", False),
+    ConfigKey("RULE_DEBUG_MODE_ENABLED", "rule_debug_mode_enabled", "bool", True),
 )
 
 BY_ENV: dict[str, ConfigKey] = {entry.env: entry for entry in CONFIG_SCHEMA}

--- a/hate_crack/config_schema.py
+++ b/hate_crack/config_schema.py
@@ -265,6 +265,7 @@ CONFIG_SCHEMA: tuple[ConfigKey, ...] = (
             "hcatRecycle",
             "hcatBruteForce",
             "hcatTopMask",
+            "hcatRosettaMask",
             "hcatPathwellBruteForce",
             "hcatAdHocMask",
             "hcatMarkovBruteForce",

--- a/hate_crack/llm.py
+++ b/hate_crack/llm.py
@@ -663,8 +663,17 @@ def generate_masks(
     seen: set[str] = set()
     masks: list[str] = []
     for raw in getattr(result, "masks", []) or []:
+        # A non-string entry is model noise, not a mask; str() on it would turn
+        # None into the literal "None", which _valid_hcmask would then reject
+        # for the wrong reason.
         if not isinstance(raw, str):
             continue
+        # Surrounding whitespace goes so that '  ?d?d  ' and '?d?d' dedupe
+        # against each other. The cost is that a mask ending in a literal
+        # trailing space cannot come back from the model this way — worth it,
+        # since models pad far more often than they emit a meaningful
+        # trailing space, and an unstripped mask would otherwise slip past
+        # dedup.
         mask = raw.strip()
         if not mask or mask in seen:
             continue

--- a/hate_crack/llm.py
+++ b/hate_crack/llm.py
@@ -2,7 +2,16 @@
 
 Isolates the atomic-agents / instructor dependency. The rest of hate_crack talks
 to this module only through ``generate_candidates`` and ``research_target``.
+
+``generate_masks`` is the one exception: it delegates entirely to
+``hashcat_rosetta.nlmask.generate_masks`` rather than using Atomic Agents,
+so hate_crack's mask-attack prompt, output schema, and hcmask validation
+all come from HashcatRosetta itself instead of a second, hand-maintained
+copy that would drift from it.
 """
+
+import os
+import sys
 
 import instructor
 from openai import APITimeoutError, OpenAI
@@ -17,6 +26,47 @@ DEFAULT_TIMEOUT_SECONDS = 300.0
 # Researched target fields are pasted into an interactive prompt as an editable
 # default, so they must stay short enough to fit on one terminal line.
 MAX_RESEARCH_FIELD_LEN = 80
+
+# Import HashcatRosetta for mask generation. This module doesn't import
+# hate_crack.main (nor is it guaranteed to be imported after main.py's own
+# sys.path insertion -- main.py imports this module before doing that), so
+# it needs its own independent path setup rather than relying on main.py's.
+# See hate_crack.main.ROSETTA_IMPORT_ERROR for the identical pattern; the
+# two guards are deliberately separate rather than shared; either module
+# can be imported and used standalone.
+_ROSETTA_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "HashcatRosetta")
+)
+# Holds the ImportError when HashcatRosetta could not be imported, else None.
+ROSETTA_MASK_IMPORT_ERROR = None
+try:
+    if _ROSETTA_DIR not in sys.path:
+        sys.path.insert(0, _ROSETTA_DIR)
+    from hashcat_rosetta.mask import format_hcmask_line as _rosetta_format_hcmask_line
+    from hashcat_rosetta.nlmask import (
+        MaskGenerationError as _RosettaMaskGenerationError,
+    )
+    from hashcat_rosetta.nlmask import generate_masks as _rosetta_generate_masks
+except ImportError as _rosetta_mask_import_error:
+    ROSETTA_MASK_IMPORT_ERROR = _rosetta_mask_import_error
+    _rosetta_format_hcmask_line = None
+    _RosettaMaskGenerationError = None
+    _rosetta_generate_masks = None
+
+
+def rosetta_mask_unavailable_reason() -> str:
+    """Return a human-readable explanation for HashcatRosetta being missing.
+
+    Mirrors ``hate_crack.main.rosetta_unavailable_reason`` -- see that
+    function's docstring for why the underlying ImportError is preserved
+    rather than discarded.
+    """
+    message = (
+        "HashcatRosetta is unavailable. Run: git submodule update --init HashcatRosetta"
+    )
+    if ROSETTA_MASK_IMPORT_ERROR is not None:
+        message += f" (import failed: {ROSETTA_MASK_IMPORT_ERROR!r})"
+    return message
 
 
 class LLMTimeoutError(Exception):
@@ -95,20 +145,6 @@ class HashcatRulesOutput(BaseIOSchema):
             "Hashcat rules, one per list entry. Each entry is the raw rule "
             "string of single-character functions, e.g. 'c$2$0$2$5'. No "
             "numbering, comments, quoting, or explanation."
-        ),
-    )
-
-
-class MaskAttackOutput(BaseIOSchema):
-    """A structured list of hashcat brute-force mask strings."""
-
-    masks: list[str] = Field(
-        ...,
-        description=(
-            "Hashcat brute-force masks, one per list entry. Each entry is a raw "
-            "mask string using only literal characters and the built-in charset "
-            "placeholders ?l ?u ?d ?s ?a ?b. No numbering, comments, quoting, or "
-            "explanation."
         ),
     )
 
@@ -310,48 +346,12 @@ _RULES_PROMPT = SystemPromptGenerator(
     ],
 )
 
-_MASK_PROMPT = SystemPromptGenerator(
-    background=[
-        "You are a security professional working an authorized penetration test.",
-        "You write hashcat brute-force masks. A mask is a string of tokens "
-        "applied left to right, each producing exactly one character position "
-        "in a generated candidate.",
-        "The built-in charset tokens, and nothing else: '?l' any lowercase "
-        "letter, '?u' any uppercase letter, '?d' any digit, '?s' any special "
-        "character, '?a' any of the above (letters, digits, specials), '?b' any "
-        "byte 0x00-0xff.",
-        "A literal character in the mask (e.g. '-' or '2026') stands for "
-        "itself and is not a token. A literal '?' must be written '??'.",
-    ],
-    steps=[
-        "Read the operator's description of the passwords they expect: "
-        "length, capitalization, digit/symbol placement, known literal "
-        "substrings (a year, a separator, a company abbreviation).",
-        "Translate each distinct shape the operator describes into one mask. "
-        "'8 characters, capitalized word plus two digits' becomes "
-        "'?u?l?l?l?l?l?d?d' (capital, six lowercase letters, two digits).",
-        "Add masks for reasonable neighboring shapes the operator implied but "
-        "did not spell out — a shorter or longer word, digits before instead "
-        "of after, a trailing symbol as well as a trailing digit pair — so the "
-        "operator gets more than one exact literal reading of their prompt.",
-    ],
-    output_instructions=[
-        "Return one mask per list entry, using only the tokens above and "
-        "literal characters. No quotes, comments, numbering, or explanation.",
-        "Return at least 5 masks, and more when the description implies "
-        "several distinct shapes.",
-        "Keep each mask under 32 characters long.",
-        "Do not include duplicate masks.",
-    ],
-)
-
 _PROMPTS = {
     "target": _TARGET_PROMPT,
     "wordlist": _WORDLIST_PROMPT,
     "cracked": _CRACKED_PROMPT,
     "pattern": _PATTERN_PROMPT,
     "rules": _RULES_PROMPT,
-    "mask": _MASK_PROMPT,
 }
 
 
@@ -631,52 +631,72 @@ def generate_masks(
 
     Unlike the other generation modes, this one takes no corpus context — the
     operator's free-text description of expected password shapes is the whole
-    request.
+    request. Unlike them too, this one delegates entirely to
+    ``hashcat_rosetta.nlmask.generate_masks`` rather than using Atomic Agents
+    directly -- the prompt, the output schema (including custom charsets),
+    hcmask syntax validation, and the one-retry-on-failure behavior all come
+    from HashcatRosetta itself, so this module never carries its own
+    independent copy of any of that to drift out of sync.
 
-    Returns a deduped list of raw mask strings in the order the model gave
-    them. Entries are *not* syntax-validated here — callers must screen them
-    (see ``main._valid_hcmask``) before handing the file to hashcat.
+    Each suggestion HashcatRosetta returns (a mask plus 0-8 custom charsets)
+    is combined into a single canonical hcmask line via
+    ``hashcat_rosetta.mask.format_hcmask_line`` before being returned here.
+
+    Returns a deduped list of hcmask line strings in the order HashcatRosetta
+    gave them. Every entry is already syntax-validated -- unlike the other
+    generation modes in this module, there is no separate screening step
+    callers need to run before handing the file to hashcat.
 
     Raises LLMTimeoutError if the request exceeds ``timeout``,
-    CloudModelRefused when ``no_cloud`` rules out ``model``; other
-    client/connection errors propagate to the caller.
+    CloudModelRefused when ``no_cloud`` rules out ``model``, RuntimeError if
+    HashcatRosetta itself is unavailable (see
+    ``rosetta_mask_unavailable_reason``); other client/connection errors
+    propagate as HashcatRosetta's own MaskGenerationError.
     """
     ensure_model_allowed(model, no_cloud=no_cloud)
-    client = _build_client(url, timeout)
 
-    agent = AtomicAgent[GenerationInput, MaskAttackOutput](
-        config=AgentConfig(
-            client=client,
-            model=model,
-            system_prompt_generator=_PROMPTS["mask"],
-            model_api_parameters={"extra_body": {"options": {"num_ctx": num_ctx}}},
-        )
-    )
+    # The three names are always set together in the single try/except above
+    # (all real or all None) -- checking all three, not just the one this
+    # function calls first, is what lets the type checker narrow the later
+    # uses of the other two instead of still seeing `X | None`.
+    if (
+        _rosetta_generate_masks is None
+        or _RosettaMaskGenerationError is None
+        or _rosetta_format_hcmask_line is None
+    ):
+        raise RuntimeError(rosetta_mask_unavailable_reason())
+
+    client = OpenAI(base_url=f"{url}/v1", api_key="ollama", timeout=timeout)
 
     try:
-        result = agent.run(GenerationInput(request=description))
-    except APITimeoutError as e:
-        raise LLMTimeoutError(
-            f"no response from {url} within {timeout:g} seconds"
-        ) from e
+        suggestions = _rosetta_generate_masks(
+            description,
+            model=model,
+            client=client,
+            extra_options={"num_ctx": num_ctx},
+        )
+    except _RosettaMaskGenerationError as e:
+        # HashcatRosetta wraps every request failure (including a plain
+        # openai.APITimeoutError) into its own MaskGenerationError, but
+        # preserves the original as __cause__ (`raise ... from exc`) -- that
+        # chained exception, not string-matching the message, is what tells
+        # a genuine timeout apart from every other failure it also wraps the
+        # same way (connection refused, bad JSON, validation failure after
+        # retry, ...).
+        if isinstance(e.__cause__, APITimeoutError):
+            raise LLMTimeoutError(
+                f"no response from {url} within {timeout:g} seconds"
+            ) from e
+        raise
 
     seen: set[str] = set()
     masks: list[str] = []
-    for raw in getattr(result, "masks", []) or []:
-        # A non-string entry is model noise, not a mask; str() on it would turn
-        # None into the literal "None", which _valid_hcmask would then reject
-        # for the wrong reason.
-        if not isinstance(raw, str):
+    for suggestion in suggestions:
+        combined = _rosetta_format_hcmask_line(
+            suggestion.custom_charsets, suggestion.mask
+        )
+        if combined in seen:
             continue
-        # Surrounding whitespace goes so that '  ?d?d  ' and '?d?d' dedupe
-        # against each other. The cost is that a mask ending in a literal
-        # trailing space cannot come back from the model this way — worth it,
-        # since models pad far more often than they emit a meaningful
-        # trailing space, and an unstripped mask would otherwise slip past
-        # dedup.
-        mask = raw.strip()
-        if not mask or mask in seen:
-            continue
-        seen.add(mask)
-        masks.append(mask)
+        seen.add(combined)
+        masks.append(combined)
     return masks

--- a/hate_crack/llm.py
+++ b/hate_crack/llm.py
@@ -99,6 +99,20 @@ class HashcatRulesOutput(BaseIOSchema):
     )
 
 
+class MaskAttackOutput(BaseIOSchema):
+    """A structured list of hashcat brute-force mask strings."""
+
+    masks: list[str] = Field(
+        ...,
+        description=(
+            "Hashcat brute-force masks, one per list entry. Each entry is a raw "
+            "mask string using only literal characters and the built-in charset "
+            "placeholders ?l ?u ?d ?s ?a ?b. No numbering, comments, quoting, or "
+            "explanation."
+        ),
+    )
+
+
 class TargetResearchInput(BaseIOSchema):
     """The company name to recall industry and location details for."""
 
@@ -296,12 +310,48 @@ _RULES_PROMPT = SystemPromptGenerator(
     ],
 )
 
+_MASK_PROMPT = SystemPromptGenerator(
+    background=[
+        "You are a security professional working an authorized penetration test.",
+        "You write hashcat brute-force masks. A mask is a string of tokens "
+        "applied left to right, each producing exactly one character position "
+        "in a generated candidate.",
+        "The built-in charset tokens, and nothing else: '?l' any lowercase "
+        "letter, '?u' any uppercase letter, '?d' any digit, '?s' any special "
+        "character, '?a' any of the above (letters, digits, specials), '?b' any "
+        "byte 0x00-0xff.",
+        "A literal character in the mask (e.g. '-' or '2026') stands for "
+        "itself and is not a token. A literal '?' must be written '??'.",
+    ],
+    steps=[
+        "Read the operator's description of the passwords they expect: "
+        "length, capitalization, digit/symbol placement, known literal "
+        "substrings (a year, a separator, a company abbreviation).",
+        "Translate each distinct shape the operator describes into one mask. "
+        "'8 characters, capitalized word plus two digits' becomes "
+        "'?u?l?l?l?l?l?d?d' (capital, six lowercase letters, two digits).",
+        "Add masks for reasonable neighboring shapes the operator implied but "
+        "did not spell out — a shorter or longer word, digits before instead "
+        "of after, a trailing symbol as well as a trailing digit pair — so the "
+        "operator gets more than one exact literal reading of their prompt.",
+    ],
+    output_instructions=[
+        "Return one mask per list entry, using only the tokens above and "
+        "literal characters. No quotes, comments, numbering, or explanation.",
+        "Return at least 5 masks, and more when the description implies "
+        "several distinct shapes.",
+        "Keep each mask under 32 characters long.",
+        "Do not include duplicate masks.",
+    ],
+)
+
 _PROMPTS = {
     "target": _TARGET_PROMPT,
     "wordlist": _WORDLIST_PROMPT,
     "cracked": _CRACKED_PROMPT,
     "pattern": _PATTERN_PROMPT,
     "rules": _RULES_PROMPT,
+    "mask": _MASK_PROMPT,
 }
 
 
@@ -566,3 +616,58 @@ def generate_rules(
         seen.add(rule)
         rules.append(rule)
     return rules
+
+
+def generate_masks(
+    url: str,
+    model: str,
+    num_ctx: int,
+    description: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    *,
+    no_cloud: bool,
+) -> list[str]:
+    """Generate hashcat brute-force masks from a plain-English description.
+
+    Unlike the other generation modes, this one takes no corpus context — the
+    operator's free-text description of expected password shapes is the whole
+    request.
+
+    Returns a deduped list of raw mask strings in the order the model gave
+    them. Entries are *not* syntax-validated here — callers must screen them
+    (see ``main._valid_hcmask``) before handing the file to hashcat.
+
+    Raises LLMTimeoutError if the request exceeds ``timeout``,
+    CloudModelRefused when ``no_cloud`` rules out ``model``; other
+    client/connection errors propagate to the caller.
+    """
+    ensure_model_allowed(model, no_cloud=no_cloud)
+    client = _build_client(url, timeout)
+
+    agent = AtomicAgent[GenerationInput, MaskAttackOutput](
+        config=AgentConfig(
+            client=client,
+            model=model,
+            system_prompt_generator=_PROMPTS["mask"],
+            model_api_parameters={"extra_body": {"options": {"num_ctx": num_ctx}}},
+        )
+    )
+
+    try:
+        result = agent.run(GenerationInput(request=description))
+    except APITimeoutError as e:
+        raise LLMTimeoutError(
+            f"no response from {url} within {timeout:g} seconds"
+        ) from e
+
+    seen: set[str] = set()
+    masks: list[str] = []
+    for raw in getattr(result, "masks", []) or []:
+        if not isinstance(raw, str):
+            continue
+        mask = raw.strip()
+        if not mask or mask in seen:
+            continue
+        seen.add(mask)
+        masks.append(mask)
+    return masks

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2222,10 +2222,16 @@ def _valid_hcmask(mask: object) -> bool:
     ``.hcmask`` file and a newline would split it into two (one of them
     possibly blank, which hashcat refuses to run). A literal space remains
     legal mask content.
+
+    A mask starting with ``#`` is rejected too: hashcat treats a ``.hcmask``
+    line beginning with ``#`` as a comment, so such a mask would be silently
+    skipped rather than run.
     """
     if not isinstance(mask, str) or not mask or len(mask) > _HCMASK_MAX_LEN:
         return False
     if any(c in mask for c in (",", "\\", "\n", "\r", "\t")):
+        return False
+    if mask.startswith("#"):
         return False
     i = 0
     n = len(mask)
@@ -4697,6 +4703,8 @@ def cleanup():
         print("\nCleaning up temporary files...")
         if os.path.exists(hcatHashFile + ".masks"):
             os.remove(hcatHashFile + ".masks")
+        if os.path.exists(hcatHashFile + ".hcmask"):
+            os.remove(hcatHashFile + ".hcmask")
         if os.path.exists(hcatHashFile + ".working"):
             os.remove(hcatHashFile + ".working")
         if os.path.exists(hcatHashFile + ".expanded"):

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -4028,7 +4028,7 @@ def rosetta_derive(
     """Derive a baseword list and rule file from hashcat debug logs.
 
     HashcatRosetta parses mode 5 (the current writer) and mode 4 (logs
-    predating the switch) natively, detecting the format per batch. Every line
+    predating the switch) natively, detecting the format per file. Every line
     records a candidate that actually cracked a hash, so the basewords and rules
     recovered here are known-productive against this target population. ``top_rules``/``top_basewords`` of None or
     0 mean "keep everything".
@@ -4042,22 +4042,29 @@ def rosetta_derive(
     if metric not in ROSETTA_RULE_METRICS:
         raise ValueError(f"unknown rule metric: {metric}")
 
-    lines = []
-    for path in debug_files:
-        with open(path, encoding="utf-8", errors="ignore") as debug_log:
-            for line in debug_log:
-                lines.append(line.rstrip("\n"))
-    if not lines:
+    # Zero-byte files are tolerated (rosetta_debug_logs() already excludes them
+    # from the picker, but direct callers may not have filtered). A capture
+    # spanning a --debug-mode switch mixes mode-4 and mode-5 files, which is
+    # why each one is parsed on its own via analyze_debug_files() rather than
+    # merged into one line list first -- format/mode detection samples the
+    # start of whatever it's given, so a merged batch lets one file's sample
+    # decide the mode for both and silently drops the other file's lines.
+    non_empty_files = [path for path in debug_files if os.path.getsize(path) > 0]
+    if not non_empty_files:
         raise ValueError("the selected debug logs are empty")
 
     analyzer = DebugAnalyzer()
-    analyzer.analyze_debug_lines(lines)
-    if not analyzer.rule_stats or not analyzer.baseword_stats:
+    try:
+        analyzer.analyze_debug_files(non_empty_files)
+    except ValueError as e:
+        # analyze_debug_files() raises per-file as soon as one file yields no
+        # entries, so a merged batch can never come back with entries but
+        # empty rule/baseword stats -- this is the only "nothing usable" case.
         raise ValueError(
             "no hashcat debug entries found. Expected lines of the form "
             "'baseword:rule:candidate' (--debug-mode 4) or "
             "'baseword:rule:candidate:wordlist' (--debug-mode 5)"
-        )
+        ) from e
 
     getter = ROSETTA_RULE_METRICS[metric][0]
     rule_limit = top_rules or len(analyzer.rule_stats)

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2204,7 +2204,7 @@ _HCMASK_PLACEHOLDER_LETTERS = frozenset("ludsab")
 _HCMASK_MAX_LEN = 32
 
 
-def _valid_hcmask(mask) -> bool:
+def _valid_hcmask(mask: object) -> bool:
     """Is *mask* a syntactically valid hashcat brute-force mask?
 
     A '?' must be followed by one of the built-in placeholder letters

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -4018,20 +4018,12 @@ def rosetta_debug_logs(directory=None):
     return sorted(found, key=os.path.getmtime, reverse=True)
 
 
-# DebugAnalyzer needs the whole batch as a list (it walks it twice, once for
-# format detection), so the logs cannot be streamed. Cap the read to keep peak
-# memory in the low hundreds of megabytes; truncation is reported, not silent.
-ROSETTA_MAX_LINES = 1_000_000
-
-
-# Lines sampled per log when deciding whether it is mode 5, and the ceiling on
 def rosetta_derive(
     debug_files,
     out_dir,
     metric="frequency",
     top_rules=None,
     top_basewords=None,
-    max_lines=ROSETTA_MAX_LINES,
 ):
     """Derive a baseword list and rule file from hashcat debug logs.
 
@@ -4051,21 +4043,10 @@ def rosetta_derive(
         raise ValueError(f"unknown rule metric: {metric}")
 
     lines = []
-    truncated = False
     for path in debug_files:
-        if truncated:
-            break
         with open(path, encoding="utf-8", errors="ignore") as debug_log:
             for line in debug_log:
                 lines.append(line.rstrip("\n"))
-                if len(lines) >= max_lines:
-                    truncated = True
-                    print(
-                        f"[!] Stopped at {max_lines} debug lines; the remainder "
-                        f"of {os.path.basename(path)} and any later logs were "
-                        "not read."
-                    )
-                    break
     if not lines:
         raise ValueError("the selected debug logs are empty")
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -97,10 +97,14 @@ try:
     sys.path.insert(0, ROSETTA_DIR)
     from hashcat_rosetta.debug_analyzer import DebugAnalyzer
     from hashcat_rosetta.formatting import display_rule_opcodes_summary
+    from hashcat_rosetta.mask import MaskError as RosettaMaskError
+    from hashcat_rosetta.mask import parse_hcmask_line as rosetta_parse_hcmask_line
 except ImportError as rosetta_import_error:
     ROSETTA_IMPORT_ERROR = rosetta_import_error
     display_rule_opcodes_summary = None
     DebugAnalyzer = None
+    RosettaMaskError = None
+    rosetta_parse_hcmask_line = None
 
 
 def rosetta_unavailable_reason():
@@ -2197,54 +2201,42 @@ def hcatQuickDictionary(
     _run_hcat_cmd(cmd, attack_name=attack_name, hash_file=hcatHashFile)
 
 
-# Built-in hashcat charset placeholders usable in a mask, per hashcat's
-# documented -1..-4/custom-charset-free set. Anything else after a '?' is
-# either a literal '?' (escaped as '??') or an invalid mask.
-_HCMASK_PLACEHOLDER_LETTERS = frozenset("ludsab")
-_HCMASK_MAX_LEN = 32
-
-
 def _valid_hcmask(mask: object) -> bool:
-    """Is *mask* a syntactically valid hashcat brute-force mask?
+    """Is *mask* a syntactically valid hashcat brute-force mask (or hcmask line)?
 
-    A '?' must be followed by one of the built-in placeholder letters
-    (l/u/d/s/a/b) or by another '?' (the escape for a literal question mark).
-    Anything else — an unescaped trailing '?', an unrecognized placeholder
-    letter, a non-string, an empty string, or a mask longer than
-    ``_HCMASK_MAX_LEN`` characters — is rejected. Length is capped as a guard
-    against runaway model output, not a hashcat limitation as such.
+    Delegates the actual hcmask grammar — builtin tokens, custom charsets
+    (``?1``-``?8``, comma-separated, ``\\,``-escaped), and hashcat's own
+    256-position mask-length limit — to
+    ``hashcat_rosetta.mask.parse_hcmask_line``. ``llm.generate_masks``
+    already ran every suggestion through that exact function before this one
+    ever sees it; this check exists for callers reaching ``hcatRosettaMask``
+    some other way, and returns ``False`` (rather than raising) for a
+    non-string, an empty string, or anything ``parse_hcmask_line`` rejects.
 
-    A ``,`` or ``\\`` is also rejected: both are structural in the ``.hcmask``
-    file format (comma separates custom-charset definitions from the mask,
-    backslash escapes within it), so a literal one in the mask text would be
-    reinterpreted rather than run verbatim. Embedded ``\\n``, ``\\r``, or
-    ``\\t`` are rejected too, since each mask becomes its own line in the
-    ``.hcmask`` file and a newline would split it into two (one of them
-    possibly blank, which hashcat refuses to run). A literal space remains
-    legal mask content.
-
-    A mask starting with ``#`` is rejected too: hashcat treats a ``.hcmask``
-    line beginning with ``#`` as a comment, so such a mask would be silently
-    skipped rather than run.
+    Three checks stay local because they're about ``.hcmask`` *file* safety,
+    not mask grammar, and ``parse_hcmask_line`` has no reason to know about
+    them: an embedded ``\\n``/``\\r``/``\\t`` is rejected because each mask
+    becomes its own line in the file and a newline would split it into two
+    (one of them possibly blank, which hashcat refuses to run); a mask
+    starting with ``#`` is rejected because hashcat treats such a
+    ``.hcmask`` line as a comment and would silently skip it.
     """
-    if not isinstance(mask, str) or not mask or len(mask) > _HCMASK_MAX_LEN:
+    if not isinstance(mask, str) or not mask:
         return False
-    if any(c in mask for c in (",", "\\", "\n", "\r", "\t")):
+    if any(c in mask for c in ("\n", "\r", "\t")):
         return False
     if mask.startswith("#"):
         return False
-    i = 0
-    n = len(mask)
-    while i < n:
-        if mask[i] == "?":
-            if i + 1 >= n:
-                return False
-            nxt = mask[i + 1]
-            if nxt != "?" and nxt not in _HCMASK_PLACEHOLDER_LETTERS:
-                return False
-            i += 2
-        else:
-            i += 1
+    # The two names are always set together in the single try/except above
+    # (both real or both None) -- checking both, not just the one this
+    # function calls, is what lets the type checker narrow the except
+    # clause below instead of still seeing `type[RosettaMaskError] | None`.
+    if rosetta_parse_hcmask_line is None or RosettaMaskError is None:
+        return False
+    try:
+        rosetta_parse_hcmask_line(mask)
+    except RosettaMaskError:
+        return False
     return True
 
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -207,6 +207,7 @@ DEFAULT_OPTIMIZED_ATTACKS = frozenset(
         "hcatRecycle",
         "hcatBruteForce",
         "hcatTopMask",
+        "hcatRosettaMask",
         "hcatPathwellBruteForce",
         "hcatAdHocMask",
         "hcatMarkovBruteForce",
@@ -2292,6 +2293,72 @@ def hcatTopMask(hcatHashType, hcatHashFile, hcatTargetTime):
     _run_hcat_cmd(cmd, attack_name="Top Mask", hash_file=hcatHashFile)
 
     hcatMaskCount = lineCount(hcatHashFile + ".out") - hcatHashCracked
+
+
+# Rosetta Mask Attack: natural-language description -> hashcat masks
+def hcatRosettaMask(hcatHashType, hcatHashFile, description):
+    """Turn a plain-English description into hashcat masks and run them.
+
+    Asks the local Ollama model (via ``llm.generate_masks``) for masks
+    matching *description*, screens the result with ``_valid_hcmask``, writes
+    the survivors to ``<hcatHashFile>.hcmask``, and runs a ``-a 3`` mask
+    attack against them immediately — mirroring ``hcatTopMask``'s tail.
+    """
+    global hcatProcess
+
+    try:
+        with spinner(f"Generating masks via Ollama ({ollamaModel})..."):
+            masks = llm.generate_masks(
+                ollamaUrl,
+                ollamaModel,
+                ollamaNumCtx,
+                description,
+                timeout=ollamaTimeout,
+                no_cloud=ollamaNoCloud,
+            )
+    except llm.LLMTimeoutError:
+        print(f"Error: the Ollama request timed out after {ollamaTimeout:g} seconds.")
+        print(
+            f"The model ({ollamaModel}) may still be loading into VRAM. Retry, or "
+            "raise OLLAMA_TIMEOUT in the .env file to wait longer."
+        )
+        return
+    except Exception as e:
+        print(f"Error generating masks: {e}")
+        print(
+            "Ensure Ollama is running (ollama serve) and the model is pulled "
+            f"(ollama pull {ollamaModel})."
+        )
+        return
+
+    valid_masks = [mask for mask in masks if _valid_hcmask(mask)]
+    if not valid_masks:
+        print("Error: the model returned no usable masks.")
+        return
+
+    hcmask_path = f"{hcatHashFile}.hcmask"
+    with open(hcmask_path, "w", encoding="utf-8") as f:
+        f.writelines(f"{mask}\n" for mask in valid_masks)
+    print(f"Generated {len(valid_masks)} mask(s) -> {hcmask_path}")
+
+    cmd = [
+        hcatBin,
+        "-m",
+        hcatHashType,
+        hcatHashFile,
+        "--session",
+        generate_session_id(),
+        "-o",
+        f"{hcatHashFile}.out",
+        "-a",
+        "3",
+        hcmask_path,
+    ]
+    if _should_use_optimized_kernel("hcatRosettaMask"):
+        _insert_optimized_flag(cmd)
+    cmd.extend(shlex.split(hcatTuning))
+    _append_potfile_arg(cmd)
+    _run_hcat_cmd(cmd, attack_name="Rosetta Mask", hash_file=hcatHashFile)
 
 
 # Fingerprint Attack

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2213,8 +2213,19 @@ def _valid_hcmask(mask) -> bool:
     letter, a non-string, an empty string, or a mask longer than
     ``_HCMASK_MAX_LEN`` characters — is rejected. Length is capped as a guard
     against runaway model output, not a hashcat limitation as such.
+
+    A ``,`` or ``\\`` is also rejected: both are structural in the ``.hcmask``
+    file format (comma separates custom-charset definitions from the mask,
+    backslash escapes within it), so a literal one in the mask text would be
+    reinterpreted rather than run verbatim. Embedded ``\\n``, ``\\r``, or
+    ``\\t`` are rejected too, since each mask becomes its own line in the
+    ``.hcmask`` file and a newline would split it into two (one of them
+    possibly blank, which hashcat refuses to run). A literal space remains
+    legal mask content.
     """
     if not isinstance(mask, str) or not mask or len(mask) > _HCMASK_MAX_LEN:
+        return False
+    if any(c in mask for c in (",", "\\", "\n", "\r", "\t")):
         return False
     i = 0
     n = len(mask)
@@ -2304,8 +2315,6 @@ def hcatRosettaMask(hcatHashType, hcatHashFile, description):
     the survivors to ``<hcatHashFile>.hcmask``, and runs a ``-a 3`` mask
     attack against them immediately — mirroring ``hcatTopMask``'s tail.
     """
-    global hcatProcess
-
     try:
         with spinner(f"Generating masks via Ollama ({ollamaModel})..."):
             masks = llm.generate_masks(

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -312,6 +312,7 @@ class FlagOverrides(NamedTuple):
     restore_potfile: bool
     optimized_kernel_disabled: bool
     potfile_path: str
+    rule_debug_mode_enabled: bool
 
 
 def _flag_or_config(flag_value, config_value):
@@ -333,7 +334,7 @@ def _flag_or_config(flag_value, config_value):
 
 
 def resolve_flag_overrides(args, config, *, base_dir, current_potfile_path=None):
-    """Resolve the six promoted preference flags against loaded ``config``.
+    """Resolve the seven promoted preference flags against loaded ``config``.
 
     ``args`` is anything with the argparse attribute names (a
     ``SimpleNamespace`` is fine); ``config`` is a ``config_parser``-shaped
@@ -342,7 +343,7 @@ def resolve_flag_overrides(args, config, *, base_dir, current_potfile_path=None)
 
     Precedence for each key is CLI flag > os.environ > that key's own home file
     > schema default. There is no cross-file fallthrough: each key lives in
-    exactly one of ``.env`` or ``config.json`` (all six resolved here are
+    exactly one of ``.env`` or ``config.json`` (all seven resolved here are
     ``config.json`` keys) and an entry in the other file is ignored with a
     warning. The loader owns the bottom three and has already collapsed
     them into ``config``; this function only layers the flag on top. It is
@@ -403,6 +404,12 @@ def resolve_flag_overrides(args, config, *, base_dir, current_potfile_path=None)
         # existing configs.
         optimized_kernel_disabled=bool(getattr(args, "no_optimized_kernel", False)),
         potfile_path=potfile_path,
+        rule_debug_mode_enabled=bool(
+            _flag_or_config(
+                getattr(args, "rule_debug_mode", None),
+                config.get("rule_debug_mode_enabled", True),
+            )
+        ),
     )
 
 
@@ -1272,6 +1279,22 @@ debug_mode = False
 non_interactive = False
 hcatUsernamePrefix: bool = False
 
+# Level requested for --debug-mode on rule-based attacks. A hashcat build
+# older than the one that introduced mode 5 rejects it with "Invalid
+# --debug-mode value specified." (exit 255); _run_hcat_cmd detects that
+# specific failure, retries the same invocation at mode 4, and drops this to
+# 4 so every later rule-based attack in the process requests mode 4 directly
+# instead of failing and retrying again.
+_debug_mode_level = 5
+_DEBUG_MODE_UNSUPPORTED_MSG = b"Invalid --debug-mode value specified."
+
+# Set from ``flags.rule_debug_mode_enabled`` in main(); --no-rule-debug-mode
+# (or ``rule_debug_mode_enabled: false`` in config.json) stops
+# _add_debug_mode_for_rules from adding --debug-mode/--debug-file at all.
+# Unrelated to ``debug_mode`` above, which only controls hate_crack's own
+# verbose logging.
+_rule_debug_mode_enabled = True
+
 
 def _open_wordlist(path):
     """Open a wordlist file, transparently decompressing gzip by magic bytes.
@@ -1335,7 +1358,7 @@ def _run_hcat_cmd(
     ``notify.suppressed_notifications``) and disabled-globally state are
     both handled inside the notify module, so callers need not branch.
     """
-    global hcatProcess
+    global hcatProcess, _debug_mode_level
 
     companions = list(companion_procs) if companion_procs else []
 
@@ -1349,7 +1372,16 @@ def _run_hcat_cmd(
     if attack_name and resolved_out and not _notify.is_suppressed():
         tailer = _notify.start_tailer(resolved_out, attack_name)
 
+    # ``--debug-mode`` is only ever added by ``_add_debug_mode_for_rules``, so
+    # only those invocations pay for the stderr capture needed to detect a
+    # hashcat build that rejects the requested mode. stdout is left alone
+    # (inherited) so the live progress output is unaffected.
+    has_debug_mode = "--debug-mode" in cmd
+    stderr_capture = tempfile.TemporaryFile() if has_debug_mode else None
+
     popen_kwargs = {"stdin": stdin} if stdin is not None else {}
+    if stderr_capture is not None:
+        popen_kwargs["stderr"] = stderr_capture
     hcatProcess = subprocess.Popen(cmd, **popen_kwargs)
     interrupted = False
     try:
@@ -1370,6 +1402,42 @@ def _run_hcat_cmd(
                 pass
     finally:
         _notify.stop_tailer(tailer)
+
+    if stderr_capture is not None:
+        try:
+            stderr_capture.seek(0)
+            captured_stderr = stderr_capture.read()
+        finally:
+            stderr_capture.close()
+
+        if (
+            not interrupted
+            and hcatProcess.returncode
+            and _DEBUG_MODE_UNSUPPORTED_MSG in captured_stderr
+        ):
+            debug_mode_idx = cmd.index("--debug-mode") + 1
+            requested_level = cmd[debug_mode_idx]
+            if requested_level == str(_debug_mode_level) and _debug_mode_level > 4:
+                print(
+                    f"[!] hashcat rejected --debug-mode {requested_level} "
+                    "(unsupported by this build); falling back to "
+                    "--debug-mode 4 for the rest of this run."
+                )
+                _debug_mode_level = 4
+                fallback_cmd = list(cmd)
+                fallback_cmd[debug_mode_idx] = "4"
+                return _run_hcat_cmd(
+                    fallback_cmd,
+                    attack_name,
+                    hash_file,
+                    stdin=stdin,
+                    companion_procs=companion_procs,
+                    reraise_interrupt=reraise_interrupt,
+                    out_path=out_path,
+                )
+        elif captured_stderr:
+            sys.stderr.write(captured_stderr.decode(errors="replace"))
+            sys.stderr.flush()
 
     # Only incur a lineCount read when notifications will actually fire.
     # This avoids disturbing existing tests that assert a specific number
@@ -1439,8 +1507,11 @@ def _add_debug_mode_for_rules(cmd):
     Mode 5 is mode 4 (baseword:rule:candidate) plus the wordlist the baseword
     came from, so a log from a multi-wordlist run records which list is actually
     producing cracks. HashcatRosetta >= 0.3.0 parses that fourth field.
+
+    Skipped entirely when ``--no-rule-debug-mode`` (or
+    ``rule_debug_mode_enabled: false`` in config.json) is in effect.
     """
-    if "-r" in cmd:
+    if "-r" in cmd and _rule_debug_mode_enabled:
         # Create debug output directory if it doesn't exist
         os.makedirs(hcatDebugLogPath, exist_ok=True)
 
@@ -1453,7 +1524,9 @@ def _add_debug_mode_for_rules(cmd):
                     hcatDebugLogPath, f"hashcat_debug_{cmd[session_idx]}.log"
                 )
 
-        cmd.extend(["--debug-mode", "5", "--debug-file", debug_filename])
+        cmd.extend(
+            ["--debug-mode", str(_debug_mode_level), "--debug-file", debug_filename]
+        )
     return cmd
 
 
@@ -6332,6 +6405,20 @@ def main():
             action="store_true",
             help="Do not pass --potfile-path to hashcat (use hashcat's built-in default).",
         )
+        parser.add_argument(
+            "--rule-debug-mode",
+            dest="rule_debug_mode",
+            action=argparse.BooleanOptionalAction,
+            default=None,
+            help=(
+                "Have every rule-based attack pass --debug-mode/--debug-file to "
+                "hashcat, so the Rosetta Attack can mine which rules/wordlists "
+                "cracked what. Overrides `rule_debug_mode_enabled` in config.json "
+                "for this run; --no-rule-debug-mode stops hate_crack from adding "
+                "those flags at all -- unrelated to --debug/--no-debug, which "
+                "only controls hate_crack's own verbose logging."
+            ),
+        )
         hashview_parser = None
         if not include_subcommands:
             return parser, hashview_parser
@@ -6470,9 +6557,9 @@ def main():
     if getattr(args, "command", None) in _noninteractive.ATTACK_COMMANDS:
         non_interactive = True
 
-    # Six flags are per-run overrides of schema-backed keys; resolve_flag_overrides
+    # Seven flags are per-run overrides of schema-backed keys; resolve_flag_overrides
     # layers the flag (when present) on top of what the loader already merged
-    # from os.environ, the key's own home file (config.json for all six) and
+    # from os.environ, the key's own home file (config.json for all seven) and
     # the schema default.
     flags = resolve_flag_overrides(
         args,
@@ -6481,8 +6568,9 @@ def main():
         current_potfile_path=hcatPotfilePath,
     )
 
-    global debug_mode
+    global debug_mode, _rule_debug_mode_enabled
     debug_mode = flags.debug
+    _rule_debug_mode_enabled = flags.rule_debug_mode_enabled
     if flags.optimized_kernel_disabled:
         disable_optimized_kernel()
         print("[*] Optimized kernels (-O) disabled for this run")

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2196,6 +2196,40 @@ def hcatQuickDictionary(
     _run_hcat_cmd(cmd, attack_name=attack_name, hash_file=hcatHashFile)
 
 
+# Built-in hashcat charset placeholders usable in a mask, per hashcat's
+# documented -1..-4/custom-charset-free set. Anything else after a '?' is
+# either a literal '?' (escaped as '??') or an invalid mask.
+_HCMASK_PLACEHOLDER_LETTERS = frozenset("ludsab")
+_HCMASK_MAX_LEN = 32
+
+
+def _valid_hcmask(mask) -> bool:
+    """Is *mask* a syntactically valid hashcat brute-force mask?
+
+    A '?' must be followed by one of the built-in placeholder letters
+    (l/u/d/s/a/b) or by another '?' (the escape for a literal question mark).
+    Anything else — an unescaped trailing '?', an unrecognized placeholder
+    letter, a non-string, an empty string, or a mask longer than
+    ``_HCMASK_MAX_LEN`` characters — is rejected. Length is capped as a guard
+    against runaway model output, not a hashcat limitation as such.
+    """
+    if not isinstance(mask, str) or not mask or len(mask) > _HCMASK_MAX_LEN:
+        return False
+    i = 0
+    n = len(mask)
+    while i < n:
+        if mask[i] == "?":
+            if i + 1 >= n:
+                return False
+            nxt = mask[i + 1]
+            if nxt != "?" and nxt not in _HCMASK_PLACEHOLDER_LETTERS:
+                return False
+            i += 2
+        else:
+            i += 1
+    return True
+
+
 # Top Mask Attack
 def hcatTopMask(hcatHashType, hcatHashFile, hcatTargetTime):
     global hcatMaskCount

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -690,16 +690,31 @@ class TestRosettaAttack:
             ctx.hcatHashType, ctx.hcatHashFile, "8 char passwords with digits"
         )
 
-    def test_mask_choice_does_not_call_hcatRosetta(self) -> None:
+    def test_mask_choice_strips_whitespace_from_description(self) -> None:
         ctx = _make_ctx()
 
         with (
             patch("hate_crack.attacks.interactive_menu", return_value="4"),
-            patch("builtins.input", return_value="pins"),
+            patch("builtins.input", return_value="  8 char passwords with digits  "),
         ):
             rosetta_attack(ctx)
 
-        ctx.hcatRosetta.assert_not_called()
+        ctx.hcatRosettaMask.assert_called_once_with(
+            ctx.hcatHashType, ctx.hcatHashFile, "8 char passwords with digits"
+        )
+
+    def test_mask_choice_with_blank_description_does_not_call_hcatRosettaMask(
+        self,
+    ) -> None:
+        ctx = _make_ctx()
+
+        with (
+            patch("hate_crack.attacks.interactive_menu", return_value="4"),
+            patch("builtins.input", return_value="   "),
+        ):
+            rosetta_attack(ctx)
+
+        ctx.hcatRosettaMask.assert_not_called()
 
     def test_existing_metric_choice_1_is_unaffected(self) -> None:
         ctx = _make_ctx()

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -12,6 +12,7 @@ from hate_crack.attacks import (
     ollama_attack,
     pathwell_crack,
     prince_attack,
+    rosetta_attack,
     thorough_combinator,
     top_mask_crack,
     yolo_combination,
@@ -673,3 +674,51 @@ class TestAdhocMaskCharsetSkipping:
         ctx.hcatAdHocMask.assert_called_once()
         charset_arg = ctx.hcatAdHocMask.call_args[0][3]
         assert charset_arg == "-1 ?u?l -3 ?d?s", charset_arg
+
+
+class TestRosettaAttack:
+    def test_mask_choice_prompts_description_and_calls_hcatRosettaMask(self) -> None:
+        ctx = _make_ctx()
+        ctx.rosetta_debug_logs.return_value = ["/tmp/debug1.log"]
+
+        with (
+            patch("hate_crack.attacks.interactive_menu", side_effect=["a", "4"]),
+            patch("builtins.input", return_value="8 char passwords with digits"),
+        ):
+            rosetta_attack(ctx)
+
+        ctx.hcatRosettaMask.assert_called_once_with(
+            ctx.hcatHashType, ctx.hcatHashFile, "8 char passwords with digits"
+        )
+
+    def test_mask_choice_does_not_call_hcatRosetta(self) -> None:
+        ctx = _make_ctx()
+        ctx.rosetta_debug_logs.return_value = ["/tmp/debug1.log"]
+
+        with (
+            patch("hate_crack.attacks.interactive_menu", side_effect=["a", "4"]),
+            patch("builtins.input", return_value="pins"),
+        ):
+            rosetta_attack(ctx)
+
+        ctx.hcatRosetta.assert_not_called()
+
+    def test_existing_metric_choice_1_is_unaffected(self) -> None:
+        ctx = _make_ctx()
+        ctx.rosetta_debug_logs.return_value = ["/tmp/debug1.log"]
+
+        with (
+            patch("hate_crack.attacks.interactive_menu", side_effect=["a", "1"]),
+            patch("builtins.input", side_effect=["", ""]),
+        ):
+            rosetta_attack(ctx)
+
+        ctx.hcatRosetta.assert_called_once_with(
+            ctx.hcatHashType,
+            ctx.hcatHashFile,
+            ["/tmp/debug1.log"],
+            metric="frequency",
+            top_rules=100,
+            top_basewords=None,
+        )
+        ctx.hcatRosettaMask.assert_not_called()

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -679,10 +679,9 @@ class TestAdhocMaskCharsetSkipping:
 class TestRosettaAttack:
     def test_mask_choice_prompts_description_and_calls_hcatRosettaMask(self) -> None:
         ctx = _make_ctx()
-        ctx.rosetta_debug_logs.return_value = ["/tmp/debug1.log"]
 
         with (
-            patch("hate_crack.attacks.interactive_menu", side_effect=["a", "4"]),
+            patch("hate_crack.attacks.interactive_menu", return_value="4"),
             patch("builtins.input", return_value="8 char passwords with digits"),
         ):
             rosetta_attack(ctx)
@@ -693,10 +692,9 @@ class TestRosettaAttack:
 
     def test_mask_choice_does_not_call_hcatRosetta(self) -> None:
         ctx = _make_ctx()
-        ctx.rosetta_debug_logs.return_value = ["/tmp/debug1.log"]
 
         with (
-            patch("hate_crack.attacks.interactive_menu", side_effect=["a", "4"]),
+            patch("hate_crack.attacks.interactive_menu", return_value="4"),
             patch("builtins.input", return_value="pins"),
         ):
             rosetta_attack(ctx)
@@ -708,7 +706,7 @@ class TestRosettaAttack:
         ctx.rosetta_debug_logs.return_value = ["/tmp/debug1.log"]
 
         with (
-            patch("hate_crack.attacks.interactive_menu", side_effect=["a", "1"]),
+            patch("hate_crack.attacks.interactive_menu", side_effect=["1", "a"]),
             patch("builtins.input", side_effect=["", ""]),
         ):
             rosetta_attack(ctx)
@@ -721,4 +719,19 @@ class TestRosettaAttack:
             top_rules=100,
             top_basewords=None,
         )
+        ctx.hcatRosettaMask.assert_not_called()
+
+    def test_metric_choice_with_no_debug_logs_returns_without_calling_hcatRosetta(
+        self,
+    ) -> None:
+        ctx = _make_ctx()
+        ctx.rosetta_debug_logs.return_value = []
+
+        with (
+            patch("hate_crack.attacks.interactive_menu", side_effect=["1", "99"]),
+            patch("builtins.input"),
+        ):
+            rosetta_attack(ctx)
+
+        ctx.hcatRosetta.assert_not_called()
         ctx.hcatRosettaMask.assert_not_called()

--- a/tests/test_config_json_example.py
+++ b/tests/test_config_json_example.py
@@ -54,6 +54,7 @@ EXPECTED_KEYS = {
     "weakpass_min_rank",
     "update_channel",
     "restore_potfile_on_start",
+    "rule_debug_mode_enabled",
 }
 
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -48,8 +48,8 @@ def test_defaults_only_matches_schema(tmp_path, monkeypatch):
     assert isinstance(result, ConfigLoadResult)
     expected_keys = {entry.legacy for entry in CONFIG_SCHEMA}
     assert set(result.config.keys()) == expected_keys
-    # 14 .env-homed integration keys + 35 config.json-homed settings.
-    assert len(expected_keys) == 49
+    # 14 .env-homed integration keys + 36 config.json-homed settings.
+    assert len(expected_keys) == 50
     for entry in CONFIG_SCHEMA:
         # path-typed defaults are expanded by load_config()'s uniform
         # post-merge normalization pass (see _normalize_path_values), so a

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -92,10 +92,10 @@ def test_env_homed_key_set_is_pinned():
     assert {entry.env for entry in ENV_KEYS} == EXPECTED_ENV_HOMED
 
 
-def test_key_counts_are_fourteen_and_thirty_five():
+def test_key_counts_are_fourteen_and_thirty_six():
     assert len(ENV_KEYS) == 14
-    assert len(JSON_KEYS) == 35
-    assert len(CONFIG_SCHEMA) == 49
+    assert len(JSON_KEYS) == 36
+    assert len(CONFIG_SCHEMA) == 50
 
 
 def test_every_key_has_exactly_one_home():
@@ -148,7 +148,7 @@ def test_type_counts_match_config_json_example_value_types():
         schema_type_counts[entry.type] = schema_type_counts.get(entry.type, 0) + 1
 
     # bool, int, float map straight across.
-    assert schema_type_counts.get("bool", 0) == json_type_counts.get("bool", 0) == 6
+    assert schema_type_counts.get("bool", 0) == json_type_counts.get("bool", 0) == 7
     assert schema_type_counts.get("int", 0) == json_type_counts.get("int", 0) == 6
     assert schema_type_counts.get("float", 0) == json_type_counts.get("float", 0) == 1
     # list splits into csv_list/charset; the two must sum to the JSON list count.

--- a/tests/test_flag_overrides.py
+++ b/tests/test_flag_overrides.py
@@ -1,7 +1,7 @@
-"""Tests for the six argparse flags promoted into schema-backed keys.
+"""Tests for the seven argparse flags promoted into schema-backed keys.
 
 Each flag is now a per-run override of a config-file-settable default, resolved
-by ``hate_crack.main.resolve_flag_overrides``. All six of these keys are
+by ``hate_crack.main.resolve_flag_overrides``. All seven of these keys are
 ``home="json"``, so their persisted default comes from ``config.json``; the
 helper below routes a ``KEY=VALUE`` body to whichever file each key's home is,
 so a test cannot accidentally assert that the wrong file works. For every flag
@@ -90,6 +90,7 @@ def _resolve(tmp_path, env_body="", environ=None, current_potfile_path=None, **f
         no_optimized_kernel=flags.get("no_optimized_kernel", False),
         potfile_path=flags.get("potfile_path"),
         no_potfile_path=flags.get("no_potfile_path", False),
+        rule_debug_mode=flags.get("rule_debug_mode"),
     )
     return hc_main.resolve_flag_overrides(
         args,
@@ -142,6 +143,33 @@ def test_restore_potfile_from_env_when_flag_absent(tmp_path):
 
 def test_restore_potfile_default_is_off(tmp_path):
     assert _resolve(tmp_path).restore_potfile is False
+
+
+# ---------------------------------------------------------------------------
+# --rule-debug-mode / --no-rule-debug-mode  <->  RULE_DEBUG_MODE_ENABLED
+# ---------------------------------------------------------------------------
+
+
+def test_rule_debug_mode_flag_negative_beats_config_that_says_on(tmp_path):
+    got = _resolve(tmp_path, "RULE_DEBUG_MODE_ENABLED=1\n", rule_debug_mode=False)
+    assert got.rule_debug_mode_enabled is False
+
+
+def test_rule_debug_mode_flag_affirmative_beats_config_that_says_off(tmp_path):
+    got = _resolve(tmp_path, "RULE_DEBUG_MODE_ENABLED=0\n", rule_debug_mode=True)
+    assert got.rule_debug_mode_enabled is True
+
+
+def test_rule_debug_mode_from_config_when_flag_absent(tmp_path):
+    got = _resolve(tmp_path, "RULE_DEBUG_MODE_ENABLED=false\n")
+    assert got.rule_debug_mode_enabled is False
+
+
+def test_rule_debug_mode_default_is_on(tmp_path):
+    # Unlike the other promoted booleans, this one defaults to True: rule
+    # debug logging (mining winning rules for the Rosetta Attack) has always
+    # been unconditional, so the flag is an opt-out, not an opt-in.
+    assert _resolve(tmp_path).rule_debug_mode_enabled is True
 
 
 # ---------------------------------------------------------------------------
@@ -450,6 +478,23 @@ def test_no_restore_potfile_is_accepted_by_the_parser(monkeypatch):
     # No hash file is given, so the restore path is never reached; this only
     # proves the negative spelling parses rather than erroring out.
     assert _run_main(monkeypatch, ["--no-restore-potfile"]) == 0
+
+
+@pytest.mark.parametrize(
+    ("argv", "config_value", "expected"),
+    [
+        (["--rule-debug-mode"], False, True),
+        (["--no-rule-debug-mode"], True, False),
+        ([], True, True),
+        ([], False, False),
+    ],
+)
+def test_rule_debug_mode_through_the_real_parser(
+    monkeypatch, argv, config_value, expected
+):
+    monkeypatch.setitem(hc_main.config_parser, "rule_debug_mode_enabled", config_value)
+    assert _run_main(monkeypatch, argv) == 0
+    assert hc_main._rule_debug_mode_enabled is expected
 
 
 def test_no_nightly_does_not_trigger_an_upgrade(monkeypatch):

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -617,6 +617,128 @@ class TestHashviewAPI:
             api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
         assert "Invalid API response" in str(excinfo.value)
 
+    def _write_cracked_lines(self, tmp_path, count):
+        """Write `count` distinct valid hash:plaintext lines and return the path.
+
+        Each line uses a distinct synthetic plaintext so every line produces a
+        distinct cache key -- needed to tell batches apart by key membership.
+        """
+        cracked_file = tmp_path / "cracked_bulk.txt"
+        lines = []
+        for i in range(count):
+            plain = f"Synthetic-Example-Bulk-{i:06d}"
+            digest = _synth_digest("1000", plain)
+            lines.append(f"{digest}:{plain}")
+        cracked_file.write_text("\n".join(lines) + "\n")
+        return str(cracked_file)
+
+    def test_upload_cracked_hashes_batch_boundary_single_post(self, api, tmp_path):
+        """Exactly HASHVIEW_CRACKED_BATCH_SIZE lines -> one POST, output
+        unchanged from today's single-request behavior (no batch print)."""
+        from hate_crack.api import HASHVIEW_CRACKED_BATCH_SIZE
+
+        cracked_file = self._write_cracked_lines(tmp_path, HASHVIEW_CRACKED_BATCH_SIZE)
+        mock_response = Mock()
+        mock_response.json.return_value = {"msg": "OK"}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        result = api.upload_cracked_hashes(cracked_file, hash_type="1000")
+
+        assert api.session.post.call_count == 1
+        assert result["uploaded"] == HASHVIEW_CRACKED_BATCH_SIZE
+
+    def test_upload_cracked_hashes_splits_into_two_batches(self, api, tmp_path, capsys):
+        """One line over the batch size -> two POSTs, two batch-progress
+        prints, and an aggregated uploaded count summing both batches."""
+        from hate_crack.api import HASHVIEW_CRACKED_BATCH_SIZE
+
+        total = HASHVIEW_CRACKED_BATCH_SIZE + 1
+        cracked_file = self._write_cracked_lines(tmp_path, total)
+        mock_response = Mock()
+        mock_response.json.return_value = {"msg": "OK"}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        result = api.upload_cracked_hashes(cracked_file, hash_type="1000")
+
+        assert api.session.post.call_count == 2
+        assert result["uploaded"] == total
+        first_call_body = api.session.post.call_args_list[0].kwargs["data"]
+        second_call_body = api.session.post.call_args_list[1].kwargs["data"]
+        assert first_call_body.count(b"\n") == HASHVIEW_CRACKED_BATCH_SIZE - 1
+        assert second_call_body.count(b"\n") == 0
+        captured = capsys.readouterr()
+        assert "Uploading batch 1/2" in captured.out
+        assert "Uploading batch 2/2" in captured.out
+
+    def test_upload_cracked_hashes_caches_each_batch_as_it_succeeds(
+        self, api, tmp_path, monkeypatch
+    ):
+        """If batch 2 of 2 fails, batch 1's keys must already be cached so a
+        retry does not resend them."""
+        from hate_crack.api import HASHVIEW_CRACKED_BATCH_SIZE
+
+        total = HASHVIEW_CRACKED_BATCH_SIZE + 1
+        cracked_file = self._write_cracked_lines(tmp_path, total)
+
+        cached_keys = []
+        monkeypatch.setattr(
+            "hate_crack.api.append_to_cache",
+            lambda keys: cached_keys.extend(keys),
+        )
+
+        ok_response = Mock()
+        ok_response.json.return_value = {"msg": "OK"}
+        ok_response.raise_for_status = Mock()
+
+        failing_response = Mock()
+        failing_response.raise_for_status = Mock(
+            side_effect=requests.exceptions.HTTPError("boom")
+        )
+        api.session.post.side_effect = [ok_response, failing_response]
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            api.upload_cracked_hashes(cracked_file, hash_type="1000")
+
+        assert api.session.post.call_count == 2
+        assert len(cached_keys) == HASHVIEW_CRACKED_BATCH_SIZE
+
+    def test_upload_cracked_hashes_merges_passthrough_fields_across_batches(
+        self, api, tmp_path
+    ):
+        """Numeric Hashview passthrough fields sum, and unmatched lists
+        concatenate, across batches."""
+        from hate_crack.api import HASHVIEW_CRACKED_BATCH_SIZE
+
+        total = HASHVIEW_CRACKED_BATCH_SIZE + 1
+        cracked_file = self._write_cracked_lines(tmp_path, total)
+
+        resp1 = Mock()
+        resp1.json.return_value = {
+            "verified": 3,
+            "updated": 1,
+            "count": HASHVIEW_CRACKED_BATCH_SIZE,
+            "unmatched": ["a"],
+        }
+        resp1.raise_for_status = Mock()
+        resp2 = Mock()
+        resp2.json.return_value = {
+            "verified": 1,
+            "updated": 0,
+            "count": 1,
+            "unmatched": ["b"],
+        }
+        resp2.raise_for_status = Mock()
+        api.session.post.side_effect = [resp1, resp2]
+
+        result = api.upload_cracked_hashes(cracked_file, hash_type="1000")
+
+        assert result["verified"] == 4
+        assert result["updated"] == 1
+        assert result["count"] == total
+        assert result["unmatched"] == ["a", "b"]
+
     def test_upload_cracked_hashes_unicode_plaintext_ntlm(self, api, tmp_path):
         """A genuine multi-byte UTF-8 plaintext validates correctly for NTLM.
 

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -866,6 +866,38 @@ class TestHashviewAPI:
             "latin-1"
         ).encode("utf-8")
 
+    def test_upload_preserves_hex_wrapped_valid_utf8_plaintext(self, api, tmp_path):
+        """A $HEX-wrapped plaintext that is already valid UTF-8 is sent as-is.
+
+        Regression test: hashcat $HEX-wraps a plaintext for reasons unrelated
+        to UTF-8 validity (an embedded colon, here), not only for genuine
+        zero-extended raw bytes. ``_wire_field_bytes`` used to always treat
+        $HEX-wrapped bytes for mode 1000 as latin-1 code points needing
+        reconstruction, which double-encoded already-valid UTF-8 text (e.g.
+        "café:" became "cafÃ©:") and sent Hashview a plaintext that no longer
+        hashed to the claimed digest -- passing hate_crack's own client-side
+        validation but rejected server-side as invalid.
+        """
+        plain_text = "Synthetic:Example-é-Fff"  # contains a real ":" plus non-ASCII
+        plain_utf8 = plain_text.encode("utf-8")
+        ntlm = _md4(plain_text.encode("utf-16le"))
+        hex_wrapped = "$HEX[" + plain_utf8.hex() + "]"
+        cracked_file = tmp_path / "cracked.txt"
+        cracked_file.write_text(f"{ntlm}:{hex_wrapped}\n", encoding="utf-8")
+        mock_response = Mock()
+        mock_response.json.return_value = {"imported": 1}
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        result = api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+        assert result["uploaded"] == 1
+        assert result["skipped"] == 0
+
+        sent = api.session.post.call_args.kwargs.get("data")
+        if sent is None:
+            sent = api.session.post.call_args.args[1]
+        assert sent == f"{ntlm}".encode() + b":" + plain_utf8
+
     def test_upload_surfaces_client_counts(self, api, tmp_path):
         """upload_cracked_hashes reports uploaded/skipped even when the server
         returns a bare OK with no counts of its own."""

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -739,6 +739,55 @@ class TestHashviewAPI:
         assert result["count"] == total
         assert result["unmatched"] == ["a", "b"]
 
+    def test_upload_cracked_hashes_single_batch_non_dict_response_passthrough(
+        self, api, tmp_path, monkeypatch
+    ):
+        """A single-batch upload with a non-dict JSON response is returned
+        as-is (matches legacy single-request behavior), and its keys are
+        still cached."""
+        from hate_crack.api import HASHVIEW_CRACKED_BATCH_SIZE
+
+        cracked_file = self._write_cracked_lines(tmp_path, HASHVIEW_CRACKED_BATCH_SIZE)
+
+        cached_keys = []
+        monkeypatch.setattr(
+            "hate_crack.api.append_to_cache",
+            lambda keys: cached_keys.extend(keys),
+        )
+
+        mock_response = Mock()
+        mock_response.json.return_value = ["ok"]
+        mock_response.raise_for_status = Mock()
+        api.session.post.return_value = mock_response
+
+        result = api.upload_cracked_hashes(cracked_file, hash_type="1000")
+
+        assert result == ["ok"]
+        assert len(cached_keys) == HASHVIEW_CRACKED_BATCH_SIZE
+
+    def test_upload_cracked_hashes_multi_batch_non_dict_response_raises(
+        self, api, tmp_path
+    ):
+        """A non-dict JSON response on a batch after the first, when there is
+        more than one batch, raises an Exception naming that batch number."""
+        from hate_crack.api import HASHVIEW_CRACKED_BATCH_SIZE
+
+        total = HASHVIEW_CRACKED_BATCH_SIZE + 1
+        cracked_file = self._write_cracked_lines(tmp_path, total)
+
+        resp1 = Mock()
+        resp1.json.return_value = {"msg": "OK"}
+        resp1.raise_for_status = Mock()
+
+        resp2 = Mock()
+        resp2.json.return_value = ["ok"]
+        resp2.raise_for_status = Mock()
+
+        api.session.post.side_effect = [resp1, resp2]
+
+        with pytest.raises(Exception, match=r"2/2"):
+            api.upload_cracked_hashes(cracked_file, hash_type="1000")
+
     def test_upload_cracked_hashes_unicode_plaintext_ntlm(self, api, tmp_path):
         """A genuine multi-byte UTF-8 plaintext validates correctly for NTLM.
 

--- a/tests/test_hcat_rosetta_mask.py
+++ b/tests/test_hcat_rosetta_mask.py
@@ -1,0 +1,143 @@
+"""Orchestration tests for hcatRosettaMask (mask generation is mocked)."""
+
+import os
+from contextlib import contextmanager
+from unittest import mock
+
+import pytest
+
+os.environ["HATE_CRACK_SKIP_INIT"] = "1"
+from hate_crack import main as hc_main  # noqa: E402
+from hate_crack import llm  # noqa: E402
+
+OLLAMA_URL = "http://localhost:11434"
+MODEL = "qwen2.5:32b"
+
+
+@contextmanager
+def rosetta_mask_globals(tuning="", potfile=""):
+    with (
+        mock.patch.object(hc_main, "ollamaUrl", OLLAMA_URL),
+        mock.patch.object(hc_main, "ollamaModel", MODEL),
+        mock.patch.object(hc_main, "ollamaNumCtx", 2048),
+        mock.patch.object(hc_main, "ollamaTimeout", 300.0),
+        mock.patch.object(hc_main, "ollamaNoCloud", False),
+        mock.patch.object(hc_main, "hcatBin", "/usr/bin/hashcat"),
+        mock.patch.object(hc_main, "hcatTuning", tuning),
+        mock.patch.object(hc_main, "hcatPotfilePath", potfile),
+        mock.patch("hate_crack.main.generate_session_id", return_value="s"),
+    ):
+        yield
+
+
+def _make_proc(wait_return=0):
+    proc = mock.MagicMock()
+    proc.wait.return_value = wait_return
+    proc.communicate.return_value = (b"", b"")
+    proc.returncode = wait_return
+    return proc
+
+
+def test_writes_hcmask_file_and_runs_mask_attack(tmp_path):
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.touch()
+
+    with (
+        rosetta_mask_globals(),
+        mock.patch(
+            "hate_crack.main.llm.generate_masks",
+            return_value=["?u?l?l?l?d?d", "?d?d?d?d"],
+        ) as gen,
+        mock.patch("subprocess.Popen", return_value=_make_proc()) as popen,
+    ):
+        hc_main.hcatRosettaMask("0", str(hash_file), "8 char passwords with digits")
+
+    gen.assert_called_once_with(
+        OLLAMA_URL,
+        MODEL,
+        2048,
+        "8 char passwords with digits",
+        timeout=300.0,
+        no_cloud=False,
+    )
+    hcmask_path = f"{hash_file}.hcmask"
+    assert os.path.isfile(hcmask_path)
+    with open(hcmask_path) as f:
+        assert f.read() == "?u?l?l?l?d?d\n?d?d?d?d\n"
+
+    cmd = popen.call_args[0][0]
+    assert "/usr/bin/hashcat" in cmd
+    assert "-a" in cmd and cmd[cmd.index("-a") + 1] == "3"
+    assert hcmask_path in cmd
+
+
+def test_invalid_masks_are_filtered_out(tmp_path):
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.touch()
+
+    with (
+        rosetta_mask_globals(),
+        mock.patch(
+            "hate_crack.main.llm.generate_masks",
+            return_value=["?d?d?d?d", "?u?l?l?", "?u?x?d"],
+        ),
+        mock.patch("subprocess.Popen", return_value=_make_proc()),
+    ):
+        hc_main.hcatRosettaMask("0", str(hash_file), "pins")
+
+    with open(f"{hash_file}.hcmask") as f:
+        assert f.read() == "?d?d?d?d\n"
+
+
+def test_no_valid_masks_skips_hashcat_run(tmp_path, capsys):
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.touch()
+
+    with (
+        rosetta_mask_globals(),
+        mock.patch("hate_crack.main.llm.generate_masks", return_value=["?u?x?"]),
+        mock.patch("subprocess.Popen") as popen,
+    ):
+        hc_main.hcatRosettaMask("0", str(hash_file), "pins")
+
+    popen.assert_not_called()
+    assert not os.path.isfile(f"{hash_file}.hcmask")
+    assert "no usable masks" in capsys.readouterr().out.lower()
+
+
+def test_llm_timeout_error_prints_message_and_skips_hashcat_run(tmp_path, capsys):
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.touch()
+
+    with (
+        rosetta_mask_globals(),
+        mock.patch(
+            "hate_crack.main.llm.generate_masks",
+            side_effect=hc_main.llm.LLMTimeoutError("no response from x within 300 seconds"),
+        ),
+        mock.patch("subprocess.Popen") as popen,
+    ):
+        hc_main.hcatRosettaMask("0", str(hash_file), "pins")
+
+    popen.assert_not_called()
+    assert "timed out" in capsys.readouterr().out.lower()
+
+
+def test_generic_generation_error_prints_message_and_skips_hashcat_run(tmp_path, capsys):
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.touch()
+
+    with (
+        rosetta_mask_globals(),
+        mock.patch(
+            "hate_crack.main.llm.generate_masks",
+            side_effect=RuntimeError("connection refused"),
+        ),
+        mock.patch("subprocess.Popen") as popen,
+    ):
+        hc_main.hcatRosettaMask("0", str(hash_file), "pins")
+
+    popen.assert_not_called()
+    out = capsys.readouterr().out.lower()
+    assert "error generating masks" in out
+    assert "ollama" in out

--- a/tests/test_hcat_rosetta_mask.py
+++ b/tests/test_hcat_rosetta_mask.py
@@ -162,3 +162,19 @@ def test_generic_generation_error_prints_message_and_skips_hashcat_run(
     out = capsys.readouterr().out.lower()
     assert "error generating masks" in out
     assert "ollama" in out
+
+
+def test_hcmask_file_removed_by_cleanup(tmp_path, monkeypatch):
+    """Mirrors test_llm_pattern_rules.test_llm_patterns_removed_by_cleanup."""
+    hash_file = str(tmp_path / "hashes.txt")
+    hcmask_path = hash_file + ".hcmask"
+    with open(hcmask_path, "w") as f:
+        f.write("?u?l?l?l?d?d\n")
+
+    monkeypatch.setattr(hc_main, "hcatHashFile", hash_file)
+    monkeypatch.setattr(hc_main, "hcatHashFileOrig", hash_file)
+    monkeypatch.setattr(hc_main, "hcatHashType", "1000")
+    monkeypatch.setattr(hc_main, "pwdump_format", False)
+    hc_main.cleanup()
+
+    assert not os.path.exists(hcmask_path)

--- a/tests/test_hcat_rosetta_mask.py
+++ b/tests/test_hcat_rosetta_mask.py
@@ -4,11 +4,8 @@ import os
 from contextlib import contextmanager
 from unittest import mock
 
-import pytest
-
 os.environ["HATE_CRACK_SKIP_INIT"] = "1"
 from hate_crack import main as hc_main  # noqa: E402
-from hate_crack import llm  # noqa: E402
 
 OLLAMA_URL = "http://localhost:11434"
 MODEL = "qwen2.5:32b"
@@ -113,7 +110,9 @@ def test_llm_timeout_error_prints_message_and_skips_hashcat_run(tmp_path, capsys
         rosetta_mask_globals(),
         mock.patch(
             "hate_crack.main.llm.generate_masks",
-            side_effect=hc_main.llm.LLMTimeoutError("no response from x within 300 seconds"),
+            side_effect=hc_main.llm.LLMTimeoutError(
+                "no response from x within 300 seconds"
+            ),
         ),
         mock.patch("subprocess.Popen") as popen,
     ):
@@ -123,7 +122,9 @@ def test_llm_timeout_error_prints_message_and_skips_hashcat_run(tmp_path, capsys
     assert "timed out" in capsys.readouterr().out.lower()
 
 
-def test_generic_generation_error_prints_message_and_skips_hashcat_run(tmp_path, capsys):
+def test_generic_generation_error_prints_message_and_skips_hashcat_run(
+    tmp_path, capsys
+):
     hash_file = tmp_path / "hashes.txt"
     hash_file.touch()
 

--- a/tests/test_hcat_rosetta_mask.py
+++ b/tests/test_hcat_rosetta_mask.py
@@ -68,6 +68,26 @@ def test_writes_hcmask_file_and_runs_mask_attack(tmp_path):
     assert hcmask_path in cmd
 
 
+def test_tuning_and_potfile_reach_the_command(tmp_path):
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.touch()
+    potfile = tmp_path / "custom.potfile"
+
+    with (
+        rosetta_mask_globals(tuning="-w 3", potfile=str(potfile)),
+        mock.patch(
+            "hate_crack.main.llm.generate_masks",
+            return_value=["?d?d?d?d"],
+        ),
+        mock.patch("subprocess.Popen", return_value=_make_proc()) as popen,
+    ):
+        hc_main.hcatRosettaMask("0", str(hash_file), "pins")
+
+    cmd = popen.call_args[0][0]
+    assert "-w" in cmd and cmd[cmd.index("-w") + 1] == "3"
+    assert f"--potfile-path={potfile}" in cmd
+
+
 def test_invalid_masks_are_filtered_out(tmp_path):
     hash_file = tmp_path / "hashes.txt"
     hash_file.touch()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -152,7 +152,7 @@ def test_cracked_prompt_is_offensive_not_denylist():
 
 
 def test_prompts_map_covers_every_supported_mode():
-    assert set(llm._PROMPTS) == {"target", "wordlist", "cracked", "pattern", "rules"}
+    assert set(llm._PROMPTS) == {"target", "wordlist", "cracked", "pattern", "rules", "mask"}
 
 
 def test_dedupes_and_caps_length():
@@ -372,3 +372,60 @@ def test_clean_research_field_collapses_internal_whitespace():
     assert llm.clean_research_field("commercial   \n construction") == (
         "commercial construction"
     )
+
+
+def test_generate_masks_returns_masks():
+    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
+    agent_instance.run.return_value.masks = ["?u?l?l?l?d?d", "?l?l?l?l?l?l?d"]
+    with p_instr, p_openai, p_agent:
+        out = llm.generate_masks(
+            "http://localhost:11434",
+            "qwen2.5:32b",
+            2048,
+            "8 character passwords, capitalized word plus two digits",
+            no_cloud=False,
+        )
+    assert out == ["?u?l?l?l?d?d", "?l?l?l?l?l?l?d"]
+    run_arg = agent_instance.run.call_args[0][0]
+    assert "8 character passwords" in run_arg.request
+
+
+def test_generate_masks_dedupes_and_strips_whitespace():
+    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
+    agent_instance.run.return_value.masks = ["  ?d?d?d?d  ", "?d?d?d?d", "?u?l?l?l"]
+    with p_instr, p_openai, p_agent:
+        out = llm.generate_masks(
+            "http://localhost:11434", "qwen2.5:32b", 2048, "four digit pins", no_cloud=False
+        )
+    assert out == ["?d?d?d?d", "?u?l?l?l"]
+
+
+def test_generate_masks_skips_non_string_entries():
+    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
+    agent_instance.run.return_value.masks = ["?d?d?d?d", None, 123]
+    with p_instr, p_openai, p_agent:
+        out = llm.generate_masks(
+            "http://localhost:11434", "qwen2.5:32b", 2048, "pins", no_cloud=False
+        )
+    assert out == ["?d?d?d?d"]
+
+
+def test_generate_masks_raises_llm_timeout_error():
+    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
+    agent_instance.run.side_effect = openai.APITimeoutError(request=mock.MagicMock())
+    with p_instr, p_openai, p_agent:
+        with pytest.raises(llm.LLMTimeoutError):
+            llm.generate_masks(
+                "http://localhost:11434", "qwen2.5:32b", 2048, "pins", no_cloud=False
+            )
+
+
+def test_generate_masks_refuses_cloud_model_when_no_cloud():
+    with pytest.raises(llm.CloudModelRefused):
+        llm.generate_masks(
+            "http://localhost:11434",
+            "deepseek-v3.1:671b-cloud",
+            2048,
+            "pins",
+            no_cloud=True,
+        )

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -421,6 +421,16 @@ def test_generate_masks_skips_non_string_entries():
     assert out == ["?d?d?d?d"]
 
 
+def test_generate_masks_skips_empty_string_entries():
+    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
+    agent_instance.run.return_value.masks = ["?d?d?d?d", "", "   "]
+    with p_instr, p_openai, p_agent:
+        out = llm.generate_masks(
+            "http://localhost:11434", "qwen2.5:32b", 2048, "pins", no_cloud=False
+        )
+    assert out == ["?d?d?d?d"]
+
+
 def test_generate_masks_raises_llm_timeout_error():
     p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
     agent_instance.run.side_effect = openai.APITimeoutError(request=mock.MagicMock())

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -152,7 +152,14 @@ def test_cracked_prompt_is_offensive_not_denylist():
 
 
 def test_prompts_map_covers_every_supported_mode():
-    assert set(llm._PROMPTS) == {"target", "wordlist", "cracked", "pattern", "rules", "mask"}
+    assert set(llm._PROMPTS) == {
+        "target",
+        "wordlist",
+        "cracked",
+        "pattern",
+        "rules",
+        "mask",
+    }
 
 
 def test_dedupes_and_caps_length():
@@ -395,7 +402,11 @@ def test_generate_masks_dedupes_and_strips_whitespace():
     agent_instance.run.return_value.masks = ["  ?d?d?d?d  ", "?d?d?d?d", "?u?l?l?l"]
     with p_instr, p_openai, p_agent:
         out = llm.generate_masks(
-            "http://localhost:11434", "qwen2.5:32b", 2048, "four digit pins", no_cloud=False
+            "http://localhost:11434",
+            "qwen2.5:32b",
+            2048,
+            "four digit pins",
+            no_cloud=False,
         )
     assert out == ["?d?d?d?d", "?u?l?l?l"]
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,7 @@
 """Unit tests for hate_crack.llm.generate_candidates."""
 
 import os
+from types import SimpleNamespace
 from unittest import mock
 
 import httpx
@@ -152,13 +153,15 @@ def test_cracked_prompt_is_offensive_not_denylist():
 
 
 def test_prompts_map_covers_every_supported_mode():
+    # "mask" is deliberately absent: generate_masks() delegates to
+    # hashcat_rosetta.nlmask.generate_masks rather than an Atomic Agents
+    # prompt from this map -- see generate_masks()'s own docstring.
     assert set(llm._PROMPTS) == {
         "target",
         "wordlist",
         "cracked",
         "pattern",
         "rules",
-        "mask",
     }
 
 
@@ -381,64 +384,118 @@ def test_clean_research_field_collapses_internal_whitespace():
     )
 
 
-def test_generate_masks_returns_masks():
-    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
-    agent_instance.run.return_value.masks = ["?u?l?l?l?d?d", "?l?l?l?l?l?l?d"]
-    with p_instr, p_openai, p_agent:
-        out = llm.generate_masks(
-            "http://localhost:11434",
-            "qwen2.5:32b",
-            2048,
-            "8 character passwords, capitalized word plus two digits",
-            no_cloud=False,
-        )
+def _rosetta_suggestion(mask, custom_charsets=()):
+    """A minimal stand-in for hashcat_rosetta.nlmask.MaskSuggestion.
+
+    generate_masks() only reads .mask and .custom_charsets off what
+    _rosetta_generate_masks returns (to build the combined hcmask line via
+    the real _rosetta_format_hcmask_line), so a plain namespace is enough --
+    no need to depend on HashcatRosetta's actual dataclass in this test file.
+    """
+    return SimpleNamespace(mask=mask, custom_charsets=list(custom_charsets))
+
+
+def test_generate_masks_returns_masks(monkeypatch):
+    captured = {}
+
+    def fake_generate_masks(description, *, model, client, extra_options):
+        captured["description"] = description
+        captured["model"] = model
+        captured["extra_options"] = extra_options
+        return [
+            _rosetta_suggestion("?u?l?l?l?d?d"),
+            _rosetta_suggestion("?l?l?l?l?l?l?d"),
+        ]
+
+    monkeypatch.setattr(llm, "_rosetta_generate_masks", fake_generate_masks)
+
+    out = llm.generate_masks(
+        "http://localhost:11434",
+        "qwen2.5:32b",
+        2048,
+        "8 character passwords, capitalized word plus two digits",
+        no_cloud=False,
+    )
+
     assert out == ["?u?l?l?l?d?d", "?l?l?l?l?l?l?d"]
-    run_arg = agent_instance.run.call_args[0][0]
-    assert "8 character passwords" in run_arg.request
+    assert captured["model"] == "qwen2.5:32b"
+    assert captured["extra_options"] == {"num_ctx": 2048}
+    assert "8 character passwords" in captured["description"]
 
 
-def test_generate_masks_dedupes_and_strips_whitespace():
-    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
-    agent_instance.run.return_value.masks = ["  ?d?d?d?d  ", "?d?d?d?d", "?u?l?l?l"]
-    with p_instr, p_openai, p_agent:
-        out = llm.generate_masks(
-            "http://localhost:11434",
-            "qwen2.5:32b",
-            2048,
-            "four digit pins",
-            no_cloud=False,
-        )
+def test_generate_masks_combines_custom_charsets(monkeypatch):
+    monkeypatch.setattr(
+        llm,
+        "_rosetta_generate_masks",
+        lambda description, **kwargs: [_rosetta_suggestion("?1?1?1?1?d?d", ["aeiou"])],
+    )
+
+    out = llm.generate_masks(
+        "http://localhost:11434",
+        "qwen2.5:32b",
+        2048,
+        "four vowels then two digits",
+        no_cloud=False,
+    )
+
+    assert out == ["aeiou,?1?1?1?1?d?d"]
+
+
+def test_generate_masks_dedupes_combined_lines(monkeypatch):
+    monkeypatch.setattr(
+        llm,
+        "_rosetta_generate_masks",
+        lambda description, **kwargs: [
+            _rosetta_suggestion("?d?d?d?d"),
+            _rosetta_suggestion("?d?d?d?d"),
+            _rosetta_suggestion("?u?l?l?l"),
+        ],
+    )
+
+    out = llm.generate_masks(
+        "http://localhost:11434", "qwen2.5:32b", 2048, "four digit pins", no_cloud=False
+    )
+
     assert out == ["?d?d?d?d", "?u?l?l?l"]
 
 
-def test_generate_masks_skips_non_string_entries():
-    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
-    agent_instance.run.return_value.masks = ["?d?d?d?d", None, 123]
-    with p_instr, p_openai, p_agent:
-        out = llm.generate_masks(
+def test_generate_masks_raises_llm_timeout_error(monkeypatch):
+    def raise_wrapped_timeout(description, **kwargs):
+        try:
+            raise openai.APITimeoutError(request=mock.MagicMock())
+        except openai.APITimeoutError as timeout_exc:
+            # Mirrors how hashcat_rosetta.nlmask.generate_masks itself wraps
+            # every request failure: `raise MaskGenerationError(...) from exc`,
+            # preserving the original as __cause__.
+            raise llm._RosettaMaskGenerationError("request failed") from timeout_exc
+
+    monkeypatch.setattr(llm, "_rosetta_generate_masks", raise_wrapped_timeout)
+
+    with pytest.raises(llm.LLMTimeoutError):
+        llm.generate_masks(
             "http://localhost:11434", "qwen2.5:32b", 2048, "pins", no_cloud=False
         )
-    assert out == ["?d?d?d?d"]
 
 
-def test_generate_masks_skips_empty_string_entries():
-    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
-    agent_instance.run.return_value.masks = ["?d?d?d?d", "", "   "]
-    with p_instr, p_openai, p_agent:
-        out = llm.generate_masks(
+def test_generate_masks_reraises_non_timeout_rosetta_errors(monkeypatch):
+    def raise_other_error(description, **kwargs):
+        raise llm._RosettaMaskGenerationError("model returned invalid JSON")
+
+    monkeypatch.setattr(llm, "_rosetta_generate_masks", raise_other_error)
+
+    with pytest.raises(llm._RosettaMaskGenerationError):
+        llm.generate_masks(
             "http://localhost:11434", "qwen2.5:32b", 2048, "pins", no_cloud=False
         )
-    assert out == ["?d?d?d?d"]
 
 
-def test_generate_masks_raises_llm_timeout_error():
-    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent([])
-    agent_instance.run.side_effect = openai.APITimeoutError(request=mock.MagicMock())
-    with p_instr, p_openai, p_agent:
-        with pytest.raises(llm.LLMTimeoutError):
-            llm.generate_masks(
-                "http://localhost:11434", "qwen2.5:32b", 2048, "pins", no_cloud=False
-            )
+def test_generate_masks_raises_runtime_error_when_rosetta_unavailable(monkeypatch):
+    monkeypatch.setattr(llm, "_rosetta_generate_masks", None)
+
+    with pytest.raises(RuntimeError, match="HashcatRosetta is unavailable"):
+        llm.generate_masks(
+            "http://localhost:11434", "qwen2.5:32b", 2048, "pins", no_cloud=False
+        )
 
 
 def test_generate_masks_refuses_cloud_model_when_no_cloud():

--- a/tests/test_main_rosetta.py
+++ b/tests/test_main_rosetta.py
@@ -150,14 +150,12 @@ class TestRosettaDerive:
         with pytest.raises(ValueError, match="hashcat debug entries"):
             main_module.rosetta_derive([str(junk)], str(tmp_path / "out"))
 
-    def test_max_lines_truncates_and_says_so(
-        self, main_module, tmp_path, debug_log, capsys
-    ):
-        result = main_module.rosetta_derive(
-            [debug_log], str(tmp_path / "out"), max_lines=2
-        )
-        assert result["entries"] == 2
-        assert "Stopped at 2 debug lines" in capsys.readouterr().out
+    def test_reads_logs_without_a_line_cap(self, main_module, tmp_path, capsys):
+        big = tmp_path / "big.log"
+        big.write_text("echo $9 echo9\n" * 5000, encoding="utf-8")
+        result = main_module.rosetta_derive([str(big)], str(tmp_path / "out"))
+        assert result["entries"] == 5000
+        assert "Stopped at" not in capsys.readouterr().out
 
     def test_missing_rosetta_dependency_reports_clearly(
         self, main_module, tmp_path, debug_log, monkeypatch

--- a/tests/test_main_rosetta.py
+++ b/tests/test_main_rosetta.py
@@ -303,7 +303,7 @@ class TestRosettaAttackHandler:
         ctx = self._ctx(tmp_path, debug_log)
         ctx.rosetta_debug_logs.return_value = [debug_log, debug_log]
         with (
-            patch("hate_crack.attacks.interactive_menu", side_effect=["a", "1"]),
+            patch("hate_crack.attacks.interactive_menu", side_effect=["1", "a"]),
             patch("builtins.input", side_effect=["", ""]),
         ):
             attacks.rosetta_attack(ctx)
@@ -312,7 +312,7 @@ class TestRosettaAttackHandler:
     def test_manual_path_option(self, tmp_path, debug_log):
         ctx = self._ctx(tmp_path, debug_log)
         with (
-            patch("hate_crack.attacks.interactive_menu", side_effect=["p", "1"]),
+            patch("hate_crack.attacks.interactive_menu", side_effect=["1", "p"]),
             patch("builtins.input", side_effect=["", ""]),
         ):
             attacks.rosetta_attack(ctx)
@@ -321,7 +321,7 @@ class TestRosettaAttackHandler:
     def test_manual_path_that_does_not_exist_aborts(self, tmp_path, debug_log, capsys):
         ctx = self._ctx(tmp_path, debug_log)
         ctx.select_file_with_autocomplete.return_value = str(tmp_path / "missing.log")
-        with patch("hate_crack.attacks.interactive_menu", side_effect=["p"]):
+        with patch("hate_crack.attacks.interactive_menu", side_effect=["1", "p"]):
             attacks.rosetta_attack(ctx)
         ctx.hcatRosetta.assert_not_called()
         assert "Debug log not found" in capsys.readouterr().out
@@ -344,7 +344,7 @@ class TestRosettaAttackHandler:
     def test_metric_choices(self, tmp_path, debug_log, choice, expected):
         ctx = self._ctx(tmp_path, debug_log)
         with (
-            patch("hate_crack.attacks.interactive_menu", side_effect=["1", choice]),
+            patch("hate_crack.attacks.interactive_menu", side_effect=[choice, "1"]),
             patch("builtins.input", side_effect=["", ""]),
         ):
             attacks.rosetta_attack(ctx)
@@ -385,20 +385,20 @@ class TestRosettaAttackHandler:
     @pytest.mark.parametrize("choice", ["99", None])
     def test_back_out_of_log_menu(self, tmp_path, debug_log, choice):
         ctx = self._ctx(tmp_path, debug_log)
-        with patch("hate_crack.attacks.interactive_menu", side_effect=[choice]):
+        with patch("hate_crack.attacks.interactive_menu", side_effect=["1", choice]):
             attacks.rosetta_attack(ctx)
         ctx.hcatRosetta.assert_not_called()
 
     @pytest.mark.parametrize("choice", ["99", None])
     def test_back_out_of_metric_menu(self, tmp_path, debug_log, choice):
         ctx = self._ctx(tmp_path, debug_log)
-        with patch("hate_crack.attacks.interactive_menu", side_effect=["1", choice]):
+        with patch("hate_crack.attacks.interactive_menu", side_effect=[choice]):
             attacks.rosetta_attack(ctx)
         ctx.hcatRosetta.assert_not_called()
 
     def test_out_of_range_log_selection_aborts(self, tmp_path, debug_log, capsys):
         ctx = self._ctx(tmp_path, debug_log)
-        with patch("hate_crack.attacks.interactive_menu", side_effect=["7"]):
+        with patch("hate_crack.attacks.interactive_menu", side_effect=["1", "7"]):
             attacks.rosetta_attack(ctx)
         ctx.hcatRosetta.assert_not_called()
         assert "Invalid selection" in capsys.readouterr().out

--- a/tests/test_main_rosetta.py
+++ b/tests/test_main_rosetta.py
@@ -444,9 +444,32 @@ class TestDebugModeFive:
 
     def test_writer_requests_mode_5(self, main_module, tmp_path, monkeypatch):
         monkeypatch.setattr(main_module, "hcatDebugLogPath", str(tmp_path))
+        monkeypatch.setattr(main_module, "_debug_mode_level", 5)
         cmd = main_module._add_debug_mode_for_rules(["hashcat", "-r", "best64.rule"])
 
         assert cmd[cmd.index("--debug-mode") + 1] == "5"
+
+    def test_disabled_via_rule_debug_mode_flag_adds_nothing(
+        self, main_module, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(main_module, "hcatDebugLogPath", str(tmp_path))
+        monkeypatch.setattr(main_module, "_rule_debug_mode_enabled", False)
+        cmd = main_module._add_debug_mode_for_rules(["hashcat", "-r", "best64.rule"])
+
+        assert "--debug-mode" not in cmd
+        assert "--debug-file" not in cmd
+
+    def test_writer_honors_a_prior_fallback_to_mode_4(
+        self, main_module, tmp_path, monkeypatch
+    ):
+        # _run_hcat_cmd drops the module-level level to 4 once it observes
+        # hashcat reject mode 5; every later rule-based attack in the
+        # process must request 4 directly rather than failing again first.
+        monkeypatch.setattr(main_module, "hcatDebugLogPath", str(tmp_path))
+        monkeypatch.setattr(main_module, "_debug_mode_level", 4)
+        cmd = main_module._add_debug_mode_for_rules(["hashcat", "-r", "best64.rule"])
+
+        assert cmd[cmd.index("--debug-mode") + 1] == "4"
 
     def test_wordlist_field_is_parsed_not_glued_to_the_candidate(self, main_module):
         # HashcatRosetta < 0.3.0 split on the first two colons only, so the

--- a/tests/test_main_rosetta.py
+++ b/tests/test_main_rosetta.py
@@ -138,6 +138,26 @@ class TestRosettaDerive:
         assert "echo" in _read(result["basewords"])
         assert "$9" in _read(result["rules"])
 
+    def test_merges_mixed_debug_mode_logs(self, main_module, tmp_path):
+        """A mode-4 colon log and a mode-5 colon log in the same batch must
+        each keep their own format detection (regression: merging their raw
+        lines before parsing let one file's sample decide the mode for both,
+        logging the other file's lines as malformed and dropping them)."""
+        mode_four = tmp_path / "mode4.log"
+        mode_four.write_text(
+            "Moldmastersmmkr:r i45 i52 r:Moldmasters25mmkr\n", encoding="utf-8"
+        )
+        mode_five = tmp_path / "mode5.log"
+        mode_five.write_text("password:c:Password:rockyou.txt\n", encoding="utf-8")
+
+        result = main_module.rosetta_derive(
+            [str(mode_four), str(mode_five)], str(tmp_path / "out")
+        )
+
+        assert result["entries"] == 2
+        assert "Moldmastersmmkr" in _read(result["basewords"])
+        assert "password" in _read(result["basewords"])
+
     def test_empty_log_rejected(self, main_module, tmp_path):
         empty = tmp_path / "empty.log"
         empty.write_text("", encoding="utf-8")

--- a/tests/test_main_utils.py
+++ b/tests/test_main_utils.py
@@ -564,6 +564,7 @@ class TestOptimizedKernel:
             "hcatRecycle",
             "hcatBruteForce",
             "hcatTopMask",
+            "hcatRosettaMask",
             "hcatPathwellBruteForce",
         ],
     )

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -1,6 +1,6 @@
 """Guards against committing cracked-plaintext artifacts to a public repo.
 
-hate_crack writes hashcat `--debug-mode 4` logs for every rule-based attack
+hate_crack writes hashcat `--debug-mode 5` logs for every rule-based attack
 without being asked (`_add_debug_mode_for_rules`), and each line pairs a rule
 with the plaintext it produced. `hcatDebugLogPath` used to default to the
 relative `./hashcat_debug`, so a session launched from a checkout dropped them

--- a/tests/test_run_hcat_cmd.py
+++ b/tests/test_run_hcat_cmd.py
@@ -199,6 +199,134 @@ class TestRunHcatCmd:
         mock_lc.assert_called_with(alt_out)
         mock_notify.notify_job_done.assert_called_once_with("LM Phase", 9, hash_file)
 
+    def test_debug_mode_5_rejection_falls_back_to_4_and_retries(
+        self, main_module, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(main_module, "_debug_mode_level", 5)
+        hash_file = str(tmp_path / "hashes.txt")
+
+        fail_proc = _make_mock_proc()
+        fail_proc.returncode = 255
+        ok_proc = _make_mock_proc()
+        ok_proc.returncode = 0
+        popen_calls = []
+
+        def fake_popen(cmd, **kwargs):
+            popen_calls.append((list(cmd), kwargs))
+            if len(popen_calls) == 1:
+                kwargs["stderr"].write(b"Invalid --debug-mode value specified.\n")
+                return fail_proc
+            return ok_proc
+
+        with (
+            patch("hate_crack.main.subprocess.Popen", side_effect=fake_popen),
+            patch("hate_crack.main._notify") as mock_notify,
+        ):
+            mock_notify.is_suppressed.return_value = False
+            mock_notify.get_settings.return_value = MagicMock(enabled=False)
+            mock_notify.start_tailer.return_value = None
+            main_module._run_hcat_cmd(
+                [
+                    "hashcat",
+                    "-r",
+                    "best64.rule",
+                    "--debug-mode",
+                    "5",
+                    "--debug-file",
+                    "x.log",
+                ],
+                attack_name="Dictionary",
+                hash_file=hash_file,
+            )
+
+        assert len(popen_calls) == 2
+        first_cmd, second_cmd = popen_calls[0][0], popen_calls[1][0]
+        assert first_cmd[first_cmd.index("--debug-mode") + 1] == "5"
+        assert second_cmd[second_cmd.index("--debug-mode") + 1] == "4"
+        assert main_module._debug_mode_level == 4
+
+    def test_debug_mode_fallback_level_is_reused_without_retrying(
+        self, main_module, tmp_path, monkeypatch
+    ):
+        # Once a prior invocation fell back, later ones request mode 4
+        # directly, so a rejection can only be re-triggered by mode 5.
+        monkeypatch.setattr(main_module, "_debug_mode_level", 4)
+        hash_file = str(tmp_path / "hashes.txt")
+
+        fail_proc = _make_mock_proc()
+        fail_proc.returncode = 255
+        popen_calls = []
+
+        def fake_popen(cmd, **kwargs):
+            popen_calls.append(list(cmd))
+            kwargs["stderr"].write(b"Invalid --debug-mode value specified.\n")
+            return fail_proc
+
+        with (
+            patch("hate_crack.main.subprocess.Popen", side_effect=fake_popen),
+            patch("hate_crack.main._notify") as mock_notify,
+        ):
+            mock_notify.is_suppressed.return_value = False
+            mock_notify.get_settings.return_value = MagicMock(enabled=False)
+            mock_notify.start_tailer.return_value = None
+            main_module._run_hcat_cmd(
+                [
+                    "hashcat",
+                    "-r",
+                    "best64.rule",
+                    "--debug-mode",
+                    "4",
+                    "--debug-file",
+                    "x.log",
+                ],
+                attack_name="Dictionary",
+                hash_file=hash_file,
+            )
+
+        # Already at mode 4: no retry loop, and the level is untouched.
+        assert len(popen_calls) == 1
+        assert main_module._debug_mode_level == 4
+
+    def test_unrelated_stderr_is_surfaced_not_treated_as_fallback(
+        self, main_module, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(main_module, "_debug_mode_level", 5)
+        hash_file = str(tmp_path / "hashes.txt")
+
+        fail_proc = _make_mock_proc()
+        fail_proc.returncode = 1
+        popen_calls = []
+
+        def fake_popen(cmd, **kwargs):
+            popen_calls.append(list(cmd))
+            kwargs["stderr"].write(b"Some unrelated hashcat error.\n")
+            return fail_proc
+
+        with (
+            patch("hate_crack.main.subprocess.Popen", side_effect=fake_popen),
+            patch("hate_crack.main._notify") as mock_notify,
+        ):
+            mock_notify.is_suppressed.return_value = False
+            mock_notify.get_settings.return_value = MagicMock(enabled=False)
+            mock_notify.start_tailer.return_value = None
+            main_module._run_hcat_cmd(
+                [
+                    "hashcat",
+                    "-r",
+                    "best64.rule",
+                    "--debug-mode",
+                    "5",
+                    "--debug-file",
+                    "x.log",
+                ],
+                attack_name="Dictionary",
+                hash_file=hash_file,
+            )
+
+        assert len(popen_calls) == 1
+        assert main_module._debug_mode_level == 5
+        assert "Some unrelated hashcat error." in capsys.readouterr().err
+
     def test_tailer_is_stopped_in_finally(self, main_module, tmp_path):
         hash_file = str(tmp_path / "hashes.txt")
         proc = _make_mock_proc(wait_side_effect=KeyboardInterrupt())

--- a/tests/test_valid_hcmask.py
+++ b/tests/test_valid_hcmask.py
@@ -56,3 +56,23 @@ def test_mask_with_embedded_newline_is_invalid():
 
 def test_mask_with_literal_space_is_valid():
     assert hc_main._valid_hcmask("?u?l?l ?d?d?d") is True
+
+
+def test_exactly_max_length_mask_is_valid():
+    assert hc_main._valid_hcmask("?a" * 16) is True  # 32 characters
+
+
+def test_one_over_max_length_mask_is_invalid():
+    assert hc_main._valid_hcmask("a" + "?a" * 16) is False  # 33 characters
+
+
+def test_single_question_mark_is_invalid():
+    assert hc_main._valid_hcmask("?") is False
+
+
+def test_triple_question_mark_is_invalid():
+    assert hc_main._valid_hcmask("???") is False
+
+
+def test_quadruple_question_mark_is_valid():
+    assert hc_main._valid_hcmask("????") is True

--- a/tests/test_valid_hcmask.py
+++ b/tests/test_valid_hcmask.py
@@ -76,3 +76,7 @@ def test_triple_question_mark_is_invalid():
 
 def test_quadruple_question_mark_is_valid():
     assert hc_main._valid_hcmask("????") is True
+
+
+def test_mask_with_leading_hash_is_invalid():
+    assert hc_main._valid_hcmask("#comment") is False

--- a/tests/test_valid_hcmask.py
+++ b/tests/test_valid_hcmask.py
@@ -34,20 +34,28 @@ def test_empty_mask_is_invalid():
     assert hc_main._valid_hcmask("") is False
 
 
-def test_overlength_mask_is_invalid():
-    assert hc_main._valid_hcmask("?a" * 40) is False
+def test_well_over_old_32_char_cap_is_now_valid():
+    # The old hand-rolled checker capped masks at 32 characters as a guard
+    # against runaway model output -- hashcat_rosetta.mask.parse_hcmask_line
+    # (delegated to since the rosetta mask integration) enforces hashcat's
+    # own real 256-position limit instead, so this 80-position mask is valid.
+    assert hc_main._valid_hcmask("?a" * 40) is True
 
 
 def test_non_string_input_is_invalid():
     assert hc_main._valid_hcmask(None) is False
 
 
-def test_mask_with_comma_is_invalid():
-    assert hc_main._valid_hcmask("?u?l?l,?d?d?d") is False
+def test_mask_with_custom_charset_comma_is_valid():
+    # A comma is the legitimate custom-charset/mask separator in real hcmask
+    # syntax -- "aeiou" here is custom charset 1, referenced as ?1.
+    assert hc_main._valid_hcmask("aeiou,?1?1?d?d?d") is True
 
 
-def test_mask_with_backslash_is_invalid():
-    assert hc_main._valid_hcmask("?u?l?l\\?d?d?d") is False
+def test_mask_with_literal_backslash_is_valid():
+    # A backslash that isn't part of an escaped comma (\,) is just an
+    # ordinary literal character in real hcmask syntax.
+    assert hc_main._valid_hcmask("?u?l?l\\?d?d?d") is True
 
 
 def test_mask_with_embedded_newline_is_invalid():
@@ -62,8 +70,12 @@ def test_exactly_max_length_mask_is_valid():
     assert hc_main._valid_hcmask("?a" * 16) is True  # 32 characters
 
 
-def test_one_over_max_length_mask_is_invalid():
-    assert hc_main._valid_hcmask("a" + "?a" * 16) is False  # 33 characters
+def test_at_hashcat_256_position_limit_is_valid():
+    assert hc_main._valid_hcmask("a" * 256) is True
+
+
+def test_one_over_hashcat_256_position_limit_is_invalid():
+    assert hc_main._valid_hcmask("a" * 257) is False
 
 
 def test_single_question_mark_is_invalid():
@@ -80,3 +92,25 @@ def test_quadruple_question_mark_is_valid():
 
 def test_mask_with_leading_hash_is_invalid():
     assert hc_main._valid_hcmask("#comment") is False
+
+
+def test_custom_charset_reference_is_valid():
+    assert hc_main._valid_hcmask("aeiou,?1?1?1?1?d?d") is True
+
+
+def test_custom_charset_reference_beyond_defined_count_is_invalid():
+    # Only one custom charset is defined here; ?2 is not.
+    assert hc_main._valid_hcmask("aeiou,?1?2") is False
+
+
+def test_up_to_eight_custom_charsets_is_valid():
+    assert hc_main._valid_hcmask("a,b,c,d,e,f,g,h,?1?2?3?4?5?6?7?8") is True
+
+
+def test_more_than_eight_custom_charsets_is_invalid():
+    assert hc_main._valid_hcmask("a,b,c,d,e,f,g,h,i,?1") is False
+
+
+def test_custom_charset_back_reference_is_valid():
+    # ?2 is defined as charset 1 (digits) plus the letter 'a'.
+    assert hc_main._valid_hcmask("0123456789,?1a,?1?2") is True

--- a/tests/test_valid_hcmask.py
+++ b/tests/test_valid_hcmask.py
@@ -1,0 +1,42 @@
+"""Unit tests for hate_crack.main._valid_hcmask."""
+
+import os
+
+os.environ["HATE_CRACK_SKIP_INIT"] = "1"
+from hate_crack import main as hc_main  # noqa: E402
+
+
+def test_literal_only_mask_is_valid():
+    assert hc_main._valid_hcmask("password123") is True
+
+
+def test_all_placeholder_classes_are_valid():
+    assert hc_main._valid_hcmask("?u?l?d?s?a?b") is True
+
+
+def test_mixed_literal_and_placeholder_is_valid():
+    assert hc_main._valid_hcmask("?u?l?l?l-2026") is True
+
+
+def test_escaped_literal_question_mark_is_valid():
+    assert hc_main._valid_hcmask("?u?l?l??") is True
+
+
+def test_trailing_unescaped_question_mark_is_invalid():
+    assert hc_main._valid_hcmask("?u?l?l?") is False
+
+
+def test_unknown_placeholder_letter_is_invalid():
+    assert hc_main._valid_hcmask("?u?x?d") is False
+
+
+def test_empty_mask_is_invalid():
+    assert hc_main._valid_hcmask("") is False
+
+
+def test_overlength_mask_is_invalid():
+    assert hc_main._valid_hcmask("?a" * 40) is False
+
+
+def test_non_string_input_is_invalid():
+    assert hc_main._valid_hcmask(None) is False

--- a/tests/test_valid_hcmask.py
+++ b/tests/test_valid_hcmask.py
@@ -40,3 +40,19 @@ def test_overlength_mask_is_invalid():
 
 def test_non_string_input_is_invalid():
     assert hc_main._valid_hcmask(None) is False
+
+
+def test_mask_with_comma_is_invalid():
+    assert hc_main._valid_hcmask("?u?l?l,?d?d?d") is False
+
+
+def test_mask_with_backslash_is_invalid():
+    assert hc_main._valid_hcmask("?u?l?l\\?d?d?d") is False
+
+
+def test_mask_with_embedded_newline_is_invalid():
+    assert hc_main._valid_hcmask("?u?l?l\n?d?d?d") is False
+
+
+def test_mask_with_literal_space_is_valid():
+    assert hc_main._valid_hcmask("?u?l?l ?d?d?d") is True


### PR DESCRIPTION
## Summary
- Batches Hashview cracked-hash uploads into 10k-line chunks
- Adds an LLM Mask Attack (Rosetta menu choice 4) and delegates its prompt/schema/validation to HashcatRosetta
- Fixes rosetta_derive mixed-mode debug log parsing and the 1M-line read cap
- Fixes NTLM $HEX[...] double-encoding for already-valid-UTF-8 plaintexts on the Hashview upload path
- Adds automatic --debug-mode 5→4 fallback for hashcat builds predating mode 5, plus a new --rule-debug-mode/--no-rule-debug-mode opt-out flag

## Test plan
- [x] Full suite green in the nightly-dev worktree (`HATE_CRACK_SKIP_INIT=1 uv run pytest -v`)
- [x] ruff check / ruff format --check / ty check clean
- [x] bandit clean against baseline
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)