### PR TITLE
release: integrate nightly-dev batch of 2026-08-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
-### Fixed
-- Added a regression test locking in that `upload_cracked_hashes` preserves leading/trailing whitespace in cracked plaintexts (#244).
+### Added
+- A regression test locking in that `upload_cracked_hashes` preserves leading/trailing whitespace in cracked plaintexts (#244).
 
 ## [2.25.1] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 - LLM target research now also recalls a parent company / acquisition history for the named organization, alongside industry and location (#263).
 
 ### Fixed
+- LLM target research now uses parent company / acquisition history when generating password candidates (previously the field was collected but not passed to the model) (#263).
 - OMEN training now decompresses gzip-compressed training wordlists, matching the N-gram attack's existing behavior (#257).
 - Config resolution now warns when a `config.json`/`.env` at a higher-priority candidate root (the repo checkout, or the installed package directory) is shadowing one at a lower-priority root (`~/.hate_crack`), instead of silently ignoring the shadowed file forever. A stray file left behind in a checkout could otherwise make a real, hand-configured `~/.hate_crack/config.json` (hashcat path, wordlist/rules directories, etc.) look like it had been silently replaced with schema-default placeholders on first run — which file wins is unchanged, this only makes the shadowing visible (#246).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 ### Added
 - A regression test locking in that `upload_cracked_hashes` preserves leading/trailing whitespace in cracked plaintexts (#244).
 
+### Fixed
+- OMEN training now decompresses gzip-compressed training wordlists, matching the N-gram attack's existing behavior (#257).
+
 ## [2.25.1] - 2026-08-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ### Fixed
 - OMEN training now decompresses gzip-compressed training wordlists, matching the N-gram attack's existing behavior (#257).
+- Config resolution now warns when a `config.json`/`.env` at a higher-priority candidate root (the repo checkout, or the installed package directory) is shadowing one at a lower-priority root (`~/.hate_crack`), instead of silently ignoring the shadowed file forever. A stray file left behind in a checkout could otherwise make a real, hand-configured `~/.hate_crack/config.json` (hashcat path, wordlist/rules directories, etc.) look like it had been silently replaced with schema-default placeholders on first run — which file wins is unchanged, this only makes the shadowing visible (#246).
 
 ## [2.25.1] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ### Added
 - A regression test locking in that `upload_cracked_hashes` preserves leading/trailing whitespace in cracked plaintexts (#244).
+- LLM target research now also recalls a parent company / acquisition history for the named organization, alongside industry and location (#263).
 
 ### Fixed
 - OMEN training now decompresses gzip-compressed training wordlists, matching the N-gram attack's existing behavior (#257).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
-## [Unreleased]
+## [2.26.0] - 2026-08-12
 
 ### Added
 - A regression test locking in that `upload_cracked_hashes` preserves leading/trailing whitespace in cracked plaintexts (#244).
-- LLM target research now also recalls a parent company / acquisition history for the named organization, alongside industry and location (#263).
+- LLM target research now also recalls a parent company / acquisition history for the named organization, alongside industry and location, and uses it when generating password candidates (#263).
 
 ### Fixed
-- LLM target research now uses parent company / acquisition history when generating password candidates (previously the field was collected but not passed to the model) (#263).
 - OMEN training now decompresses gzip-compressed training wordlists, matching the N-gram attack's existing behavior (#257).
 - Config resolution now warns when a `config.json`/`.env` at a higher-priority candidate root (the repo checkout, or the installed package directory) is shadowing one at a lower-priority root (`~/.hate_crack`), instead of silently ignoring the shadowed file forever. A stray file left behind in a checkout could otherwise make a real, hand-configured `~/.hate_crack/config.json` (hashcat path, wordlist/rules directories, etc.) look like it had been silently replaced with schema-default placeholders on first run — which file wins is unchanged, this only makes the shadowing visible (#246).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+### Fixed
+- Added a regression test locking in that `upload_cracked_hashes` preserves leading/trailing whitespace in cracked plaintexts (#244).
+
 ## [2.25.1] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -587,15 +587,15 @@ OLLAMA_TIMEOUT=300
 
   This replaces the previous behaviour of pasting an evenly-spaced sample of up to `ollamaMaxSampleLines` passwords. A sample of a large dump conveyed no frequency information at all: the model could not distinguish a baseword used by 8% of the organization from one used by a single person, which is precisely the signal that makes a guess worth running.
 - **`OLLAMA_NO_CLOUD`** — When `true`, refuse to send anything to an Ollama *cloud* model. Ollama proxies a `-cloud`-tagged model (`gpt-oss:120b-cloud`, `deepseek-v3.1:671b-cloud`) to ollama.com through the same local endpoint a local model uses, so nothing about the request looks different — but hate_crack's prompts carry recovered plaintexts, corpus statistics, and the client's name, industry, and location. With this set, a cloud model name is refused before any request is built. Defaults to `false`, so a deliberately-configured cloud model keeps working; turn it on for engagements where client data must not leave the host.
-- **`OLLAMA_AUTO_RESEARCH`** — When `true` (default), **Target info** mode asks the local model to suggest the industry and location as soon as you have typed the company name, and offers them as editable prompt defaults. Set to `false` to always get blank prompts (useful with a slow model, since research costs one extra round-trip before the attack starts).
+- **`OLLAMA_AUTO_RESEARCH`** — When `true` (default), **Target info** mode asks the local model to suggest the industry, location, and parent company / acquisition history as soon as you have typed the company name, and offers them as editable prompt defaults. Set to `false` to always get blank prompts (useful with a slow model, since research costs one extra round-trip before the attack starts).
 - **`OLLAMA_HOST`** — Where Ollama is listening. Accepts a bare `host:port` (`theplague.lan:11434`) or a full URL with a scheme (`https://ollama.example.com`); either way the base URL is normalized before use. Defaults to `localhost:11434`. Set it in `.env`, or export it as a real environment variable to override that for a single run — it is the same variable name Ollama's own CLI reads.
 - Ensure Ollama is running and the model is pulled (`ollama pull qwen2.5:32b`) before using the LLM Attack — hate_crack no longer auto-pulls missing models.
 
 The attack offers three generation modes:
 
-1. **Target info** — company / industry / location; the model derives candidates from those details.
+1. **Target info** — company / industry / location / parent company; the model derives candidates from those details.
 
-   After you type the company name, hate_crack asks the same local model what it already knows about that organization and pre-fills the **Industry** and **Location** prompts with the answers, shown in parentheses:
+   After you type the company name, hate_crack asks the same local model what it already knows about that organization and pre-fills the **Industry**, **Location**, and **Parent Company** prompts with the answers, shown in parentheses:
 
    ```
    Company name: Acme Rail Services
@@ -604,6 +604,7 @@ The attack offers three generation modes:
        Press Enter to accept, or type your own value to override.
    Industry (freight rail maintenance):
    Location (Omaha, Nebraska):
+   Parent company / acquired by:
    ```
 
    Press Enter to accept a suggestion or type over it. These values are the model's recollection, **not OSINT** — treat them as a starting point, not intelligence about the client. The lookup uses only the local Ollama server, so the client name never leaves the host; there are no web or third-party API calls. If the model does not recognize the organization (the common case for small clients), it returns nothing and you get plain blank prompts:
@@ -612,6 +613,7 @@ The attack offers three generation modes:
    Company name: Acme Rail Services
    Industry:
    Location:
+   Parent company / acquired by:
    ```
 
    A research failure — timeout, Ollama not running, empty answer — never blocks the attack; it just falls back to blank prompts. Set `ollamaAutoResearch` to `false` to skip research entirely.
@@ -1053,12 +1055,12 @@ Uses hashcat's loopback mode to feed cracked passwords from the current session 
 * Automatically downloads Hashmob rules if no rules are available locally
 
 #### LLM Attack
-Uses a local Ollama instance to generate password candidates for a capture-the-flag scenario. Prompts for the fake company name, industry, and location, then sends these details to the configured LLM model to produce likely password candidates using industry terms and company name permutations. The generated candidates are fed into a hashcat wordlist+rules attack.
+Uses a local Ollama instance to generate password candidates for a capture-the-flag scenario. Prompts for the fake company name, industry, location, and parent company / acquisition history, then sends these details to the configured LLM model to produce likely password candidates using industry terms and company name permutations. The generated candidates are fed into a hashcat wordlist+rules attack.
 
 * Requires a running Ollama instance (default: `http://localhost:11434`, override with `OLLAMA_HOST` in `.env` or the environment) with the model already pulled — hate_crack does not auto-pull
 * Candidate generation uses structured (JSON) output via Atomic Agents, so pick a model with good schema adherence (default: `qwen2.5:32b`)
 * Configurable model, context window, request timeout, and sample size via `.env` (see Ollama Configuration below)
-* Prompts for target company name, industry, and location. The industry and location prompts are pre-filled with the local model's guesses about the named organization (editable, and clearly labelled as guesses rather than verified OSINT); disable with `ollamaAutoResearch: false`
+* Prompts for target company name, industry, location, and parent company / acquisition history. The industry, location, and parent company prompts are pre-filled with the local model's guesses about the named organization (editable, and clearly labelled as guesses rather than verified OSINT); disable with `ollamaAutoResearch: false`
 * Alternatively derives basewords from a sample **wordlist**, or from the **cracked passwords** of the current session (`<hashfile>.out`) so the model mirrors the target organization's own password conventions and produces new candidates in that style (only offered once something has been cracked)
 * A live spinner with an elapsed-seconds counter runs during generation, and requests are bounded by `ollamaTimeout` so a model stuck loading into VRAM reports a timeout instead of hanging
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Most users can use defaults without customization:
 
   Read those two lines before debugging a setting that "isn't taking effect". They exist because of two traps in the search order:
 
-  - **A checkout outranks your home directory.** The repo root is searched first, so a `.env` or `config.json` sitting in *any* checkout you run the tool from wins over the one in `~/.hate_crack` — and running the tool from a checkout is exactly what creates those files there in the first place.
+  - **A checkout outranks your home directory.** The repo root is searched first, so a `.env` or `config.json` sitting in *any* checkout you run the tool from wins over the one in `~/.hate_crack` — and running the tool from a checkout is exactly what creates those files there in the first place. If this ever shadows a real `~/.hate_crack` config, hate_crack now says so with a third `[!]` line naming both paths — treat that line as "the file below is being ignored," not as a second, equally-valid config.
   - **The current working directory is never searched.** A `.env` in the directory you happen to be standing in is ignored, deliberately: engagement directories are full of files nobody intended as configuration. Put it in the repo root or `~/.hate_crack`.
 
 ### Error: merge with ref 'refs/heads/master' but no such ref was fetched

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -1189,6 +1189,27 @@ def _digest_for_type(hash_type: str, raw: bytes) -> Optional[str]:
     return None
 
 
+_REJECTED_HASH_RE = re.compile(
+    r"Plaintext for hash ([0-9a-fA-F]+), was found to be invalid\."
+)
+
+
+def _extract_rejected_hash(msg):
+    """Return the hash value named in a Hashview "plaintext invalid" error,
+    or None if ``msg`` doesn't match that shape.
+
+    Hashview's ``/v1/hashes/import`` rolls back the entire batch on the first
+    line it can't verify -- notably including a hashcat plaintext with a raw
+    embedded CR/LF byte, which the client can't inline without corrupting
+    this line-based upload and so sends as a literal ``$HEX[...]`` token that
+    an older Hashview hashes verbatim instead of decoding. Parsing the
+    rejected hash out of the error lets the caller drop just that one line
+    and retry, instead of losing the whole batch to it.
+    """
+    match = _REJECTED_HASH_RE.search(msg or "")
+    return match.group(1) if match else None
+
+
 def _validate_cracked_pair(hash_type, hash_value, plaintext):
     """Return (ok, reason) for a single hash:plaintext pair.
 
@@ -1991,43 +2012,65 @@ class HashviewAPI:
         aggregated = {}
         summable_fields = ("verified", "updated", "count")
         list_fields = ("unmatched",)
+        rejected_by_server = []
         for batch_num, (line_batch, key_batch) in enumerate(
             zip(batches, key_batches), start=1
         ):
+            line_batch = list(line_batch)
+            key_batch = list(key_batch)
             if len(batches) > 1:
                 print(
                     f"Uploading batch {batch_num}/{len(batches)} "
                     f"({len(line_batch)} hashes)..."
                 )
-            converted_content = b"\n".join(line_batch)
-            resp = self.session.post(
-                url,
-                data=converted_content,
-                headers=headers,
-                timeout=HASHVIEW_UPLOAD_TIMEOUT,
-            )
-            resp.raise_for_status()
-            try:
-                json_response = resp.json()
-            except (json.JSONDecodeError, ValueError):
-                raise Exception(f"Invalid API response: {resp.text[:200]}")
-            if not isinstance(json_response, dict):
-                if len(batches) == 1:
-                    # Matches today's single-request behavior: a non-dict
-                    # response (rare, but Hashview's contract doesn't forbid
-                    # it) is returned as-is rather than merged.
-                    append_to_cache(key_batch)
-                    return json_response
-                raise Exception(
-                    f"Hashview API returned a non-object response for batch "
-                    f"{batch_num}/{len(batches)}: {json_response!r}"
+            # A single line Hashview rejects rolls back its whole batch. Retry
+            # with that one line dropped rather than losing every hash in the
+            # batch to it -- bounded by the batch size so a server that keeps
+            # rejecting can't loop forever.
+            for _attempt in range(len(line_batch) + 1):
+                if not line_batch:
+                    break
+                converted_content = b"\n".join(line_batch)
+                resp = self.session.post(
+                    url,
+                    data=converted_content,
+                    headers=headers,
+                    timeout=HASHVIEW_UPLOAD_TIMEOUT,
                 )
-            if json_response.get("type") == "Error":
-                raise Exception(
-                    f"Hashview API Error: {json_response.get('msg', 'Unknown error')}"
-                )
-            append_to_cache(key_batch)
-            if isinstance(json_response, dict):
+                resp.raise_for_status()
+                try:
+                    json_response = resp.json()
+                except (json.JSONDecodeError, ValueError):
+                    raise Exception(f"Invalid API response: {resp.text[:200]}")
+                if not isinstance(json_response, dict):
+                    if len(batches) == 1:
+                        # Matches today's single-request behavior: a non-dict
+                        # response (rare, but Hashview's contract doesn't
+                        # forbid it) is returned as-is rather than merged.
+                        append_to_cache(key_batch)
+                        return json_response
+                    raise Exception(
+                        f"Hashview API returned a non-object response for "
+                        f"batch {batch_num}/{len(batches)}: {json_response!r}"
+                    )
+                if json_response.get("type") == "Error":
+                    rejected_hash = _extract_rejected_hash(json_response.get("msg", ""))
+                    if rejected_hash is not None:
+                        kept_lines, kept_keys = [], []
+                        for line, key in zip(line_batch, key_batch):
+                            line_hash = line.split(b":", 1)[0].decode("ascii", "ignore")
+                            if line_hash.lower() == rejected_hash.lower():
+                                rejected_by_server.append(line_hash)
+                                continue
+                            kept_lines.append(line)
+                            kept_keys.append(key)
+                        line_batch, key_batch = kept_lines, kept_keys
+                        continue
+                    raise Exception(
+                        f"Hashview API Error: "
+                        f"{json_response.get('msg', 'Unknown error')}"
+                    )
+                append_to_cache(key_batch)
                 for field in summable_fields:
                     if isinstance(json_response.get(field), (int, float)):
                         aggregated[field] = (
@@ -2040,9 +2083,21 @@ class HashviewAPI:
                 for key, value in json_response.items():
                     if key not in summable_fields and key not in list_fields:
                         aggregated.setdefault(key, value)
+                break
 
-        aggregated.setdefault("uploaded", len(valid_lines))
-        aggregated["skipped"] = len(skipped)
+        if rejected_by_server:
+            print(
+                f"⚠ Hashview rejected {len(rejected_by_server)} plaintext(s) as "
+                "invalid (server does not decode $HEX[...] on import) -- "
+                "skipped, rest of the batch uploaded:"
+            )
+            for hash_value in rejected_by_server[:10]:
+                print(f"    {hash_value}")
+            if len(rejected_by_server) > 10:
+                print(f"    ... and {len(rejected_by_server) - 10} more")
+
+        aggregated.setdefault("uploaded", len(valid_lines) - len(rejected_by_server))
+        aggregated["skipped"] = len(skipped) + len(rejected_by_server)
         aggregated["skipped_cached"] = skipped_cached
         return aggregated
 

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -709,7 +709,7 @@ def bandrel_method(ctx: Any) -> None:
 
 
 def _research_target_suggestions(ctx: Any, company: str) -> dict[str, str]:
-    """Ask the local model for industry/location suggestions for *company*.
+    """Ask the local model for industry/location/parent-company suggestions for *company*.
 
     Returns a dict of cleaned suggestion strings (values may be ''). Research is
     a convenience only, so any failure is swallowed here as well as in
@@ -727,7 +727,7 @@ def _research_target_suggestions(ctx: Any, company: str) -> dict[str, str]:
 
     suggestions = {}
     if isinstance(raw, dict):
-        for key in ("industry", "location"):
+        for key in ("industry", "location", "parent_company"):
             value = clean_research_field(raw.get(key, ""))
             if value:
                 suggestions[key] = value
@@ -827,11 +827,19 @@ def ollama_attack(ctx: Any) -> None:
             suggestions = _research_target_suggestions(ctx, company)
             industry = _prompt_with_default("Industry", suggestions.get("industry"))
             location = _prompt_with_default("Location", suggestions.get("location"))
+            parent_company = _prompt_with_default(
+                "Parent company / acquired by", suggestions.get("parent_company")
+            )
             ctx.hcatOllama(
                 ctx.hcatHashType,
                 ctx.hcatHashFile,
                 "target",
-                {"company": company, "industry": industry, "location": location},
+                {
+                    "company": company,
+                    "industry": industry,
+                    "location": location,
+                    "parent_company": parent_company,
+                },
             )
             return
         elif choice == "2":

--- a/hate_crack/config_loader.py
+++ b/hate_crack/config_loader.py
@@ -110,6 +110,47 @@ def _shadowed_config_warning(filename: str, winner: str, loser: str) -> str:
     )
 
 
+class _OneFileSearch:
+    """Tracks the winning path for one filename (``.env`` or ``config.json``)
+    across successive candidate roots, and the shadow warnings that come with
+    it.
+
+    Kept as a small stateful helper rather than a free function so
+    :func:`resolve_config_paths` can drive both filenames through the exact
+    same logic with a loop instead of two near-identical blocks (#246 review).
+    """
+
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        self.winner: str | None = None
+        self.warnings: list[str] = []
+
+    def visit(self, candidate_root: str) -> None:
+        candidate_path = os.path.join(candidate_root, self.filename)
+        if self.winner is None:
+            if _config_file_is_usable(candidate_path):
+                self.winner = candidate_path
+            return
+        try:
+            shadowed = _config_file_is_usable(candidate_path)
+        except ConfigFileUnreadableError:
+            # Only the winning path's usability is allowed to be fatal --
+            # this candidate isn't the file the process is about to act on.
+            shadowed = False
+        if not shadowed:
+            return
+        # A candidate symlinked to (or itself a symlink target shared with)
+        # the winning path is the supported "one shared config across several
+        # checkouts" setup (_config_file_is_usable's own docstring, and
+        # test_discovery_follows_a_valid_symlink) -- nothing is actually being
+        # ignored there, so it must not warn.
+        if os.path.realpath(candidate_path) == os.path.realpath(self.winner):
+            return
+        self.warnings.append(
+            _shadowed_config_warning(self.filename, self.winner, candidate_path)
+        )
+
+
 def resolve_config_paths() -> tuple[str | None, str | None, list[str]]:
     """Locate ``.env`` and ``config.json`` using the shared search order.
 
@@ -123,45 +164,21 @@ def resolve_config_paths() -> tuple[str | None, str | None, list[str]]:
     shadowed file, naming both paths, never silent. A shadowed candidate's own
     unreadability (e.g. a dangling symlink) does not raise: only the winning
     path's usability is allowed to be fatal, since that is the only file this
-    process is about to act on.
+    process is about to act on. A candidate that resolves (via
+    :func:`os.path.realpath`) to the same file as the winner -- the supported
+    "one config symlinked into several checkouts" setup -- is not a shadow and
+    does not warn.
 
     Raises :class:`ConfigFileUnreadableError` when the *winning* candidate
     path exists as a symlink whose target is missing -- see
     :func:`_config_file_is_usable`.
     """
-    warnings: list[str] = []
-    env_path: str | None = None
-    legacy_json_path: str | None = None
-    for candidate in candidate_roots():
-        candidate_env = os.path.join(candidate, ".env")
-        if env_path is None:
-            if _config_file_is_usable(candidate_env):
-                env_path = candidate_env
-        else:
-            try:
-                shadowed = _config_file_is_usable(candidate_env)
-            except ConfigFileUnreadableError:
-                shadowed = False
-            if shadowed:
-                warnings.append(
-                    _shadowed_config_warning(".env", env_path, candidate_env)
-                )
-        candidate_json = os.path.join(candidate, "config.json")
-        if legacy_json_path is None:
-            if _config_file_is_usable(candidate_json):
-                legacy_json_path = candidate_json
-        else:
-            try:
-                shadowed = _config_file_is_usable(candidate_json)
-            except ConfigFileUnreadableError:
-                shadowed = False
-            if shadowed:
-                warnings.append(
-                    _shadowed_config_warning(
-                        "config.json", legacy_json_path, candidate_json
-                    )
-                )
-    return env_path, legacy_json_path, warnings
+    searches = {name: _OneFileSearch(name) for name in (".env", "config.json")}
+    for candidate_root in candidate_roots():
+        for search in searches.values():
+            search.visit(candidate_root)
+    warnings = [w for search in searches.values() for w in search.warnings]
+    return searches[".env"].winner, searches["config.json"].winner, warnings
 
 
 class ConfigFileJSONError(Exception):

--- a/hate_crack/config_loader.py
+++ b/hate_crack/config_loader.py
@@ -91,29 +91,77 @@ def candidate_roots() -> list[str]:
     ]
 
 
-def resolve_config_paths() -> tuple[str | None, str | None]:
+def _shadowed_config_warning(filename: str, winner: str, loser: str) -> str:
+    """Warning text for a *loser* file of ``filename`` that lost to *winner*.
+
+    Named after the specific trap this covers (#246): ``candidate_roots()``
+    ranks the repo root above the package directory above ``~/.hate_crack``,
+    so a stray ``config.json``/``.env`` left in a checkout -- e.g. from a run
+    that predates a real ``~/.hate_crack`` config existing, or from bootstrap
+    itself creating one there on a fresh clone -- silently outranks a real,
+    hand-configured file living in a lower-priority root, forever, with no
+    indication anything is being ignored. The loader still picks the same
+    winner it always did; this only makes the shadowing visible.
+    """
+    return (
+        f"Using {filename} at {winner}, but another {filename} exists at "
+        f"{loser} and is being ignored. If {loser} is your real "
+        f"configuration, remove or rename the file at {winner}."
+    )
+
+
+def resolve_config_paths() -> tuple[str | None, str | None, list[str]]:
     """Locate ``.env`` and ``config.json`` using the shared search order.
 
-    Returns ``(env_path, json_path)``. Either element is ``None`` if no
+    Returns ``(env_path, json_path, warnings)``. Either path is ``None`` if no
     matching file was found in any candidate directory. The two are resolved
     independently -- they are separate, equally first-class files, and it is
     normal for them to live in different candidate directories.
 
-    Raises :class:`ConfigFileUnreadableError` when a candidate path exists as a
-    symlink whose target is missing -- see :func:`_config_file_is_usable`.
+    ``warnings`` names every lower-priority candidate root that also holds a
+    same-named file the winning one is shadowing (#246) -- one entry per
+    shadowed file, naming both paths, never silent. A shadowed candidate's own
+    unreadability (e.g. a dangling symlink) does not raise: only the winning
+    path's usability is allowed to be fatal, since that is the only file this
+    process is about to act on.
+
+    Raises :class:`ConfigFileUnreadableError` when the *winning* candidate
+    path exists as a symlink whose target is missing -- see
+    :func:`_config_file_is_usable`.
     """
+    warnings: list[str] = []
     env_path: str | None = None
     legacy_json_path: str | None = None
     for candidate in candidate_roots():
+        candidate_env = os.path.join(candidate, ".env")
         if env_path is None:
-            candidate_env = os.path.join(candidate, ".env")
             if _config_file_is_usable(candidate_env):
                 env_path = candidate_env
+        else:
+            try:
+                shadowed = _config_file_is_usable(candidate_env)
+            except ConfigFileUnreadableError:
+                shadowed = False
+            if shadowed:
+                warnings.append(
+                    _shadowed_config_warning(".env", env_path, candidate_env)
+                )
+        candidate_json = os.path.join(candidate, "config.json")
         if legacy_json_path is None:
-            candidate_json = os.path.join(candidate, "config.json")
             if _config_file_is_usable(candidate_json):
                 legacy_json_path = candidate_json
-    return env_path, legacy_json_path
+        else:
+            try:
+                shadowed = _config_file_is_usable(candidate_json)
+            except ConfigFileUnreadableError:
+                shadowed = False
+            if shadowed:
+                warnings.append(
+                    _shadowed_config_warning(
+                        "config.json", legacy_json_path, candidate_json
+                    )
+                )
+    return env_path, legacy_json_path, warnings
 
 
 class ConfigFileJSONError(Exception):

--- a/hate_crack/llm.py
+++ b/hate_crack/llm.py
@@ -158,7 +158,7 @@ class TargetResearchInput(BaseIOSchema):
 
 
 class TargetResearchOutput(BaseIOSchema):
-    """Recalled industry and location for a named organization, or empty strings."""
+    """Recalled industry, location, and parent company for a named organization, or empty strings."""
 
     industry: str = Field(
         ...,
@@ -175,6 +175,16 @@ class TargetResearchOutput(BaseIOSchema):
             "an empty string if you do not actually recognize this organization."
         ),
     )
+    parent_company: str = Field(
+        ...,
+        description=(
+            "The organization's parent company or the company that acquired it, "
+            "if you specifically recall an acquisition or merger, e.g. 'Acquired "
+            "by Global Corp in 2021'. Return an empty string if you do not "
+            "genuinely recall an acquisition, or if the organization is "
+            "independent as far as you know."
+        ),
+    )
 
 
 _RESEARCH_PROMPT = SystemPromptGenerator(
@@ -189,7 +199,9 @@ _RESEARCH_PROMPT = SystemPromptGenerator(
     ],
     steps=[
         "Decide whether you genuinely recognize this specific organization by name.",
-        "If you do, recall its industry or sector and its primary location.",
+        "If you do, recall its industry or sector, its primary location, and "
+        "whether you specifically recall it being acquired by or merged into "
+        "another company.",
         "If you do not recognize it, or you are not reasonably confident, do not "
         "guess and do not infer anything from the words in the name.",
     ],
@@ -198,8 +210,8 @@ _RESEARCH_PROMPT = SystemPromptGenerator(
         "about. An empty field is correct and useful; a fabricated one is harmful "
         "because the operator may mistake it for real intelligence.",
         "Keep each field under 80 characters.",
-        "Return only the industry and location fields — no explanations, "
-        "hedging, caveats, or commentary.",
+        "Return only the industry, location, and parent_company fields — no "
+        "explanations, hedging, caveats, or commentary.",
     ],
 )
 
@@ -490,6 +502,7 @@ def research_target(
     return TargetResearchOutput(
         industry=clean_research_field(getattr(result, "industry", "")),
         location=clean_research_field(getattr(result, "location", "")),
+        parent_company=clean_research_field(getattr(result, "parent_company", "")),
     )
 
 

--- a/hate_crack/llm.py
+++ b/hate_crack/llm.py
@@ -150,7 +150,7 @@ class HashcatRulesOutput(BaseIOSchema):
 
 
 class TargetResearchInput(BaseIOSchema):
-    """The company name to recall industry and location details for."""
+    """The company name to recall industry, location, and parent company details for."""
 
     company: str = Field(
         ..., description="The name of the target organization, exactly as typed."
@@ -471,9 +471,10 @@ def research_target(
 ) -> TargetResearchOutput:
     """Ask the local model what it already knows about *company*.
 
-    Returns a ``TargetResearchOutput`` whose ``industry`` and ``location`` are
-    stripped and capped at ``MAX_RESEARCH_FIELD_LEN``; either may be '' when the
-    model is not confident, which callers must treat as "no suggestion".
+    Returns a ``TargetResearchOutput`` whose ``industry``, ``location``, and
+    ``parent_company`` fields are stripped and capped at ``MAX_RESEARCH_FIELD_LEN``;
+    any field may be '' when the model is not confident, which callers must treat
+    as "no suggestion".
 
     Uses only the configured local Ollama server — no web lookups, so the client
     name never leaves the host. Raises LLMTimeoutError if the request exceeds

--- a/hate_crack/llm.py
+++ b/hate_crack/llm.py
@@ -221,8 +221,8 @@ _TARGET_PROMPT = SystemPromptGenerator(
         "authorized penetration test / capture-the-flag exercise.",
     ],
     steps=[
-        "Study the provided target context (company, industry, location).",
-        "Derive basewords from the company name and industry terms.",
+        "Study the provided target context (company, industry, location, and any parent company information).",
+        "Derive basewords from the company name and industry terms, including any names the organization was previously known by.",
         "Combine basewords with common suffixes, years, and leetspeak substitutions.",
     ],
     output_instructions=[
@@ -392,9 +392,17 @@ def _build_request(mode: str, context_data: dict) -> str:
         company = context_data.get("company", "")
         industry = context_data.get("industry", "")
         location = context_data.get("location", "")
+        parent_company = context_data.get("parent_company", "")
+        # Build the target description, optionally including parent company info.
+        target_desc = (
+            f"The target organization is '{company}', a {industry} in {location}"
+        )
+        if parent_company:
+            target_desc += f" ({parent_company})"
+        target_desc += ". "
         return (
-            f"The target organization is '{company}', a {industry} in {location}. "
-            "Generate as many plausible password candidates as you can, using "
+            target_desc
+            + "Generate as many plausible password candidates as you can, using "
             "permutations of the company name and industry terms with common "
             "suffixes, years, and leetspeak substitutions."
         )

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -4323,29 +4323,30 @@ def hcatOmenTrain(training_file):
     model_dir = _omen_model_dir()
     print(f"Training OMEN model with: {training_file}")
     print(f"Model output directory: {model_dir}")
-    cmd = [
-        create_bin,
-        "--iPwdList",
-        training_file,
-        "-C",
-        os.path.join(model_dir, "createConfig"),
-        "-c",
-        os.path.join(model_dir, "CP"),
-        "-i",
-        os.path.join(model_dir, "IP"),
-        "-e",
-        os.path.join(model_dir, "EP"),
-        "-l",
-        os.path.join(model_dir, "LN"),
-    ]
-    print(f"[*] Running: {_format_cmd(cmd)}")
-    proc = subprocess.Popen(cmd)
-    try:
-        proc.wait()
-    except KeyboardInterrupt:
-        print("Killing PID {0}...".format(str(proc.pid)))
-        proc.kill()
-        return False
+    with _wordlist_path(training_file) as resolved_training_file:
+        cmd = [
+            create_bin,
+            "--iPwdList",
+            resolved_training_file,
+            "-C",
+            os.path.join(model_dir, "createConfig"),
+            "-c",
+            os.path.join(model_dir, "CP"),
+            "-i",
+            os.path.join(model_dir, "IP"),
+            "-e",
+            os.path.join(model_dir, "EP"),
+            "-l",
+            os.path.join(model_dir, "LN"),
+        ]
+        print(f"[*] Running: {_format_cmd(cmd)}")
+        proc = subprocess.Popen(cmd)
+        try:
+            proc.wait()
+        except KeyboardInterrupt:
+            print("Killing PID {0}...".format(str(proc.pid)))
+            proc.kill()
+            return False
     if proc.returncode != 0:
         print(f"OMEN training failed with exit code {proc.returncode}")
         return False

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -3031,15 +3031,15 @@ def _corpus_context(path, source_label="wordlist"):
 def hcatOllamaResearchTarget(company):
     """Ask the local Ollama model what it knows about *company*.
 
-    Returns a dict with "industry" and "location" keys; either value may be an
-    empty string when the model is not confident or the request failed. Never
-    raises: research is a convenience, so any failure degrades to empty
-    suggestions (blank prompts) rather than blocking the attack.
+    Returns a dict with "industry", "location", and "parent_company" keys; any
+    value may be an empty string when the model is not confident or the request
+    failed. Never raises: research is a convenience, so any failure degrades to
+    empty suggestions (blank prompts) rather than blocking the attack.
 
     Uses only the configured local Ollama server — the company name is never
     sent to a third-party service.
     """
-    blank = {"industry": "", "location": ""}
+    blank = {"industry": "", "location": "", "parent_company": ""}
     if not ollamaAutoResearch or not company:
         return blank
 
@@ -3063,7 +3063,11 @@ def hcatOllamaResearchTarget(company):
         print(f"Note: target research unavailable ({e}) — enter the details manually.")
         return blank
 
-    return {"industry": result.industry, "location": result.location}
+    return {
+        "industry": result.industry,
+        "location": result.location,
+        "parent_company": result.parent_company,
+    }
 
 
 # LLM Ollama Attack

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -737,8 +737,25 @@ def _print_config_sources(
     )
 
 
+def _print_discovery_warnings(warnings):
+    """Print any :func:`hate_crack.config_loader.resolve_config_paths`
+    shadowing warnings (#246), one per line.
+
+    Printed after :func:`_print_config_sources` so each warning reads against
+    the two paths just named. Silent under ``SKIP_INIT``, matching
+    :func:`_print_config_sources`: the test suite imports this module
+    constantly.
+    """
+    if SKIP_INIT:
+        return
+    for warning in warnings:
+        print(f"[!] {warning}")
+
+
 try:
-    _env_path, _legacy_json_path = _config_loader.resolve_config_paths()
+    _env_path, _legacy_json_path, _discovery_warnings = (
+        _config_loader.resolve_config_paths()
+    )
 except _config_loader.ConfigFileUnreadableError as _exc:
     # Discovery itself can fail now: a dangling `.env`/config.json symlink is
     # fatal rather than silently ignored (#227). Same diagnostic the loader
@@ -755,6 +772,7 @@ _print_config_sources(
     env_detail=_config_bootstrap_detail.get("env"),
     json_detail=_config_bootstrap_detail.get("json"),
 )
+_print_discovery_warnings(_discovery_warnings)
 
 # The loader is the single definition of the precedence stack: for each key,
 # schema default < that key's own home file < os.environ. config_parser stays

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -359,7 +359,7 @@ class TestOllamaAttack:
 
         with (
             patch("hate_crack.attacks.interactive_menu", return_value="1"),
-            patch("builtins.input", side_effect=["ACME", "tech", "NYC"]),
+            patch("builtins.input", side_effect=["ACME", "tech", "NYC", ""]),
         ):
             ollama_attack(ctx)
 
@@ -367,7 +367,12 @@ class TestOllamaAttack:
             ctx.hcatHashType,
             ctx.hcatHashFile,
             "target",
-            {"company": "ACME", "industry": "tech", "location": "NYC"},
+            {
+                "company": "ACME",
+                "industry": "tech",
+                "location": "NYC",
+                "parent_company": "",
+            },
         )
 
     def test_passes_hash_type_and_file(self) -> None:
@@ -375,7 +380,7 @@ class TestOllamaAttack:
 
         with (
             patch("hate_crack.attacks.interactive_menu", return_value="1"),
-            patch("builtins.input", side_effect=["Corp", "finance", "London"]),
+            patch("builtins.input", side_effect=["Corp", "finance", "London", ""]),
         ):
             ollama_attack(ctx)
 
@@ -388,7 +393,10 @@ class TestOllamaAttack:
 
         with (
             patch("hate_crack.attacks.interactive_menu", return_value="1"),
-            patch("builtins.input", side_effect=["  ACME  ", "  tech  ", "  NYC  "]),
+            patch(
+                "builtins.input",
+                side_effect=["  ACME  ", "  tech  ", "  NYC  ", "  parent corp  "],
+            ),
         ):
             ollama_attack(ctx)
 
@@ -396,13 +404,14 @@ class TestOllamaAttack:
         assert target_info["company"] == "ACME"
         assert target_info["industry"] == "tech"
         assert target_info["location"] == "NYC"
+        assert target_info["parent_company"] == "parent corp"
 
     def test_target_string_is_literal_target(self) -> None:
         ctx = _make_ctx()
 
         with (
             patch("hate_crack.attacks.interactive_menu", return_value="1"),
-            patch("builtins.input", side_effect=["X", "Y", "Z"]),
+            patch("builtins.input", side_effect=["X", "Y", "Z", ""]),
         ):
             ollama_attack(ctx)
 
@@ -528,7 +537,7 @@ class TestOllamaAttack:
 
         with (
             patch("hate_crack.attacks.interactive_menu", return_value="1"),
-            patch("builtins.input", side_effect=["ACME", "tech", "NYC"]),
+            patch("builtins.input", side_effect=["ACME", "tech", "NYC", ""]),
         ):
             ollama_attack(ctx)
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -612,6 +612,65 @@ def test_discovery_follows_a_valid_symlink(monkeypatch, tmp_path, name):
     assert found == str(link_path)
 
 
+@pytest.mark.parametrize("name", [".env", "config.json"])
+def test_discovery_does_not_warn_when_two_roots_share_one_symlinked_file(
+    monkeypatch, tmp_path, name
+):
+    """#246 review: the shadow-warning check must not fire a false positive
+    for the supported "one config symlinked into several checkouts" setup
+    (see :func:`_config_file_is_usable`'s docstring and
+    ``test_discovery_follows_a_valid_symlink`` above). Two candidate roots
+    that both symlink to the *same* shared real file are not shadowing one
+    another -- both paths resolve to the identical file, so nothing is
+    actually being ignored.
+    """
+    _require_symlinks(tmp_path)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    target = shared / name
+    target.write_text("OLLAMA_MODEL=synthetic-model\n" if name == ".env" else "{}")
+
+    higher = tmp_path / "higher"
+    lower = tmp_path / "lower"
+    higher.mkdir()
+    lower.mkdir()
+    higher_link = higher / name
+    lower_link = lower / name
+    os.symlink(target, higher_link)
+    os.symlink(target, lower_link)
+
+    monkeypatch.setattr(
+        config_loader, "candidate_roots", lambda: [str(higher), str(lower)]
+    )
+    env_path, json_path, warnings = config_loader.resolve_config_paths()
+
+    winner = env_path if name == ".env" else json_path
+    assert winner == str(higher_link)
+    assert warnings == []
+
+
+def test_discovery_does_not_warn_when_one_root_is_a_symlink_to_another(
+    monkeypatch, tmp_path
+):
+    """Same false-positive risk, other direction: a candidate *root* is
+    itself a symlink to a different candidate root, so their config.json is
+    the same file by construction, not two separate copies."""
+    _require_symlinks(tmp_path)
+    real_root = tmp_path / "real_root"
+    real_root.mkdir()
+    (real_root / "config.json").write_text("{}")
+    linked_root = tmp_path / "linked_root"
+    os.symlink(real_root, linked_root)
+
+    monkeypatch.setattr(
+        config_loader, "candidate_roots", lambda: [str(linked_root), str(real_root)]
+    )
+    _env_path, json_path, warnings = config_loader.resolve_config_paths()
+
+    assert json_path == str(linked_root / "config.json")
+    assert warnings == []
+
+
 def test_discovery_ignores_a_directory_named_like_a_config_file(monkeypatch, tmp_path):
     """Why ``os.path.isfile()`` stays the positive test instead of collapsing
     the gate into ``os.path.exists()``: a *directory* called ``.env`` is not a
@@ -674,3 +733,31 @@ def test_discovery_does_not_warn_when_only_one_root_has_the_file(monkeypatch, tm
     _env_path, _json_path, warnings = config_loader.resolve_config_paths()
 
     assert warnings == []
+
+
+def test_discovery_warns_once_per_shadowed_root_with_three_roots(monkeypatch, tmp_path):
+    """``candidate_roots()`` returns three real directories (repo root,
+    package directory, ``~/.hate_crack``), not two. With a distinct
+    config.json at every one of them, discovery must warn once per shadowed
+    (lower-priority) root -- two warnings, not one and not three -- while the
+    highest-priority root still wins.
+    """
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    third = tmp_path / "third"
+    for root in (first, second, third):
+        root.mkdir()
+        (root / "config.json").write_text("{}")
+
+    monkeypatch.setattr(
+        config_loader,
+        "candidate_roots",
+        lambda: [str(first), str(second), str(third)],
+    )
+    _env_path, json_path, warnings = config_loader.resolve_config_paths()
+
+    assert json_path == str(first / "config.json")
+    assert len(warnings) == 2
+    assert all(str(first / "config.json") in w for w in warnings)
+    assert any(str(second / "config.json") in w for w in warnings)
+    assert any(str(third / "config.json") in w for w in warnings)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -550,9 +550,10 @@ def test_json_missing_new_keys_gets_defaults(tmp_path):
 
 
 def test_resolve_config_paths_returns_tuple():
-    env_path, legacy_json_path = resolve_config_paths()
+    env_path, legacy_json_path, warnings = resolve_config_paths()
     assert env_path is None or isinstance(env_path, str)
     assert legacy_json_path is None or isinstance(legacy_json_path, str)
+    assert warnings == []
 
 
 def _require_symlinks(tmp_path):
@@ -605,7 +606,7 @@ def test_discovery_follows_a_valid_symlink(monkeypatch, tmp_path, name):
     link_path = tmp_path / name
     os.symlink(target, link_path)
 
-    env_path, json_path = _discover_in(monkeypatch, tmp_path)
+    env_path, json_path, _warnings = _discover_in(monkeypatch, tmp_path)
 
     found = env_path if name == ".env" else json_path
     assert found == str(link_path)
@@ -618,8 +619,58 @@ def test_discovery_ignores_a_directory_named_like_a_config_file(monkeypatch, tmp
     (tmp_path / ".env").mkdir()
     (tmp_path / "config.json").mkdir()
 
-    assert _discover_in(monkeypatch, tmp_path) == (None, None)
+    assert _discover_in(monkeypatch, tmp_path) == (None, None, [])
 
 
 def test_discovery_reports_a_genuinely_absent_file_as_none(monkeypatch, tmp_path):
-    assert _discover_in(monkeypatch, tmp_path) == (None, None)
+    assert _discover_in(monkeypatch, tmp_path) == (None, None, [])
+
+
+@pytest.mark.parametrize("name", [".env", "config.json"])
+def test_discovery_warns_when_a_lower_priority_file_is_shadowed(
+    monkeypatch, tmp_path, name
+):
+    """#246: a stray file at a higher-priority candidate root (e.g. a repo
+    checkout) can silently shadow a real one at a lower-priority root
+    (``~/.hate_crack``) forever, with no indication anything was ignored.
+
+    The winning path must not change -- higher-priority still wins, exactly as
+    before -- but discovery must now say so, naming both paths.
+    """
+    higher = tmp_path / "higher"
+    lower = tmp_path / "lower"
+    higher.mkdir()
+    lower.mkdir()
+    higher_file = higher / name
+    lower_file = lower / name
+    body = "OLLAMA_MODEL=synthetic-model\n" if name == ".env" else "{}"
+    higher_file.write_text(body)
+    lower_file.write_text(body)
+
+    monkeypatch.setattr(
+        config_loader, "candidate_roots", lambda: [str(higher), str(lower)]
+    )
+    env_path, json_path, warnings = config_loader.resolve_config_paths()
+
+    winner = env_path if name == ".env" else json_path
+    assert winner == str(higher_file)
+    assert len(warnings) == 1
+    assert str(higher_file) in warnings[0]
+    assert str(lower_file) in warnings[0]
+
+
+def test_discovery_does_not_warn_when_only_one_root_has_the_file(monkeypatch, tmp_path):
+    """A clean single-location setup -- the overwhelmingly common case --
+    must produce no shadowing warning at all."""
+    higher = tmp_path / "higher"
+    lower = tmp_path / "lower"
+    higher.mkdir()
+    lower.mkdir()
+    (higher / "config.json").write_text("{}")
+
+    monkeypatch.setattr(
+        config_loader, "candidate_roots", lambda: [str(higher), str(lower)]
+    )
+    _env_path, _json_path, warnings = config_loader.resolve_config_paths()
+
+    assert warnings == []

--- a/tests/test_config_startup_wiring.py
+++ b/tests/test_config_startup_wiring.py
@@ -123,6 +123,41 @@ def test_case1_migrates_integration_keys_and_prunes_config_json(
     assert config["hcatPotfilePath"] == ""
 
 
+def test_first_migration_preserves_real_nonsecret_path_values(
+    bootstrap, tmp_path, capsys
+):
+    """Reproduces #246: on the FIRST migration of a pre-split, secrets-inline
+    config.json, non-secret path keys must keep their real values, not fall
+    back to schema defaults.
+
+    Deliberately uses a *minimal*, partial legacy body -- not the fully
+    populated 47-key fixture ``_pre_split_config()`` builds -- because a real
+    pre-split ``config.json`` in the wild need not carry every key the current
+    schema defines (older schema revisions, hand-trimmed files, etc.).
+    """
+    legacy_config = {
+        "hcatPath": "/opt/real/hashcat/",
+        "hcatWordlists": "/opt/real/wordlists/",
+        "hcatOptimizedWordlists": "/opt/real/optimized_wordlists",
+        "rules_directory": "/opt/real/hashcat/rules",
+        "hashview_api_key": "some-real-secret-value",
+        "hashmob_api_key": "another-real-secret-value",
+        "ollamaModel": "llama3",
+    }
+    legacy_path = tmp_path / "config.json"
+    legacy_path.write_text(json.dumps(legacy_config))
+
+    bootstrap(None, str(legacy_path))
+
+    migrated = json.loads(legacy_path.read_text())
+    assert migrated["hcatPath"] == "/opt/real/hashcat/"
+    assert migrated["hcatWordlists"] == "/opt/real/wordlists/"
+    assert migrated["hcatOptimizedWordlists"] == "/opt/real/optimized_wordlists"
+    assert migrated["rules_directory"] == "/opt/real/hashcat/rules"
+
+    capsys.readouterr()
+
+
 @pytest.mark.parametrize(
     "make_unusable",
     [
@@ -984,3 +1019,38 @@ def test_startup_prints_nothing_under_skip_init(capsys, monkeypatch, tmp_path):
         json_created=False,
     )
     assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# A stray config.json/.env at a higher-priority candidate root silently
+# shadows a real one at a lower-priority root -- resolve_config_paths()'s
+# warnings must actually reach the terminal (#246).
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_warnings_are_printed_after_config_sources(monkeypatch, capsys):
+    monkeypatch.setattr(hc_main, "SKIP_INIT", False)
+    hc_main._print_discovery_warnings(
+        [
+            "Using config.json at /higher/config.json, but another config.json "
+            "exists at /lower/config.json and is being ignored. If "
+            "/lower/config.json is your real configuration, remove or rename "
+            "the file at /higher/config.json."
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "/higher/config.json" in out
+    assert "/lower/config.json" in out
+    assert out.startswith("[!] ")
+
+
+def test_discovery_warnings_are_silent_under_skip_init(monkeypatch, capsys):
+    monkeypatch.setattr(hc_main, "SKIP_INIT", True)
+    hc_main._print_discovery_warnings(["some warning that must not print"])
+    assert capsys.readouterr().out == ""
+
+
+def test_discovery_warnings_print_nothing_when_there_are_none(monkeypatch, capsys):
+    monkeypatch.setattr(hc_main, "SKIP_INIT", False)
+    hc_main._print_discovery_warnings([])
+    assert capsys.readouterr().out == ""

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -898,6 +898,67 @@ class TestHashviewAPI:
             sent = api.session.post.call_args.args[1]
         assert sent == f"{ntlm}".encode() + b":" + plain_utf8
 
+    def test_upload_retries_batch_after_server_rejects_one_plaintext(
+        self, api, tmp_path, capsys
+    ):
+        """A Hashview that rejects one $HEX-fallback plaintext (embedded CR/LF,
+        server doesn't decode $HEX[...] on import) shouldn't sink the whole
+        batch -- retry without that line so the rest still uploads.
+
+        Regression for a live report: hate_crack correctly falls back to
+        sending $HEX[...] verbatim for a plaintext with an embedded newline
+        (inlining the raw bytes would corrupt this line-based upload), but a
+        Hashview that hashes that literal wrapper string instead of decoding
+        it rejects the line and rolls back its entire atomic import --
+        taking every other valid hash in the batch down with it.
+        """
+        newline_plain_bytes = SYNTH_PLAIN_A.encode("utf-8") + b"\n"
+        ntlm_newline = _digest_for_type("1000", newline_plain_bytes)
+        hex_wrapped = "$HEX[" + newline_plain_bytes.hex() + "]"
+
+        cracked_file = tmp_path / "cracked.txt"
+        cracked_file.write_bytes(
+            f"{ntlm_newline}:{hex_wrapped}\n".encode()
+            + f"{NTLM_B}:{SYNTH_PLAIN_B}\n".encode()
+        )
+
+        error_response = Mock()
+        error_response.json.return_value = {
+            "status": 500,
+            "type": "Error",
+            "msg": f"Plaintext for hash {ntlm_newline}, was found to be invalid.",
+        }
+        error_response.raise_for_status = Mock()
+
+        success_response = Mock()
+        success_response.json.return_value = {
+            "status": 200,
+            "type": "message",
+            "msg": "OK",
+            "verified": 1,
+            "updated": 1,
+            "unmatched": 0,
+        }
+        success_response.raise_for_status = Mock()
+
+        api.session.post.side_effect = [error_response, success_response]
+
+        result = api.upload_cracked_hashes(str(cracked_file), hash_type="1000")
+
+        assert api.session.post.call_count == 2
+        retry_body = api.session.post.call_args_list[1].kwargs.get("data")
+        if retry_body is None:
+            retry_body = api.session.post.call_args_list[1].args[1]
+        assert ntlm_newline.encode() not in retry_body
+        assert NTLM_B.encode() in retry_body
+
+        assert result["uploaded"] == 1
+        assert result["skipped"] == 1
+
+        out = capsys.readouterr().out
+        assert "Hashview rejected 1 plaintext" in out
+        assert ntlm_newline in out
+
     def test_upload_surfaces_client_counts(self, api, tmp_path):
         """upload_cracked_hashes reports uploaded/skipped even when the server
         returns a bare OK with no counts of its own."""

--- a/tests/test_hashview_cli_subcommands_subprocess.py
+++ b/tests/test_hashview_cli_subcommands_subprocess.py
@@ -46,7 +46,7 @@ def _resolved_hashview_config():
     original = config_loader.candidate_roots
     config_loader.candidate_roots = _REAL_CANDIDATE_ROOTS
     try:
-        env_path, legacy_json_path = config_loader.resolve_config_paths()
+        env_path, legacy_json_path, _warnings = config_loader.resolve_config_paths()
         resolved = config_loader.load_config(
             env_path=env_path, legacy_json_path=legacy_json_path
         ).config

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -267,11 +267,12 @@ def test_api_timeout_reraised_as_domain_error():
 # ---------------------------------------------------------------------------
 
 
-def _patch_research_agent(industry, location):
+def _patch_research_agent(industry, location, parent_company=""):
     """Patch client builders + AtomicAgent for a research call. No network."""
     result = mock.MagicMock()
     result.industry = industry
     result.location = location
+    result.parent_company = parent_company
 
     agent_instance = mock.MagicMock()
     agent_instance.run.return_value = result
@@ -382,6 +383,36 @@ def test_clean_research_field_collapses_internal_whitespace():
     assert llm.clean_research_field("commercial   \n construction") == (
         "commercial construction"
     )
+
+
+def test_research_target_includes_parent_company_field():
+    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_research_agent(
+        "healthcare", "Boston, Massachusetts", "Acquired by Global Health Corp in 2023"
+    )
+    with p_instr, p_openai, p_agent:
+        out = llm.research_target(
+            "http://localhost:11434",
+            "qwen2.5:32b",
+            2048,
+            "Acme Health Services",
+            no_cloud=False,
+        )
+    assert out.parent_company == "Acquired by Global Health Corp in 2023"
+
+
+def test_research_target_handles_empty_parent_company():
+    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_research_agent(
+        "healthcare", "Boston, Massachusetts", ""
+    )
+    with p_instr, p_openai, p_agent:
+        out = llm.research_target(
+            "http://localhost:11434",
+            "qwen2.5:32b",
+            2048,
+            "Independent Clinic",
+            no_cloud=False,
+        )
+    assert out.parent_company == ""
 
 
 def _rosetta_suggestion(mask, custom_charsets=()):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -144,6 +144,58 @@ def test_target_mode_still_uses_target_prompt():
     assert config.system_prompt_generator is llm._TARGET_PROMPT
 
 
+def test_target_mode_includes_parent_company_when_present():
+    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent(
+        ["AcmeCorp2024"]
+    )
+    with p_instr, p_openai, p_agent:
+        llm.generate_candidates(
+            "http://localhost:11434",
+            "qwen2.5:32b",
+            2048,
+            "target",
+            {
+                "company": "AcmeCorp",
+                "industry": "Finance",
+                "location": "NYC",
+                "parent_company": "Acquired by Global Holdings in 2022",
+            },
+            no_cloud=False,
+        )
+    run_arg = agent_instance.run.call_args[0][0]
+    # Verify all fields are in the request.
+    assert "AcmeCorp" in run_arg.request
+    assert "Finance" in run_arg.request
+    assert "NYC" in run_arg.request
+    assert "Acquired by Global Holdings in 2022" in run_arg.request
+
+
+def test_target_mode_handles_empty_parent_company():
+    p_instr, p_openai, p_agent, agent_cls, agent_instance = _patch_agent(["Candidate1"])
+    with p_instr, p_openai, p_agent:
+        llm.generate_candidates(
+            "http://localhost:11434",
+            "qwen2.5:32b",
+            2048,
+            "target",
+            {
+                "company": "IndependentCorp",
+                "industry": "Tech",
+                "location": "SF",
+                "parent_company": "",
+            },
+            no_cloud=False,
+        )
+    run_arg = agent_instance.run.call_args[0][0]
+    # Verify required fields are present but no empty parens appear.
+    assert "IndependentCorp" in run_arg.request
+    assert "Tech" in run_arg.request
+    assert "SF" in run_arg.request
+    # Ensure that an empty parent_company doesn't add stray parentheses.
+    assert "( )" not in run_arg.request
+    assert "()" not in run_arg.request
+
+
 def test_cracked_prompt_is_offensive_not_denylist():
     """_CRACKED_PROMPT's objective is candidate generation, not denylist building."""
     rendered = llm._CRACKED_PROMPT.generate_prompt()

--- a/tests/test_ollama_target_research.py
+++ b/tests/test_ollama_target_research.py
@@ -55,15 +55,17 @@ class TestResearchPrefill:
         ctx.hcatOllamaResearchTarget.return_value = {
             "industry": "freight rail maintenance",
             "location": "Omaha, Nebraska",
+            "parent_company": "",
         }
 
-        recorder = _run_target_mode(ctx, ["Acme Rail", "", ""])
+        recorder = _run_target_mode(ctx, ["Acme Rail", "", "", ""])
 
         ctx.hcatOllamaResearchTarget.assert_called_once_with("Acme Rail")
         assert recorder.prompts == [
             "Company name: ",
             "Industry (freight rail maintenance): ",
             "Location (Omaha, Nebraska): ",
+            "Parent company / acquired by: ",
         ]
 
     def test_enter_accepts_the_suggested_defaults(self) -> None:
@@ -71,14 +73,16 @@ class TestResearchPrefill:
         ctx.hcatOllamaResearchTarget.return_value = {
             "industry": "healthcare",
             "location": "Austin, Texas",
+            "parent_company": "",
         }
 
-        _run_target_mode(ctx, ["Acme", "", ""])
+        _run_target_mode(ctx, ["Acme", "", "", ""])
 
         assert ctx.hcatOllama.call_args[0][3] == {
             "company": "Acme",
             "industry": "healthcare",
             "location": "Austin, Texas",
+            "parent_company": "",
         }
 
     def test_typed_input_overrides_the_default(self) -> None:
@@ -86,14 +90,16 @@ class TestResearchPrefill:
         ctx.hcatOllamaResearchTarget.return_value = {
             "industry": "healthcare",
             "location": "Austin, Texas",
+            "parent_company": "",
         }
 
-        _run_target_mode(ctx, ["Acme", "  banking  ", "Berlin"])
+        _run_target_mode(ctx, ["Acme", "  banking  ", "Berlin", ""])
 
         assert ctx.hcatOllama.call_args[0][3] == {
             "company": "Acme",
             "industry": "banking",
             "location": "Berlin",
+            "parent_company": "",
         }
 
     def test_partial_research_prefills_only_known_field(self) -> None:
@@ -101,25 +107,58 @@ class TestResearchPrefill:
         ctx.hcatOllamaResearchTarget.return_value = {
             "industry": "mining",
             "location": "",
+            "parent_company": "",
         }
 
-        recorder = _run_target_mode(ctx, ["Acme", "", "Perth"])
+        recorder = _run_target_mode(ctx, ["Acme", "", "Perth", ""])
 
         assert recorder.prompts[1] == "Industry (mining): "
         assert recorder.prompts[2] == "Location: "
+        assert recorder.prompts[3] == "Parent company / acquired by: "
         assert ctx.hcatOllama.call_args[0][3]["location"] == "Perth"
+
+    def test_partial_research_includes_parent_company_when_known(self) -> None:
+        ctx = _make_ctx()
+        ctx.hcatOllamaResearchTarget.return_value = {
+            "industry": "",
+            "location": "",
+            "parent_company": "Acquired by Global Holdings in 2022",
+        }
+
+        recorder = _run_target_mode(ctx, ["Acme", "", "", ""])
+
+        assert recorder.prompts[1] == "Industry: "
+        assert recorder.prompts[2] == "Location: "
+        assert (
+            recorder.prompts[3]
+            == "Parent company / acquired by (Acquired by Global Holdings in 2022): "
+        )
+        assert (
+            ctx.hcatOllama.call_args[0][3]["parent_company"]
+            == "Acquired by Global Holdings in 2022"
+        )
 
     def test_empty_research_falls_back_to_blank_prompts(self) -> None:
         ctx = _make_ctx()
-        ctx.hcatOllamaResearchTarget.return_value = {"industry": "", "location": ""}
+        ctx.hcatOllamaResearchTarget.return_value = {
+            "industry": "",
+            "location": "",
+            "parent_company": "",
+        }
 
-        recorder = _run_target_mode(ctx, ["Acme", "tech", "NYC"])
+        recorder = _run_target_mode(ctx, ["Acme", "tech", "NYC", ""])
 
-        assert recorder.prompts == ["Company name: ", "Industry: ", "Location: "]
+        assert recorder.prompts == [
+            "Company name: ",
+            "Industry: ",
+            "Location: ",
+            "Parent company / acquired by: ",
+        ]
         assert ctx.hcatOllama.call_args[0][3] == {
             "company": "Acme",
             "industry": "tech",
             "location": "NYC",
+            "parent_company": "",
         }
 
     def test_whitespace_only_research_is_treated_as_no_suggestion(self) -> None:
@@ -127,20 +166,27 @@ class TestResearchPrefill:
         ctx.hcatOllamaResearchTarget.return_value = {
             "industry": "   ",
             "location": "\t\n",
+            "parent_company": "  \n  ",
         }
 
-        recorder = _run_target_mode(ctx, ["Acme", "", ""])
+        recorder = _run_target_mode(ctx, ["Acme", "", "", ""])
 
-        assert recorder.prompts == ["Company name: ", "Industry: ", "Location: "]
+        assert recorder.prompts == [
+            "Company name: ",
+            "Industry: ",
+            "Location: ",
+            "Parent company / acquired by: ",
+        ]
 
     def test_overlong_suggestion_is_capped_in_the_prompt(self) -> None:
         ctx = _make_ctx()
         ctx.hcatOllamaResearchTarget.return_value = {
             "industry": "z" * 500,
             "location": "",
+            "parent_company": "",
         }
 
-        recorder = _run_target_mode(ctx, ["Acme", "", ""])
+        recorder = _run_target_mode(ctx, ["Acme", "", "", ""])
 
         assert recorder.prompts[1] == f"Industry ({'z' * llm.MAX_RESEARCH_FIELD_LEN}): "
         industry = ctx.hcatOllama.call_args[0][3]["industry"]
@@ -151,35 +197,51 @@ class TestResearchPrefill:
         ctx = _make_ctx()
         ctx.hcatOllamaResearchTarget.side_effect = RuntimeError("boom")
 
-        recorder = _run_target_mode(ctx, ["Acme", "tech", "NYC"])
+        recorder = _run_target_mode(ctx, ["Acme", "tech", "NYC", ""])
 
-        assert recorder.prompts == ["Company name: ", "Industry: ", "Location: "]
+        assert recorder.prompts == [
+            "Company name: ",
+            "Industry: ",
+            "Location: ",
+            "Parent company / acquired by: ",
+        ]
         ctx.hcatOllama.assert_called_once()
 
     def test_non_dict_research_result_falls_back(self) -> None:
         ctx = _make_ctx()
         ctx.hcatOllamaResearchTarget.return_value = None
 
-        recorder = _run_target_mode(ctx, ["Acme", "tech", "NYC"])
+        recorder = _run_target_mode(ctx, ["Acme", "tech", "NYC", ""])
 
-        assert recorder.prompts == ["Company name: ", "Industry: ", "Location: "]
+        assert recorder.prompts == [
+            "Company name: ",
+            "Industry: ",
+            "Location: ",
+            "Parent company / acquired by: ",
+        ]
 
     def test_blank_company_skips_research_entirely(self) -> None:
         ctx = _make_ctx()
 
-        recorder = _run_target_mode(ctx, ["", "tech", "NYC"])
+        recorder = _run_target_mode(ctx, ["", "tech", "NYC", ""])
 
         ctx.hcatOllamaResearchTarget.assert_not_called()
-        assert recorder.prompts == ["Company name: ", "Industry: ", "Location: "]
+        assert recorder.prompts == [
+            "Company name: ",
+            "Industry: ",
+            "Location: ",
+            "Parent company / acquired by: ",
+        ]
 
     def test_suggestions_are_labelled_as_guesses(self, capsys) -> None:
         ctx = _make_ctx()
         ctx.hcatOllamaResearchTarget.return_value = {
             "industry": "healthcare",
             "location": "Austin, Texas",
+            "parent_company": "",
         }
 
-        _run_target_mode(ctx, ["Acme", "", ""])
+        _run_target_mode(ctx, ["Acme", "", "", ""])
 
         out = capsys.readouterr().out
         assert "GUESSES" in out
@@ -187,9 +249,13 @@ class TestResearchPrefill:
 
     def test_no_guess_banner_when_research_returns_nothing(self, capsys) -> None:
         ctx = _make_ctx()
-        ctx.hcatOllamaResearchTarget.return_value = {"industry": "", "location": ""}
+        ctx.hcatOllamaResearchTarget.return_value = {
+            "industry": "",
+            "location": "",
+            "parent_company": "",
+        }
 
-        _run_target_mode(ctx, ["Acme", "", ""])
+        _run_target_mode(ctx, ["Acme", "", "", ""])
 
         assert "GUESSES" not in capsys.readouterr().out
 
@@ -198,15 +264,16 @@ class TestResearchPrefill:
         ctx.hcatOllamaResearchTarget.return_value = {
             "industry": "healthcare",
             "location": "Austin",
+            "parent_company": "",
         }
 
-        _run_target_mode(ctx, ["Acme", "", ""])
+        _run_target_mode(ctx, ["Acme", "", "", ""])
 
         args = ctx.hcatOllama.call_args[0]
         assert args[0] == "1800"
         assert args[1] == "/tmp/sha512.txt"
         assert args[2] == "target"
-        assert set(args[3]) == {"company", "industry", "location"}
+        assert set(args[3]) == {"company", "industry", "location", "parent_company"}
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +283,9 @@ class TestResearchPrefill:
 
 class TestHcatOllamaResearchTarget:
     def test_returns_researched_fields_and_shows_progress(self) -> None:
-        result = hc_main.llm.TargetResearchOutput(industry="mining", location="Perth")
+        result = hc_main.llm.TargetResearchOutput(
+            industry="mining", location="Perth", parent_company=""
+        )
         with (
             mock.patch.object(hc_main, "ollamaAutoResearch", True),
             mock.patch.object(hc_main, "ollamaModel", "qwen2.5:32b"),
@@ -226,13 +295,15 @@ class TestHcatOllamaResearchTarget:
         ):
             out = hc_main.hcatOllamaResearchTarget("Acme")
 
-        assert out == {"industry": "mining", "location": "Perth"}
+        assert out == {"industry": "mining", "location": "Perth", "parent_company": ""}
         # The call must be wrapped in the progress spinner, not look like a hang.
         assert spin.call_count == 1
         assert "Acme" in spin.call_args[0][0]
 
     def test_forwards_config_values_to_research_target(self) -> None:
-        result = hc_main.llm.TargetResearchOutput(industry="", location="")
+        result = hc_main.llm.TargetResearchOutput(
+            industry="", location="", parent_company=""
+        )
         with (
             mock.patch.object(hc_main, "ollamaAutoResearch", True),
             mock.patch.object(hc_main, "ollamaUrl", "http://localhost:11434"),
@@ -260,7 +331,7 @@ class TestHcatOllamaResearchTarget:
         ):
             out = hc_main.hcatOllamaResearchTarget("Acme")
 
-        assert out == {"industry": "", "location": ""}
+        assert out == {"industry": "", "location": "", "parent_company": ""}
         assert "timed out" in capsys.readouterr().out
 
     def test_connection_failure_degrades_to_blank_suggestions(self, capsys) -> None:
@@ -274,7 +345,7 @@ class TestHcatOllamaResearchTarget:
         ):
             out = hc_main.hcatOllamaResearchTarget("Acme")
 
-        assert out == {"industry": "", "location": ""}
+        assert out == {"industry": "", "location": "", "parent_company": ""}
         assert "unavailable" in capsys.readouterr().out
 
     def test_disabled_by_config_skips_the_model_call(self) -> None:
@@ -285,7 +356,7 @@ class TestHcatOllamaResearchTarget:
             out = hc_main.hcatOllamaResearchTarget("Acme")
 
         research.assert_not_called()
-        assert out == {"industry": "", "location": ""}
+        assert out == {"industry": "", "location": "", "parent_company": ""}
 
     def test_blank_company_skips_the_model_call(self) -> None:
         with (
@@ -295,7 +366,7 @@ class TestHcatOllamaResearchTarget:
             out = hc_main.hcatOllamaResearchTarget("")
 
         research.assert_not_called()
-        assert out == {"industry": "", "location": ""}
+        assert out == {"industry": "", "location": "", "parent_company": ""}
 
     def test_auto_research_default_is_enabled(self) -> None:
         assert hc_main.ollamaAutoResearch is True

--- a/tests/test_omen_attack.py
+++ b/tests/test_omen_attack.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 from unittest.mock import MagicMock, patch
 
@@ -135,6 +136,47 @@ class TestHcatOmenTrain:
         ):
             result = main_module.hcatOmenTrain("/nonexistent/file.txt")
         assert result is False
+
+    def test_gzipped_training_file_is_decompressed_before_training(
+        self, main_module, tmp_path
+    ):
+        """A .gz training wordlist must be transparently decompressed -- see #257."""
+        plaintext_content = b"corpus_word1\ncorpus_word2\ncorpus_word3\n"
+        gz_path = tmp_path / "corpus.txt.gz"
+        with gzip.open(gz_path, "wb") as f:
+            f.write(plaintext_content)
+
+        omen_dir = tmp_path / "omen"
+        omen_dir.mkdir()
+        create_bin = omen_dir / "createNG"
+        create_bin.touch()
+        create_bin.chmod(0o755)
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+
+        with (
+            patch.object(main_module, "_omen_dir", str(omen_dir)),
+            patch.object(main_module, "hcatOmenCreateBin", "createNG"),
+            patch("hate_crack.main._omen_model_dir", return_value=str(model_dir)),
+            patch("hate_crack.main.subprocess.Popen") as mock_popen,
+        ):
+            mock_proc = MagicMock()
+            mock_proc.wait.return_value = None
+            mock_proc.returncode = 0
+            mock_popen.return_value = mock_proc
+
+            result = main_module.hcatOmenTrain(str(gz_path))
+
+            assert result is True
+            mock_popen.assert_called_once()
+            cmd = mock_popen.call_args[0][0]
+            ipwdlist_index = cmd.index("--iPwdList") + 1
+            resolved_path = cmd[ipwdlist_index]
+            # The resolved path should be different from the original .gz path
+            # (proving decompression happened)
+            assert resolved_path != str(gz_path)
+            # The resolved path should not end with .gz
+            assert not resolved_path.endswith(".gz")
 
 
 class TestHcatOmen:

--- a/tests/test_upload_cracked_hashes.py
+++ b/tests/test_upload_cracked_hashes.py
@@ -1,9 +1,8 @@
 import os
 import json
 import pytest
-import tempfile
-from unittest.mock import Mock, patch
-from hate_crack.api import HashviewAPI, _digest_for_type, _md4
+from unittest.mock import Mock, patch, MagicMock
+from hate_crack.api import HashviewAPI
 
 
 def get_hashview_config():
@@ -35,30 +34,50 @@ def test_upload_cracked_hashes_from_file():
     assert result.get("type") != "Error"
 
 
-def test_ntlm_plaintext_with_leading_space_is_not_skipped(tmp_path):
-    """A genuine leading/trailing space in the cracked password must survive
-    re-validation — see #244. NTLM of " Newpass4" (leading space) is
-    ebc5560e1f9fc1de16638e92c1b52ce2.
-    """
-    hash_file = tmp_path / "cracked.txt"
-    hash_file.write_bytes(b"ebc5560e1f9fc1de16638e92c1b52ce2: Newpass4\n")
+def test_upload_cracked_hashes_preserves_plaintext_whitespace(tmp_path):
+    """A plaintext with leading/trailing spaces must not be flagged as a
+    hash/plaintext mismatch — see #244.
 
-    with patch("requests.Session") as mock_session_class:
-        mock_session = Mock()
-        mock_session_class.return_value = mock_session
+    A bare ``.strip()`` on the plaintext field before validation eats
+    whitespace that is part of the real password, desyncing it from the
+    hash it was validated against and causing a false-positive skip.
+    Regression test using synthetic plaintext with padded spaces.
+    """
+    from hate_crack.api import _digest_for_type
+
+    # Use synthetic plaintext, not a real password
+    synthetic_plain = "Synthetic-Example-Xxx"
+    padded_plain = " " + synthetic_plain + " "
+
+    # Compute the correct NTLM hash for the padded plaintext
+    padded_ntlm = _digest_for_type("1000", padded_plain.encode("utf-8"))
+
+    # Create the cracked hash:plaintext file
+    cracked_file = tmp_path / "cracked.txt"
+    cracked_file.write_text(f"{padded_ntlm}:{padded_plain}\n")
+
+    # Stub the cache functions to prevent writing to the real ~/.hate_crack directory
+    with patch(
+        "hate_crack.api.load_cache", return_value={}
+    ), patch("hate_crack.api.append_to_cache"), patch("requests.Session"):
+        api = HashviewAPI(base_url="http://example.invalid", api_key="unused")
+        api.session = MagicMock()
         mock_response = Mock()
         mock_response.json.return_value = {"imported": 1}
         mock_response.raise_for_status = Mock()
-        mock_session.post.return_value = mock_response
+        api.session.post.return_value = mock_response
 
-        api = HashviewAPI(base_url="http://example.invalid", api_key="unused")
-        result = api.upload_cracked_hashes(str(hash_file), hash_type="1000", validate=True)
+        result = api.upload_cracked_hashes(
+            str(cracked_file), hash_type="1000", validate=True
+        )
 
-        assert result["skipped"] == 0, f"plaintext with leading space should not be skipped, got {result}"
+        assert result["skipped"] == 0, (
+            f"plaintext with padded spaces should not be skipped, got {result}"
+        )
         assert result["uploaded"] == 1, f"should have uploaded 1 hash, got {result}"
 
-        # Verify the plaintext with its leading space was sent to Hashview
-        posted_body = mock_session.post.call_args.kwargs["data"]
-        assert b" Newpass4" in posted_body, (
-            "The leading space in the plaintext must reach Hashview intact, not stripped"
+        # Verify the plaintext with its leading/trailing spaces was sent to Hashview intact
+        posted_body = api.session.post.call_args.kwargs["data"]
+        assert padded_plain.encode() in posted_body, (
+            f"The padded plaintext '{padded_plain}' must reach Hashview intact, not stripped"
         )

--- a/tests/test_upload_cracked_hashes.py
+++ b/tests/test_upload_cracked_hashes.py
@@ -57,9 +57,11 @@ def test_upload_cracked_hashes_preserves_plaintext_whitespace(tmp_path):
     cracked_file.write_text(f"{padded_ntlm}:{padded_plain}\n")
 
     # Stub the cache functions to prevent writing to the real ~/.hate_crack directory
-    with patch(
-        "hate_crack.api.load_cache", return_value={}
-    ), patch("hate_crack.api.append_to_cache"), patch("requests.Session"):
+    with (
+        patch("hate_crack.api.load_cache", return_value={}),
+        patch("hate_crack.api.append_to_cache"),
+        patch("requests.Session"),
+    ):
         api = HashviewAPI(base_url="http://example.invalid", api_key="unused")
         api.session = MagicMock()
         mock_response = Mock()

--- a/tests/test_upload_cracked_hashes.py
+++ b/tests/test_upload_cracked_hashes.py
@@ -1,7 +1,9 @@
 import os
 import json
 import pytest
-from hate_crack.api import HashviewAPI
+import tempfile
+from unittest.mock import Mock, patch
+from hate_crack.api import HashviewAPI, _digest_for_type, _md4
 
 
 def get_hashview_config():
@@ -31,3 +33,32 @@ def test_upload_cracked_hashes_from_file():
     result = api.upload_cracked_hashes(file_path, hash_type="1000")
     assert result is not None
     assert result.get("type") != "Error"
+
+
+def test_ntlm_plaintext_with_leading_space_is_not_skipped(tmp_path):
+    """A genuine leading/trailing space in the cracked password must survive
+    re-validation — see #244. NTLM of " Newpass4" (leading space) is
+    ebc5560e1f9fc1de16638e92c1b52ce2.
+    """
+    hash_file = tmp_path / "cracked.txt"
+    hash_file.write_bytes(b"ebc5560e1f9fc1de16638e92c1b52ce2: Newpass4\n")
+
+    with patch("requests.Session") as mock_session_class:
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+        mock_response = Mock()
+        mock_response.json.return_value = {"imported": 1}
+        mock_response.raise_for_status = Mock()
+        mock_session.post.return_value = mock_response
+
+        api = HashviewAPI(base_url="http://example.invalid", api_key="unused")
+        result = api.upload_cracked_hashes(str(hash_file), hash_type="1000", validate=True)
+
+        assert result["skipped"] == 0, f"plaintext with leading space should not be skipped, got {result}"
+        assert result["uploaded"] == 1, f"should have uploaded 1 hash, got {result}"
+
+        # Verify the plaintext with its leading space was sent to Hashview
+        posted_body = mock_session.post.call_args.kwargs["data"]
+        assert b" Newpass4" in posted_body, (
+            "The leading space in the plaintext must reach Hashview intact, not stripped"
+        )


### PR DESCRIPTION
## Summary

Batch integration of nightly-dev into main, cutting v2.26.0.

- Added a regression test locking in that `upload_cracked_hashes` preserves leading/trailing whitespace in cracked plaintexts.
- LLM target research now recalls a parent company / acquisition history for the named organization (alongside industry and location) and uses it when generating password candidates.
- OMEN training now decompresses gzip-compressed training wordlists, matching the N-gram attack's existing behavior.
- Config resolution now warns when a `config.json`/`.env` at a higher-priority candidate root is shadowing one at a lower-priority root (`~/.hate_crack`), instead of silently ignoring the shadowed file.
- Also includes an unrelated concurrent fix: Hashview batch upload now retries after the server rejects one plaintext in a batch.

Closes #244
Closes #257
Closes #246
Closes #263

## Test plan

- [x] Full test suite green on nightly-dev tip (2272 passed, 41 skipped, 0 failed)
- [x] `ruff check` / `ruff format --check` clean (full prek scope)
- [x] `ty check --exit-zero-on-warning` — 55 pre-existing warning-level diagnostics, no new errors
- [x] `bandit` clean against baseline
- [x] Each fix independently reviewed and mutation-tested during implementation (see CHANGELOG for details)