### PR TITLE
release: integrate nightly-dev batch of 2026-08-04 (2.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+### Fixed
+- **`--update`/`--nightly` refused to run on an install that had ever built the
+  bundled binaries**, printing `Cannot auto-upgrade: uncommitted changes` even
+  though the operator had not touched a single tracked file. `make
+  submodules`/`make install` build hashcat-utils, princeprocessor, OMEN and the
+  other bundled binaries inside their own submodule working trees, leaving
+  generated sources, object files, and a touched `Makefile` there — content
+  `git status --porcelain` reports as `M <submodule>` on the superproject. The
+  pre-upgrade dirty check now passes `--ignore-submodules=dirty`, so build
+  byproducts inside a submodule no longer block the upgrade; a submodule
+  actually pinned to a different commit than recorded still does, since
+  `checkout -B` on the superproject cannot fix that anyway.
+
 ## [2.25.0] - 2026-08-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+## [2.25.1] - 2026-08-04
+
 ### Fixed
 - **`--update`/`--nightly` refused to run on an install that had ever built the
   bundled binaries**, printing `Cannot auto-upgrade: uncommitted changes` even

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1661,8 +1661,18 @@ def _run_upgrade(branch="main"):
     # `checkout -B` moves the branch to origin's tip instead of merging into it,
     # which recovers those clones. It discards local commits on the branch, so
     # the dirty check above it is load-bearing and must stay unconditional too.
+    #
+    # --ignore-submodules=dirty: `make submodules`/`make install` builds the
+    # bundled binaries (hashcat-utils, princeprocessor, OMEN, ...) inside their
+    # own submodule working trees, which leaves untracked/modified content
+    # there (generated sources, object files, a touched Makefile) with no
+    # action from the operator. Plain `git status --porcelain` reports that as
+    # `M <submodule>` on the superproject, permanently blocking auto-upgrade
+    # after the very install this tool tells people to run. `dirty` still
+    # reports a submodule pinned to a different commit than recorded, which
+    # `checkout -B` on the superproject cannot fix anyway.
     status = subprocess.run(
-        ["git", "status", "--porcelain"],
+        ["git", "status", "--porcelain", "--ignore-submodules=dirty"],
         cwd=repo_root,
         capture_output=True,
         text=True,

--- a/tests/test_upgrade_real_git.py
+++ b/tests/test_upgrade_real_git.py
@@ -174,6 +174,86 @@ def test_run_upgrade_refuses_to_discard_uncommitted_work(
     assert (clone / "app.py").read_text() == "print('my local edit')\n"
 
 
+def test_run_upgrade_ignores_submodule_build_byproducts(
+    hc_module_real_git, tmp_path, capsys
+):
+    """`make submodules`/`make install` leaves untracked/modified content
+
+    inside bundled submodules (generated sources, object files, a touched
+    Makefile) with no action from the operator. A plain `git status
+    --porcelain` reports that as `M <submodule>` on the superproject, which
+    must not be treated the same as an actual uncommitted edit to a tracked
+    file -- that would permanently block auto-upgrade after the very install
+    this tool tells people to run.
+    """
+    sub_remote = _init(tmp_path / "sub-remote")
+    (sub_remote / "expander.c").write_text("// v1\n")
+    _git("add", "-A", cwd=sub_remote)
+    _git("commit", "-qm", "sub v1", cwd=sub_remote)
+
+    remote = _init(tmp_path / "remote")
+    # Local submodule clones need this explicitly allowed: modern git refuses
+    # `file://`-transport submodule clones by default (CVE-2022-39253).
+    _git(
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "-q",
+        str(sub_remote),
+        "vendored",
+        cwd=remote,
+    )
+    (remote / "app.py").write_text("print('v1')\n")
+    _git("add", "-A", cwd=remote)
+    _git("commit", "-qm", "release 1.0", cwd=remote)
+    _git("tag", "v1.0", cwd=remote)
+
+    clone = tmp_path / "clone"
+    _git(
+        "-c",
+        "protocol.file.allow=always",
+        "clone",
+        "-q",
+        "--recurse-submodules",
+        str(remote),
+        str(clone),
+        cwd=tmp_path,
+    )
+
+    # A build step regenerated a source file and touched the Makefile inside
+    # the submodule's own working tree -- untracked/modified content within
+    # the submodule, not a commit change and not an edit to any file the
+    # superproject itself tracks.
+    (clone / "vendored" / "expander2.c").write_text("// generated\n")
+    (clone / "vendored" / "expander.c").write_text("// v1, rebuilt\n")
+
+    real_run = subprocess.run
+    shell_calls = []
+
+    def passthrough(cmd, *args, **kwargs):
+        if kwargs.get("shell"):
+            shell_calls.append(cmd)
+
+            class Ok:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return Ok()
+        return real_run(cmd, *args, **kwargs)
+
+    with (
+        patch.object(hc_module_real_git, "_repo_root", str(clone)),
+        patch("subprocess.run", side_effect=passthrough),
+        pytest.raises(SystemExit) as exc,
+    ):
+        hc_module_real_git._run_upgrade()
+
+    assert exc.value.code == 0, capsys.readouterr().out
+    assert shell_calls and "make install" in shell_calls[0]
+
+
 @pytest.fixture
 def hc_module_real_git():
     import importlib


### PR DESCRIPTION
## Summary
- `--update`/`--nightly` no longer refuse to run on an install that has ever built the bundled binaries (`make submodules`/`make install`). Submodule build byproducts (generated sources, object files, a touched Makefile) were tripping the pre-upgrade dirty check via `git status --porcelain` reporting `M <submodule>`, even with zero operator edits. Fixed with `--ignore-submodules=dirty`.

## Test plan
- [x] Full suite green in the nightly-dev worktree (`HATE_CRACK_SKIP_INIT=1 uv run pytest -v`), including a new real-git regression test reproducing the submodule-dirt scenario
- [x] ruff check / ruff format --check / ty check clean
- [x] bandit clean against baseline
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)