### PR TITLE
fix: extract cracked plaintext as the last field, not a fixed index

### DIFF
--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2070,7 +2070,9 @@ def lineCount(file):
         return 0
 
 
-def _write_delimited_field(input_path, output_path, field_index, delimiter=":"):
+def _write_delimited_field(
+    input_path, output_path, field_index, delimiter=":", last_field=False
+):
     try:
         with (
             open(input_path, "r", errors="replace") as src,
@@ -2078,6 +2080,13 @@ def _write_delimited_field(input_path, output_path, field_index, delimiter=":"):
         ):
             for line in src:
                 line = line.rstrip("\n")
+                if last_field:
+                    # Hash components for some modes (NetNTLM, Kerberos, ...)
+                    # embed their own colons, so the plaintext is only ever
+                    # reliably found as the last field, not a fixed index.
+                    if delimiter in line:
+                        dst.write(line.rsplit(delimiter, 1)[-1] + "\n")
+                    continue
                 parts = line.split(delimiter, field_index)
                 if len(parts) >= field_index:
                     dst.write(parts[field_index - 1] + "\n")
@@ -2467,7 +2476,9 @@ def _valid_hcmask(mask: object) -> bool:
 def hcatTopMask(hcatHashType, hcatHashFile, hcatTargetTime):
     global hcatMaskCount
     global hcatProcess
-    _write_delimited_field(f"{hcatHashFile}.out", f"{hcatHashFile}.working", 2)
+    _write_delimited_field(
+        f"{hcatHashFile}.out", f"{hcatHashFile}.working", 2, last_field=True
+    )
     hcatProcess = subprocess.Popen(
         [
             sys.executable,
@@ -2610,7 +2621,9 @@ def hcatFingerprint(
 
     crackedBefore = lineCount(hcatHashFile + ".out")
     while True:
-        _write_delimited_field(f"{hcatHashFile}.out", f"{hcatHashFile}.working", 2)
+        _write_delimited_field(
+            f"{hcatHashFile}.out", f"{hcatHashFile}.working", 2, last_field=True
+        )
         expander_bin = (
             hcatExpanderBin if expander_len == 7 else f"expander{expander_len}.bin"
         )
@@ -4747,7 +4760,9 @@ def hcatLMtoNT():
         out_path=f"{hcatHashFile}.lm.cracked",
     )
 
-    _write_delimited_field(f"{hcatHashFile}.lm.cracked", f"{hcatHashFile}.working", 2)
+    _write_delimited_field(
+        f"{hcatHashFile}.lm.cracked", f"{hcatHashFile}.working", 2, last_field=True
+    )
     converted = convert_hex("{hash_file}.working".format(hash_file=hcatHashFile))
     with open(
         "{hash_file}.working".format(hash_file=hcatHashFile), mode="w"
@@ -4812,7 +4827,7 @@ def hcatRecycle(hcatHashType, hcatHashFile, hcatNewPasswords):
     global hcatProcess
     working_file = hcatHashFile + ".working"
     if hcatNewPasswords > 0:
-        _write_delimited_field(f"{hcatHashFile}.out", working_file, 2)
+        _write_delimited_field(f"{hcatHashFile}.out", working_file, 2, last_field=True)
 
         converted = convert_hex(working_file)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -333,6 +333,32 @@ def test_line_count_and_write_helpers(tmp_path, monkeypatch):
     assert out_unique.read_text().splitlines() == ["2", "b"]
 
 
+def test_write_delimited_field_last_field_handles_embedded_colons(
+    tmp_path, monkeypatch
+):
+    """Hash components for modes like NetNTLM embed their own colons
+    (e.g. `user::domain:challenge:response:plain`), so the plaintext must be
+    read as the last field, not a fixed index."""
+    monkeypatch.setenv("HATE_CRACK_SKIP_INIT", "1")
+    from hate_crack import main as main_module
+
+    importlib.reload(main_module)
+
+    input_path = tmp_path / "input.txt"
+    input_path.write_text(
+        "simplehash:plain1\nuser::domain:challenge:response:plain2\nno-delim\n"
+    )
+    out_path = tmp_path / "out.txt"
+
+    assert (
+        main_module._write_delimited_field(
+            str(input_path), str(out_path), 2, last_field=True
+        )
+        is True
+    )
+    assert out_path.read_text().splitlines() == ["plain1", "plain2"]
+
+
 def test_get_customer_hashfiles_with_hashtype_filters(monkeypatch):
     hv = api.HashviewAPI("https://example", "key")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- `_write_delimited_field(..., field_index=2)` extracted the plaintext from `.out`/`.lm.cracked` lines by splitting from the left and taking the second field — correct only when the hash side contains zero colons of its own.
- Hash modes whose hash component embeds colons (NetNTLM's `user::domain:challenge:response:plain`, some Kerberos/PDF formats, ...) fed a fragment of the hash into downstream consumers instead of the real cracked password, silently degrading the Fingerprint expander, Top Mask's statsgen pass, LM-to-NT recombination, and rule Recycle for these hash types.
- Added a `last_field=True` mode that extracts via `rsplit(delimiter, 1)[-1]`, which is correct regardless of how many colons the hash side contains, and switched all four plaintext-extraction call sites to use it.

## Test plan
- [x] Added `test_write_delimited_field_last_field_handles_embedded_colons` covering a simple `hash:plain` line and a multi-colon-hash line (NetNTLM-style)
- [x] `python -m pytest tests/ -q` — 2381 passed, 46 skipped
- [x] `uv run ruff check` / `uv run ruff format --check` — clean