### PR TITLE
release: integrate nightly-dev batch of 2026-08-13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 ## [Unreleased]
 
 ### Fixed
-- `tests/test_random_rules_attack.py`'s `load_cli_module()` now also preserves `hate_crack.hashview_cache` in `sys.modules` when purging other `hate_crack.*` modules for a fresh reload, matching the existing preservation of `hate_crack.api`/`hate_crack.attacks`. `hate_crack.api` imports `load_cache`/`append_to_cache` by name at module load time, so reloading `hashview_cache` while leaving `api` in place left `api`'s cache functions bound to a stale module object that `tests/conftest.py`'s `_isolate_hashview_cache` fixture could no longer patch — silently defeating cache test isolation for every test file running after `test_random_rules_attack.py` alphabetically and risking writes to the operator's real `~/.hate_crack/hashview_uploaded_cache.txt` (#264).
+- `tests/test_random_rules_attack.py`'s `load_cli_module()` now purges only `hate_crack.main`/`hate_crack` from `sys.modules` instead of deleting every `hate_crack.*` module except a hand-maintained preserve list. The old approach let any name-bound import (e.g. `hate_crack.api`'s `load_cache`/`append_to_cache`) drift out of sync with a reloaded module, which would silently defeat `tests/conftest.py`'s isolation fixtures and risk writes to the operator's real `~/.hate_crack` cache file (#264).
 
 ## [2.26.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
-## [Unreleased]
+## [2.26.1] - 2026-08-13
 
 ### Fixed
 - `tests/test_random_rules_attack.py`'s `load_cli_module()` now purges only `hate_crack.main`/`hate_crack` from `sys.modules` instead of deleting every `hate_crack.*` module except a hand-maintained preserve list. The old approach let any name-bound import (e.g. `hate_crack.api`'s `load_cache`/`append_to_cache`) drift out of sync with a reloaded module, which would silently defeat `tests/conftest.py`'s isolation fixtures and risk writes to the operator's real `~/.hate_crack` cache file (#264).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Fixed
+- `tests/test_random_rules_attack.py`'s `load_cli_module()` now also preserves `hate_crack.hashview_cache` in `sys.modules` when purging other `hate_crack.*` modules for a fresh reload, matching the existing preservation of `hate_crack.api`/`hate_crack.attacks`. `hate_crack.api` imports `load_cache`/`append_to_cache` by name at module load time, so reloading `hashview_cache` while leaving `api` in place left `api`'s cache functions bound to a stale module object that `tests/conftest.py`'s `_isolate_hashview_cache` fixture could no longer patch — silently defeating cache test isolation for every test file running after `test_random_rules_attack.py` alphabetically and risking writes to the operator's real `~/.hate_crack/hashview_uploaded_cache.txt` (#264).
+
 ## [2.26.0] - 2026-08-12
 
 ### Added

--- a/tests/test_random_rules_attack.py
+++ b/tests/test_random_rules_attack.py
@@ -11,7 +11,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 def load_cli_module():
     os.environ["HATE_CRACK_SKIP_INIT"] = "1"
-    _preserve = {"hate_crack.attacks", "hate_crack.api"}
+    _preserve = {"hate_crack.attacks", "hate_crack.api", "hate_crack.hashview_cache"}
     for key in list(sys.modules.keys()):
         # Preserve hate_crack.attacks and hate_crack.api - reloading them creates
         # new module objects that break __globals__ references held by functions
@@ -19,6 +19,17 @@ def load_cli_module():
         # In particular, hate_crack.api must be preserved so that mocks applied via
         # patch("hate_crack.api.*") in later tests (e.g. test_rule_download_parallel)
         # target the same module object that the already-imported functions reference.
+        #
+        # hate_crack.hashview_cache must be preserved for the same reason:
+        # hate_crack.api does `from hate_crack.hashview_cache import load_cache,
+        # append_to_cache` at module level, binding api's names directly to that
+        # module's function objects. If hashview_cache is reloaded here while api
+        # is preserved, api's load_cache/append_to_cache keep pointing at the OLD
+        # module's functions (whose __globals__ is the old module dict). Any later
+        # test's `_isolate_hashview_cache` fixture then patches the NEW module's
+        # _cache_path, which api's already-bound functions never see -- silently
+        # defeating the cache isolation and risking writes to the real
+        # ~/.hate_crack/hashview_uploaded_cache.txt (#264).
         if "hate_crack" in key and key not in _preserve:
             del sys.modules[key]
     spec = importlib.util.spec_from_file_location(
@@ -50,3 +61,25 @@ def test_generate_rules_crack_handler_calls_main(cli, tmp_path):
     with patch("builtins.input", side_effect=["100", str(wl)]):
         cli._attacks.generate_rules_crack(ctx)
     ctx.hcatGenerateRules.assert_called_once_with("1000", "/tmp/h.txt", 100, str(wl))
+
+
+def test_load_cli_module_preserves_hashview_cache_identity(cli):
+    """Regression test for #264.
+
+    load_cli_module() purges most `hate_crack.*` modules from sys.modules to
+    force a fresh reload, but must preserve `hate_crack.hashview_cache`
+    alongside `hate_crack.api`/`hate_crack.attacks`. `hate_crack.api` imports
+    `load_cache`/`append_to_cache` by name at module load time
+    (`from hate_crack.hashview_cache import ...`), binding those names
+    directly to that module's function objects. If hashview_cache were
+    reloaded here while api is preserved, api's load_cache/append_to_cache
+    would keep pointing at the OLD module's functions -- and a later test's
+    `_isolate_hashview_cache` conftest fixture, which patches the *current*
+    `hate_crack.hashview_cache` module's `_cache_path`, would silently fail
+    to isolate api's calls from the real `~/.hate_crack` cache file.
+    """
+    import hate_crack.api as api
+    import hate_crack.hashview_cache as hashview_cache
+
+    assert api.load_cache is hashview_cache.load_cache
+    assert api.append_to_cache is hashview_cache.append_to_cache

--- a/tests/test_random_rules_attack.py
+++ b/tests/test_random_rules_attack.py
@@ -10,28 +10,37 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 def load_cli_module():
+    """Load a fresh copy of the root ``hate_crack.py`` CLI shim.
+
+    This needs ``hate_crack.main`` (and the ``hate_crack`` package init that
+    re-exports it) to be re-executed, so a freshly added menu option is
+    visible even if an earlier test already imported and cached the old
+    module. Earlier revisions did this by deleting *every* ``hate_crack.*``
+    module from ``sys.modules`` except a hand-maintained preserve list
+    (``hate_crack.attacks``, ``hate_crack.api``, ...). That approach is
+    whack-a-mole: any module that does a name-binding import at module load
+    time (``from hate_crack.X import y``) ends up with a stale reference the
+    moment X is reloaded while the importer isn't -- because ``y`` is bound
+    to a specific function/class object whose ``__globals__``/identity is
+    fixed to the OLD module, not looked up live through ``sys.modules``. Each
+    such binding (``hate_crack.api``'s ``load_cache``/``append_to_cache``
+    from ``hate_crack.hashview_cache`` (#264), ``api``'s ``ConfigValueError``
+    from ``config_schema``, ``attacks``'s ``_notify`` from ``notify``, ...)
+    was a fresh entry that had to be discovered and added to the preserve
+    list one at a time, and a conftest fixture patching the reloaded module
+    silently stops reaching the code that actually runs.
+
+    The fix is to invert the list: purge only the two modules that actually
+    need to be fresh (``hate_crack.main`` and the ``hate_crack`` package
+    itself, since ``hate_crack.py`` does ``from hate_crack import main``) and
+    leave every other already-imported ``hate_crack.*`` submodule alone. That
+    keeps every name-binding import made anywhere else pointed at the same
+    module object conftest's isolation fixtures patch, with no per-binding
+    accounting required.
+    """
     os.environ["HATE_CRACK_SKIP_INIT"] = "1"
-    _preserve = {"hate_crack.attacks", "hate_crack.api", "hate_crack.hashview_cache"}
-    for key in list(sys.modules.keys()):
-        # Preserve hate_crack.attacks and hate_crack.api - reloading them creates
-        # new module objects that break __globals__ references held by functions
-        # imported at module level in other test files (test isolation violation).
-        # In particular, hate_crack.api must be preserved so that mocks applied via
-        # patch("hate_crack.api.*") in later tests (e.g. test_rule_download_parallel)
-        # target the same module object that the already-imported functions reference.
-        #
-        # hate_crack.hashview_cache must be preserved for the same reason:
-        # hate_crack.api does `from hate_crack.hashview_cache import load_cache,
-        # append_to_cache` at module level, binding api's names directly to that
-        # module's function objects. If hashview_cache is reloaded here while api
-        # is preserved, api's load_cache/append_to_cache keep pointing at the OLD
-        # module's functions (whose __globals__ is the old module dict). Any later
-        # test's `_isolate_hashview_cache` fixture then patches the NEW module's
-        # _cache_path, which api's already-bound functions never see -- silently
-        # defeating the cache isolation and risking writes to the real
-        # ~/.hate_crack/hashview_uploaded_cache.txt (#264).
-        if "hate_crack" in key and key not in _preserve:
-            del sys.modules[key]
+    sys.modules.pop("hate_crack.main", None)
+    sys.modules.pop("hate_crack", None)
     spec = importlib.util.spec_from_file_location(
         "hate_crack_cli", PROJECT_ROOT / "hate_crack.py"
     )
@@ -63,23 +72,52 @@ def test_generate_rules_crack_handler_calls_main(cli, tmp_path):
     ctx.hcatGenerateRules.assert_called_once_with("1000", "/tmp/h.txt", 100, str(wl))
 
 
-def test_load_cli_module_preserves_hashview_cache_identity(cli):
-    """Regression test for #264.
+def test_load_cli_module_in_main_menu_after_reload(cli):
+    """load_cli_module()'s narrow purge still produces a fresh CLI module."""
+    options = cli.get_main_menu_options()
+    assert "18" in options
 
-    load_cli_module() purges most `hate_crack.*` modules from sys.modules to
-    force a fresh reload, but must preserve `hate_crack.hashview_cache`
-    alongside `hate_crack.api`/`hate_crack.attacks`. `hate_crack.api` imports
-    `load_cache`/`append_to_cache` by name at module load time
-    (`from hate_crack.hashview_cache import ...`), binding those names
-    directly to that module's function objects. If hashview_cache were
-    reloaded here while api is preserved, api's load_cache/append_to_cache
-    would keep pointing at the OLD module's functions -- and a later test's
-    `_isolate_hashview_cache` conftest fixture, which patches the *current*
-    `hate_crack.hashview_cache` module's `_cache_path`, would silently fail
-    to isolate api's calls from the real `~/.hate_crack` cache file.
+
+def test_load_cli_module_preserves_name_bound_import_identity(cli):
+    """Regression test for #264 (and the module-identity-drift class it belongs to).
+
+    load_cli_module() forces a fresh reload of `hate_crack.main` (and the
+    `hate_crack` package init) so newly added state is visible, without
+    reloading every other already-imported `hate_crack.*` submodule. Several
+    modules bind names directly from another module at import time (`from
+    hate_crack.X import y`), e.g.:
+
+    - `hate_crack.api` imports `load_cache`/`append_to_cache` from
+      `hate_crack.hashview_cache` (#264's original report).
+    - `hate_crack.api` imports `ConfigValueError` from `hate_crack.config_schema`
+      -- a class-identity drift here would make `except ConfigValueError` in
+      `api.py` silently fail to catch an exception raised by a reloaded
+      `config_schema`.
+    - `hate_crack.attacks` imports `notify` as `_notify` from `hate_crack.notify`
+      -- drift here would mean `notify`'s `_settings`/`_run_consent`/
+      `_input_func` state (and conftest's `_isolate_notify_state` fixture,
+      which resets that module's state) silently stops applying to the
+      object `attacks` actually calls into.
+
+    The `cli` fixture only exercises a single `load_cli_module()` call, which
+    can't surface this class of bug by itself -- there is no earlier cached
+    module state to drift from on a first import. The drift only shows up
+    across a *second* call, which is exactly the real-world shape: one test
+    file already forced a reload, then a later test file's fixtures
+    re-trigger the module-level `from hate_crack.X import y` imports. So this
+    calls `load_cli_module()` again here to reproduce that shape within one
+    test. (Verified manually that with the old blanket-purge-except-preserve-
+    list implementation, all four assertions below fail after this second
+    call; under the current narrow-purge implementation they hold.)
     """
+    second_cli = load_cli_module()
+
     import hate_crack.api as api
+    import hate_crack.config_schema as config_schema
     import hate_crack.hashview_cache as hashview_cache
+    import hate_crack.notify as notify
 
     assert api.load_cache is hashview_cache.load_cache
     assert api.append_to_cache is hashview_cache.append_to_cache
+    assert api.ConfigValueError is config_schema.ConfigValueError
+    assert second_cli._attacks._notify is notify


### PR DESCRIPTION
## Summary

Batch integration of nightly-dev into main, cutting v2.26.1 (patch — fix-only batch).

- `load_cli_module()`'s test-harness sys.modules purge is now a narrow, targeted purge (`hate_crack.main`/`hate_crack` only) instead of a hand-maintained preserve-list. The old approach let any name-bound import elsewhere in the codebase silently drift out of identity with a reloaded module — confirmed live for `hate_crack.api`'s `load_cache`/`append_to_cache`/`ConfigValueError` and `hate_crack.attacks`'s `_notify` — which could defeat test isolation fixtures and risk writes to the operator's real `~/.hate_crack` cache file.

Closes #264

## Test plan

- [x] Full test suite green on nightly-dev tip (2274 passed, 41 skipped, 0 failed)
- [x] `ruff check` / `ruff format --check` clean (full prek scope)
- [x] `ty check --exit-zero-on-warning` — 55 pre-existing warning-level diagnostics, no new errors
- [x] `bandit` clean against baseline
- [x] New regression test mutation-verified against the prior (whack-a-mole) fix and the original bug