### PR TITLE
release: integrate nightly-dev batch of 2026-08-13 (v2.26.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 ## [Unreleased]
 
 ### Fixed
-- Fresh git worktrees' first `pytest` run would fail ~23 tests in hashcat_rosetta-dependent test files, all with "AssertionError: hcmask validity check failed". The issue: `git submodule update --init` was deferred to a test body, which runs *after* collection, but `hate_crack.main`'s module-level imports cache the ImportError if HashcatRosetta is not found at import time (collection phase). Submodule initialization is now part of `pytest_configure`, which runs *before* collection, so the import always sees populated submodules on the first run (#266).
+- Fresh git worktrees' first `pytest` run would fail ~23 tests in hashcat_rosetta-dependent test files, all with "AssertionError: hcmask validity check failed". The issue: `git submodule update --init` was deferred to a test body, which runs *after* collection, but `hate_crack.main`'s module-level imports cache the ImportError if HashcatRosetta is not found at import time (collection phase). Submodule initialization is now part of `pytest_configure`, which runs *before* collection, so the import always sees populated submodules on the first run. Additionally fixed: the guard logic now correctly detects git worktrees (where `.git` is a file, not a directory), checks submodule status before running update (so developers can intentionally move a submodule to a different commit/branch without pytest silently resetting it), adds a 600s timeout with network stalling protection and opt-out via `HATE_CRACK_SKIP_SUBMODULE_INIT=1` for CI environments, and avoids potential hangs from unresponsive networks or credential prompts (#266).
 
 ## [2.26.1] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Fixed
+- Fresh git worktrees' first `pytest` run would fail ~23 tests in hashcat_rosetta-dependent test files, all with "AssertionError: hcmask validity check failed". The issue: `git submodule update --init` was deferred to a test body, which runs *after* collection, but `hate_crack.main`'s module-level imports cache the ImportError if HashcatRosetta is not found at import time (collection phase). Submodule initialization is now part of `pytest_configure`, which runs *before* collection, so the import always sees populated submodules on the first run (#266).
+
 ## [2.26.1] - 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
-## [Unreleased]
+## [2.26.2] - 2026-08-13
 
 ### Fixed
 - Fresh git worktrees' first `pytest` run would fail ~23 tests in hashcat_rosetta-dependent test files, all with "AssertionError: hcmask validity check failed". The issue: `git submodule update --init` was deferred to a test body, which runs *after* collection, but `hate_crack.main`'s module-level imports cache the ImportError if HashcatRosetta is not found at import time (collection phase). Submodule initialization is now part of `pytest_configure`, which runs *before* collection, so the import always sees populated submodules on the first run. Additionally fixed: the guard logic now correctly detects git worktrees (where `.git` is a file, not a directory), checks submodule status before running update (so developers can intentionally move a submodule to a different commit/branch without pytest silently resetting it), adds a 600s timeout with network stalling protection and opt-out via `HATE_CRACK_SKIP_SUBMODULE_INIT=1` for CI environments, and avoids potential hangs from unresponsive networks or credential prompts (#266).

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,6 +15,7 @@ make coverage
 | Variable | Purpose |
 |----------|---------|
 | `HATE_CRACK_SKIP_INIT=1` | Skip binary/config validation at startup. Required in worktrees and CI where submodules are not built. `make test` sets this automatically. |
+| `HATE_CRACK_SKIP_SUBMODULE_INIT=1` | Skip submodule initialization in `pytest_configure`. Use in CI or network-restricted environments that manage submodules explicitly. Must be set to the exact string `"1"` (other truthy values are not recognized). |
 | `HASHMOB_TEST_REAL=1` | Enable live Hashmob connectivity tests |
 | `HASHVIEW_TEST_REAL=1` | Enable live Hashview CLI menu tests |
 | `WEAKPASS_TEST_REAL=1` | Enable live Weakpass CLI menu tests |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,7 +145,7 @@ def pytest_configure(config):
     _setup_local_hashview_if_enabled(config)
 
 
-def _ensure_submodules_initialized(config):
+def _ensure_submodules_initialized(config, repo_root=None):
     """Ensure submodules are initialized before test collection.
 
     This runs in pytest_configure — *before* test collection — so that
@@ -154,6 +154,12 @@ def _ensure_submodules_initialized(config):
     module level in hate_crack/main.py (~line 96-107), so a fresh-worktree
     first run would cache ROSETTA_IMPORT_ERROR if the submodule wasn't populated
     yet. See issue #266.
+
+    Args:
+        config: pytest Config object for issuing warnings.
+        repo_root: Optional explicit repo root path. If not provided, defaults to the
+            parent directory of this file (conftest.py). Allows testing with
+            alternative repos without mocking.
 
     No-op if:
     - HATE_CRACK_SKIP_SUBMODULE_INIT=1 is set (opt-out for CI/network-restricted envs)
@@ -164,7 +170,8 @@ def _ensure_submodules_initialized(config):
     import subprocess
     import shutil
 
-    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    if repo_root is None:
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
     # Opt-out: HATE_CRACK_SKIP_SUBMODULE_INIT=1 skips this hook entirely
     if os.environ.get("HATE_CRACK_SKIP_SUBMODULE_INIT") == "1":
@@ -184,7 +191,7 @@ def _ensure_submodules_initialized(config):
     # developer has intentionally moved to a different commit/branch.
     try:
         status_result = subprocess.run(
-            ["git", "submodule", "status"],
+            ["git", "submodule", "status", "--recursive"],
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,72 @@ def _isolate_hashview_cache(monkeypatch, tmp_path):
 
 
 def pytest_configure(config):
+    """Run setup before test collection.
+
+    - Ensure submodules are initialized (issue #266)
+    - Spin up + seed a local Hashview docker stack if enabled
+    """
+    _ensure_submodules_initialized(config)
+    _setup_local_hashview_if_enabled(config)
+
+
+def _ensure_submodules_initialized(config):
+    """Ensure submodules are initialized before test collection.
+
+    This runs in pytest_configure — *before* test collection — so that
+    hate_crack.main's module-level import always sees a populated HashcatRosetta/
+    on the very first run, not just the second. hashcat_rosetta is imported at
+    module level in hate_crack/main.py (~line 96-107), so a fresh-worktree
+    first run would cache ROSETTA_IMPORT_ERROR if the submodule wasn't populated
+    yet. See issue #266.
+
+    No-op if we're not in a git repo, or if git/git submodules are unavailable.
+    In a git worktree, the submodule directories might remain empty (submodule
+    update exits 0 but doesn't populate worktree dirs), which is expected and
+    not an error — just not all tests will be available.
+    """
+    import subprocess
+    import shutil
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+    # Guard: only attempt init if we're in a git repo with .gitmodules
+    has_git_dir = os.path.isdir(os.path.join(repo_root, ".git"))
+    has_gitmodules = os.path.isfile(os.path.join(repo_root, ".gitmodules"))
+    has_git_cmd = shutil.which("git") is not None
+
+    if not (has_git_dir and has_gitmodules and has_git_cmd):
+        return
+
+    # Try to init submodules
+    try:
+        result = subprocess.run(
+            ["git", "submodule", "update", "--init", "--recursive"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        # Don't fail if the command fails or if dirs remain empty (worktree case).
+        # Log a warning if something went wrong, but continue.
+        if result.returncode != 0:
+            config.issue_config_time_warning(
+                pytest.PytestWarning(
+                    f"git submodule update failed during pytest_configure "
+                    f"(some tests may fail): {result.stderr}"
+                ),
+                stacklevel=2,
+            )
+    except Exception as e:
+        config.issue_config_time_warning(
+            pytest.PytestWarning(
+                f"Failed to initialize submodules during pytest_configure: {e}"
+            ),
+            stacklevel=2,
+        )
+
+
+def _setup_local_hashview_if_enabled(config):
     """Spin up + seed a local Hashview docker stack for the live test suite.
 
     No-op unless ``HASHVIEW_TEST_LOCAL=1``. When enabled, brings up the stack

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,22 +165,24 @@ def _ensure_submodules_initialized(config):
 
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
-    # Guard: only attempt init if we're in a git repo with .gitmodules
-    has_git_dir = os.path.isdir(os.path.join(repo_root, ".git"))
+    # Guard: only attempt init if we're in a git repo with .gitmodules.
+    # .git can be either a directory (normal repo) or a file (git worktree).
+    has_git = os.path.exists(os.path.join(repo_root, ".git"))
     has_gitmodules = os.path.isfile(os.path.join(repo_root, ".gitmodules"))
     has_git_cmd = shutil.which("git") is not None
 
-    if not (has_git_dir and has_gitmodules and has_git_cmd):
+    if not (has_git and has_gitmodules and has_git_cmd):
         return
 
-    # Try to init submodules
+    # Try to init submodules. No timeout: a cold initial clone over the network
+    # can take much longer than 30s, and the Makefile's own `git submodule update`
+    # call has no timeout at all.
     try:
         result = subprocess.run(
             ["git", "submodule", "update", "--init", "--recursive"],
             cwd=repo_root,
             capture_output=True,
             text=True,
-            timeout=30,
         )
         # Don't fail if the command fails or if dirs remain empty (worktree case).
         # Log a warning if something went wrong, but continue.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,15 +155,20 @@ def _ensure_submodules_initialized(config):
     first run would cache ROSETTA_IMPORT_ERROR if the submodule wasn't populated
     yet. See issue #266.
 
-    No-op if we're not in a git repo, or if git/git submodules are unavailable.
-    In a git worktree, the submodule directories might remain empty (submodule
-    update exits 0 but doesn't populate worktree dirs), which is expected and
-    not an error — just not all tests will be available.
+    No-op if:
+    - HATE_CRACK_SKIP_SUBMODULE_INIT=1 is set (opt-out for CI/network-restricted envs)
+    - Not in a git repo with .gitmodules (tarball/non-git installs)
+    - git command unavailable
+    - All submodules are already initialized (fast path, zero subprocess work)
     """
     import subprocess
     import shutil
 
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+    # Opt-out: HATE_CRACK_SKIP_SUBMODULE_INIT=1 skips this hook entirely
+    if os.environ.get("HATE_CRACK_SKIP_SUBMODULE_INIT") == "1":
+        return
 
     # Guard: only attempt init if we're in a git repo with .gitmodules.
     # .git can be either a directory (normal repo) or a file (git worktree).
@@ -174,18 +179,61 @@ def _ensure_submodules_initialized(config):
     if not (has_git and has_gitmodules and has_git_cmd):
         return
 
-    # Try to init submodules. No timeout: a cold initial clone over the network
-    # can take much longer than 30s, and the Makefile's own `git submodule update`
-    # call has no timeout at all.
+    # Check submodule status first: only run update if any are uninitialized.
+    # This is the common-case fast path and avoids resetting submodules a
+    # developer has intentionally moved to a different commit/branch.
     try:
-        result = subprocess.run(
-            ["git", "submodule", "update", "--init", "--recursive"],
+        status_result = subprocess.run(
+            ["git", "submodule", "status"],
             cwd=repo_root,
             capture_output=True,
             text=True,
+            timeout=10,
         )
-        # Don't fail if the command fails or if dirs remain empty (worktree case).
-        # Log a warning if something went wrong, but continue.
+        if status_result.returncode == 0:
+            # "-" prefix means uninitialized; "+" means at wrong commit
+            needs_update = any(
+                line.startswith("-")
+                for line in status_result.stdout.split("\n")
+                if line.strip()
+            )
+            if not needs_update:
+                # All submodules are already initialized; nothing to do
+                return
+    except Exception:
+        # If status check fails, continue anyway and try the update
+        pass
+
+    # Print a notice before potentially long subprocess (for cold initial clones)
+    print("Initializing git submodules (first run may take a minute)…")
+
+    # Try to init submodules with hardened subprocess handling.
+    # - Timeout: 600s (10 min) for a cold initial clone over network, but not infinite.
+    # - GIT_TERMINAL_PROMPT=0: fail fast on credential prompts rather than hang.
+    # - stdin=DEVNULL: prevent interactive input from blocking.
+    # - http.lowSpeedLimit/Time: abort stalled-but-open connections within bounded time.
+    subprocess_env = os.environ.copy()
+    subprocess_env["GIT_TERMINAL_PROMPT"] = "0"
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-c",
+                "http.lowSpeedLimit=1000",
+                "-c",
+                "http.lowSpeedTime=60",
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            env=subprocess_env,
+            timeout=600,
+        )
         if result.returncode != 0:
             config.issue_config_time_warning(
                 pytest.PytestWarning(
@@ -194,6 +242,14 @@ def _ensure_submodules_initialized(config):
                 ),
                 stacklevel=2,
             )
+    except subprocess.TimeoutExpired:
+        config.issue_config_time_warning(
+            pytest.PytestWarning(
+                "git submodule update timed out during pytest_configure after 600s "
+                "(network stalled or blackholed). Set HATE_CRACK_SKIP_SUBMODULE_INIT=1 to skip."
+            ),
+            stacklevel=2,
+        )
     except Exception as e:
         config.issue_config_time_warning(
             pytest.PytestWarning(

--- a/tests/test_submodule_hashcat_utils.py
+++ b/tests/test_submodule_hashcat_utils.py
@@ -11,29 +11,71 @@ def _is_hashcat_utils_empty(path):
     return len(entries) == 0
 
 
+def test_submodule_status_check_identifies_uninitialized():
+    """Unit test: verify the status check logic correctly identifies uninitialized submodules.
+
+    This tests that the guard logic in _ensure_submodules_initialized would correctly
+    identify submodules that need updating (those with '-' prefix) vs. those that are
+    already initialized. This is a quick unit test that doesn't require a real worktree.
+    """
+    # Example git submodule status output with both initialized and uninitialized
+    status_output_with_uninitialized = """-c0e94cc274401da98599fab7c1971acdfe543c18 HashcatRosetta
+ 8bbf2baf7b341c8ec23ca91e44e0ac7d7fcc0355 hashcat-utils
++10aa99e30bb88a10052d389feb53f739254eb1d1 omen
+"""
+    # The guard logic checks for '-' prefix to detect uninitialized
+    uninitialized = [
+        line
+        for line in status_output_with_uninitialized.split("\n")
+        if line.strip().startswith("-")
+    ]
+    assert uninitialized, "Should detect uninitialized submodules with '-' prefix"
+    assert len(uninitialized) == 1, "Should find exactly one uninitialized submodule"
+
+    # Example output with all initialized
+    status_output_all_initialized = """ 8bbf2baf7b341c8ec23ca91e44e0ac7d7fcc0355 hashcat-utils
+ 10aa99e30bb88a10052d389feb53f739254eb1d1 omen
+ 4160061be78352adb2186619dd18be095da26340 princeprocessor
+"""
+    uninitialized = [
+        line
+        for line in status_output_all_initialized.split("\n")
+        if line.strip().startswith("-")
+    ]
+    assert not uninitialized, (
+        "Should find no uninitialized submodules when all are initialized"
+    )
+
+
 def test_hashcat_utils_submodule_populated():
-    """Assert hashcat-utils submodule is populated.
+    """Assert hashcat-utils submodule is populated after pytest_configure's init.
 
-    conftest.py's pytest_configure hook ensures this is initialized before
-    collection (see issue #266). This test serves as a runtime check that
-    the initialization was successful.
+    conftest.py's pytest_configure hook initializes submodules before collection
+    (see issue #266), so by the time a test runs, HashcatRosetta and hashcat-utils
+    should always be populated. This test serves as a regression check: if this
+    fails, it means the pytest_configure guard logic broke (e.g., reintroduced
+    the isdir-vs-exists bug, or the opt-out env var is unexpectedly set).
 
-    In a git worktree, submodule directories might remain empty (expected
-    behavior), so we skip the test in that case.
+    Only skip when there's genuinely no repo to work with (git unavailable, or
+    no .git/.gitmodules at all — e.g., a tarball/non-git install).
     """
     if shutil.which("git") is None:
         pytest.skip("git not available")
 
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+    # Skip only if not in a git repo at all (tarball install, etc.)
+    has_git = os.path.exists(os.path.join(repo_root, ".git"))
+    has_gitmodules = os.path.isfile(os.path.join(repo_root, ".gitmodules"))
+    if not (has_git and has_gitmodules):
+        pytest.skip("Not in a git repo with .gitmodules (non-repo install)")
+
     submodule_path = os.path.join(repo_root, "hashcat-utils")
 
-    # In a git worktree, submodule directories might remain empty (expected
-    # behavior — conftest already attempted to init them). Skip in that case.
-    if _is_hashcat_utils_empty(submodule_path):
-        pytest.skip(
-            "hashcat-utils submodule not populated (likely a git worktree); "
-            "run `git submodule update --init --recursive` in the main checkout"
-        )
-
-    # If we get here, submodule should be populated
-    assert not _is_hashcat_utils_empty(submodule_path)
+    # If pytest_configure's guard is working, this submodule should be populated.
+    # If it's empty, that's a regression of the guard logic.
+    assert not _is_hashcat_utils_empty(submodule_path), (
+        "hashcat-utils submodule is empty after pytest_configure ran. "
+        "Check that the guard logic in conftest.py._ensure_submodules_initialized() "
+        "is working correctly (e.g., os.path.exists check for .git, status check, etc.)"
+    )

--- a/tests/test_submodule_hashcat_utils.py
+++ b/tests/test_submodule_hashcat_utils.py
@@ -1,6 +1,7 @@
 import os
-import subprocess
 import shutil
+
+import pytest
 
 
 def _is_hashcat_utils_empty(path):
@@ -10,36 +11,29 @@ def _is_hashcat_utils_empty(path):
     return len(entries) == 0
 
 
-def test_hashcat_utils_submodule_initialized():
-    import pytest
+def test_hashcat_utils_submodule_populated():
+    """Assert hashcat-utils submodule is populated.
 
+    conftest.py's pytest_configure hook ensures this is initialized before
+    collection (see issue #266). This test serves as a runtime check that
+    the initialization was successful.
+
+    In a git worktree, submodule directories might remain empty (expected
+    behavior), so we skip the test in that case.
+    """
     if shutil.which("git") is None:
         pytest.skip("git not available")
 
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     submodule_path = os.path.join(repo_root, "hashcat-utils")
 
+    # In a git worktree, submodule directories might remain empty (expected
+    # behavior — conftest already attempted to init them). Skip in that case.
     if _is_hashcat_utils_empty(submodule_path):
-        result = subprocess.run(
-            ["git", "submodule", "update", "--init", "--recursive"],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
+        pytest.skip(
+            "hashcat-utils submodule not populated (likely a git worktree); "
+            "run `git submodule update --init --recursive` in the main checkout"
         )
-        assert result.returncode == 0, (
-            "git submodule update failed: "
-            f"stdout={result.stdout} stderr={result.stderr}"
-        )
-        # Git worktrees share the parent repo's submodules — `submodule update`
-        # exits 0 but does not populate the worktree's submodule dirs. When that
-        # happens, skip rather than fail: the test's intent is to flag missing
-        # initialization in normal checkouts, not to gate worktree workflows.
-        if _is_hashcat_utils_empty(submodule_path):
-            pytest.skip(
-                "hashcat-utils submodule not populated (likely a git worktree); "
-                "run `git submodule update --init --recursive` in the main checkout"
-            )
 
-    assert not _is_hashcat_utils_empty(submodule_path), (
-        "hashcat-utils submodule is empty. Run: git submodule update --init --recursive"
-    )
+    # If we get here, submodule should be populated
+    assert not _is_hashcat_utils_empty(submodule_path)

--- a/tests/test_submodule_hashcat_utils.py
+++ b/tests/test_submodule_hashcat_utils.py
@@ -11,42 +11,6 @@ def _is_hashcat_utils_empty(path):
     return len(entries) == 0
 
 
-def test_submodule_status_check_identifies_uninitialized():
-    """Unit test: verify the status check logic correctly identifies uninitialized submodules.
-
-    This tests that the guard logic in _ensure_submodules_initialized would correctly
-    identify submodules that need updating (those with '-' prefix) vs. those that are
-    already initialized. This is a quick unit test that doesn't require a real worktree.
-    """
-    # Example git submodule status output with both initialized and uninitialized
-    status_output_with_uninitialized = """-c0e94cc274401da98599fab7c1971acdfe543c18 HashcatRosetta
- 8bbf2baf7b341c8ec23ca91e44e0ac7d7fcc0355 hashcat-utils
-+10aa99e30bb88a10052d389feb53f739254eb1d1 omen
-"""
-    # The guard logic checks for '-' prefix to detect uninitialized
-    uninitialized = [
-        line
-        for line in status_output_with_uninitialized.split("\n")
-        if line.strip().startswith("-")
-    ]
-    assert uninitialized, "Should detect uninitialized submodules with '-' prefix"
-    assert len(uninitialized) == 1, "Should find exactly one uninitialized submodule"
-
-    # Example output with all initialized
-    status_output_all_initialized = """ 8bbf2baf7b341c8ec23ca91e44e0ac7d7fcc0355 hashcat-utils
- 10aa99e30bb88a10052d389feb53f739254eb1d1 omen
- 4160061be78352adb2186619dd18be095da26340 princeprocessor
-"""
-    uninitialized = [
-        line
-        for line in status_output_all_initialized.split("\n")
-        if line.strip().startswith("-")
-    ]
-    assert not uninitialized, (
-        "Should find no uninitialized submodules when all are initialized"
-    )
-
-
 def test_hashcat_utils_submodule_populated():
     """Assert hashcat-utils submodule is populated after pytest_configure's init.
 


### PR DESCRIPTION
## Summary

Batch integration of nightly-dev into main, cutting v2.26.2 (patch — fix-only batch).

- Fresh git worktrees' first `pytest` run failed ~23 tests in hashcat_rosetta-dependent test files. `git submodule update --init` was deferred to a test body, which runs after pytest collection — too late, since `hate_crack.main`'s module-level import caches the ImportError if HashcatRosetta isn't found at import time. Submodule initialization now runs in `pytest_configure`, before collection.
- Also fixes: git-worktree `.git`-is-a-file detection, a status-check-first fast path so pytest never silently resets a submodule a developer intentionally moved, a 600s timeout with network-stall/credential-prompt hardening (replacing a broken 30s timeout that could kill a cold clone), and an `HATE_CRACK_SKIP_SUBMODULE_INIT=1` opt-out for CI/network-restricted environments.

Closes #266

## Test plan

- [x] Full test suite green on nightly-dev tip (2274 passed, 41 skipped, 0 failed)
- [x] `ruff check` / `ruff format --check` clean (full prek scope)
- [x] `ty check --exit-zero-on-warning` — 55 pre-existing warning-level diagnostics, no new errors
- [x] `bandit` clean against baseline
- [x] Fix independently verified against genuinely cold worktrees (submodules unpopulated) three separate times across the review's fix-loop rounds, not just re-run in an already-touched worktree — this is what caught two real defects (a timeout too short for a cold clone, and a hang risk on a stalled/blackholed network) that would not have shown up otherwise