### PR TITLE
feat: close the gap between the Fingerprint Attack and its documented methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,7 +987,7 @@ Presents the user a choice of target cracking time to spend (default 4 hours).
 #### Fingerprint Attack
 https://hashcat.net/wiki/doku.php?id=fingerprint_attack
 
-Runs a fingerprint attack using passwords already cracked for the current session. Expander substring length escalates automatically (7, 14, 21, ... up to the chosen ceiling), and an optional wordlist can be combined against the expanded fragments in addition to self-combination.
+Runs a fingerprint attack using passwords already cracked for the current session. Expander substring length escalates automatically (7, 14, 21, ... up to the chosen ceiling), and an optional wordlist can be combined against the expanded fragments in addition to self-combination. Set `hcatFingerprintWordlist` in `config.json` to a default wordlist path so the prompt offers it instead of asking for a path every time; leave it as `""` to always ask (or skip).
 
 #### Combinator Attack
 https://hashcat.net/wiki/doku.php?id=combinator_attack

--- a/README.md
+++ b/README.md
@@ -987,7 +987,7 @@ Presents the user a choice of target cracking time to spend (default 4 hours).
 #### Fingerprint Attack
 https://hashcat.net/wiki/doku.php?id=fingerprint_attack
 
-Runs a fingerprint attack using passwords already cracked for the current session.
+Runs a fingerprint attack using passwords already cracked for the current session. Expander substring length escalates automatically (7, 14, 21, ... up to the chosen ceiling), and an optional wordlist can be combined against the expanded fragments in addition to self-combination.
 
 #### Combinator Attack
 https://hashcat.net/wiki/doku.php?id=combinator_attack

--- a/config.json.example
+++ b/config.json.example
@@ -10,6 +10,7 @@
   "hcatDictionaryWordlist": ["rockyou.txt"],
   "hcatCombinationWordlist": ["rockyou.txt","rockyou.txt"],
   "hcatHybridlist": ["rockyou.txt"],
+  "hcatFingerprintWordlist": "",
   "hcatMiddleCombinatorMasks": ["2","4"," ","-","_","+",",",".","&"],
   "hcatMiddleBaseList": "rockyou.txt",
   "hcatThoroughCombinatorMasks": ["0","1","2","3","4","5","6","7","8","9"," ","-","_","+",",","!","#","$","\"","%","&","'","(",")","*",".","/",":",";","<","=",">","?","@","[","\\","]","^","`","{","|","}","~"],

--- a/config.json.example
+++ b/config.json.example
@@ -10,7 +10,7 @@
   "hcatDictionaryWordlist": ["rockyou.txt"],
   "hcatCombinationWordlist": ["rockyou.txt","rockyou.txt"],
   "hcatHybridlist": ["rockyou.txt"],
-  "hcatFingerprintWordlist": "",
+  "hcatFingerprintWordlist": [],
   "hcatMiddleCombinatorMasks": ["2","4"," ","-","_","+",",",".","&"],
   "hcatMiddleBaseList": "rockyou.txt",
   "hcatThoroughCombinatorMasks": ["0","1","2","3","4","5","6","7","8","9"," ","-","_","+",",","!","#","$","\"","%","&","'","(",")","*",".","/",":",";","<","=",">","?","@","[","\\","]","^","`","{","|","}","~"],

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -314,9 +314,14 @@ def fingerprint_crack(ctx: Any) -> None:
             break
         print("Please enter an integer between 7 and 36.")
 
-    wordlist_raw = input(
-        "\nEnter a wordlist to combine expanded fragments against (blank to skip): "
-    ).strip()
+    _configure_readline(_wordlist_path_completer(ctx))
+    try:
+        wordlist_raw = input(
+            "\nEnter a wordlist to combine expanded fragments against "
+            "(tab to autocomplete, blank to skip): "
+        ).strip()
+    finally:
+        readline.set_completer(None)
 
     ctx.hcatFingerprint(
         ctx.hcatHashType,
@@ -714,12 +719,9 @@ def middle_combinator(ctx: Any) -> None:
     ctx.hcatMiddleCombinator(ctx.hcatHashType, ctx.hcatHashFile)
 
 
-def _prompt_wordlist_paths(ctx, max_count: int) -> list[str]:
-    """Prompt for wordlist paths one at a time with tab-autocomplete.
-
-    Stops when a blank line is entered or max_count paths have been collected.
-    Returns a list of resolved, valid file paths.
-    """
+def _wordlist_path_completer(ctx):
+    """Tab-completer for a wordlist path prompt, rooted at ctx.hcatWordlists
+    unless the user has typed an absolute/relative/home-anchored path."""
 
     def path_completer(text, state):
         base = ctx.hcatWordlists
@@ -739,7 +741,17 @@ def _prompt_wordlist_paths(ctx, max_count: int) -> list[str]:
         except IndexError:
             return None
 
-    _configure_readline(path_completer)
+    return path_completer
+
+
+def _prompt_wordlist_paths(ctx, max_count: int) -> list[str]:
+    """Prompt for wordlist paths one at a time with tab-autocomplete.
+
+    Stops when a blank line is entered or max_count paths have been collected.
+    Returns a list of resolved, valid file paths.
+    """
+
+    _configure_readline(_wordlist_path_completer(ctx))
 
     collected: list[str] = []
     count = 1

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -257,7 +257,11 @@ def extensive_crack(ctx: Any) -> None:
         ctx.hcatTopMask(ctx.hcatHashType, ctx.hcatHashFile, hcatTargetTime)
         ctx.hcatRecycle(ctx.hcatHashType, ctx.hcatHashFile, ctx.hcatMaskCount)
         ctx.hcatFingerprint(
-            ctx.hcatHashType, ctx.hcatHashFile, 7, run_hybrid_on_expanded=False
+            ctx.hcatHashType,
+            ctx.hcatHashFile,
+            max_expander_len=21,
+            run_hybrid_on_expanded=False,
+            unattended=True,
         )
         ctx.hcatRecycle(ctx.hcatHashType, ctx.hcatHashFile, ctx.hcatFingerprintCount)
         ctx.hcatCombination(ctx.hcatHashType, ctx.hcatHashFile)
@@ -297,24 +301,29 @@ def top_mask_crack(ctx: Any) -> None:
 def fingerprint_crack(ctx: Any) -> None:
     _notify.prompt_notify_for_attack("Fingerprint")
     while True:
-        raw = input("\nEnter expander max length (7-36) (7): ").strip()
+        raw = input("\nEnter max expander length to escalate to (7-36) (21): ").strip()
         if raw == "":
-            expander_len = 7
+            max_expander_len = 21
             break
         try:
-            expander_len = int(raw)
+            max_expander_len = int(raw)
         except ValueError:
             print("Please enter an integer between 7 and 36.")
             continue
-        if 7 <= expander_len <= 36:
+        if 7 <= max_expander_len <= 36:
             break
         print("Please enter an integer between 7 and 36.")
+
+    wordlist_raw = input(
+        "\nEnter a wordlist to combine expanded fragments against (blank to skip): "
+    ).strip()
 
     ctx.hcatFingerprint(
         ctx.hcatHashType,
         ctx.hcatHashFile,
-        expander_len,
+        max_expander_len=max_expander_len,
         run_hybrid_on_expanded=True,
+        dictionary_wordlist=wordlist_raw or None,
     )
 
 

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -305,17 +305,18 @@ def _prompt_fingerprint_wordlist(ctx) -> str:
     falling back to manual tab-completed entry, matching how
     combinator_crack/hybrid_crack offer their config defaults.
     """
-    if ctx.hcatFingerprintWordlist:
+    configured = ctx.hcatFingerprintWordlist[0] if ctx.hcatFingerprintWordlist else None
+    if configured:
         use_default = (
             input(
                 "\nCombine expanded fragments against configured wordlist "
-                f"'{ctx.hcatFingerprintWordlist}'? (Y/n): "
+                f"'{configured}'? (Y/n): "
             )
             .strip()
             .lower()
         )
         if use_default != "n":
-            return ctx.hcatFingerprintWordlist
+            return configured
 
     _configure_readline(_wordlist_path_completer(ctx))
     try:

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -297,6 +297,36 @@ def top_mask_crack(ctx: Any) -> None:
     ctx.hcatTopMask(ctx.hcatHashType, ctx.hcatHashFile, hcatTargetTime)
 
 
+def _prompt_fingerprint_wordlist(ctx) -> str:
+    """Prompt for an optional wordlist to combine fingerprint fragments
+    against. Returns a path, or "" to skip.
+
+    Offers the configured hcatFingerprintWordlist default (if any) before
+    falling back to manual tab-completed entry, matching how
+    combinator_crack/hybrid_crack offer their config defaults.
+    """
+    if ctx.hcatFingerprintWordlist:
+        use_default = (
+            input(
+                "\nCombine expanded fragments against configured wordlist "
+                f"'{ctx.hcatFingerprintWordlist}'? (Y/n): "
+            )
+            .strip()
+            .lower()
+        )
+        if use_default != "n":
+            return ctx.hcatFingerprintWordlist
+
+    _configure_readline(_wordlist_path_completer(ctx))
+    try:
+        return input(
+            "\nEnter a wordlist to combine expanded fragments against "
+            "(tab to autocomplete, blank to skip): "
+        ).strip()
+    finally:
+        readline.set_completer(None)
+
+
 def fingerprint_crack(ctx: Any) -> None:
     _notify.prompt_notify_for_attack("Fingerprint")
     while True:
@@ -313,14 +343,7 @@ def fingerprint_crack(ctx: Any) -> None:
             break
         print("Please enter an integer between 7 and 36.")
 
-    _configure_readline(_wordlist_path_completer(ctx))
-    try:
-        wordlist_raw = input(
-            "\nEnter a wordlist to combine expanded fragments against "
-            "(tab to autocomplete, blank to skip): "
-        ).strip()
-    finally:
-        readline.set_completer(None)
+    wordlist_raw = _prompt_fingerprint_wordlist(ctx)
 
     while True:
         limit_raw = input(
@@ -349,7 +372,7 @@ def fingerprint_crack(ctx: Any) -> None:
         ctx.hcatHashFile,
         max_expander_len=max_expander_len,
         run_hybrid_on_expanded=True,
-        dictionary_wordlist=wordlist_raw or None,
+        dictionary_wordlist=wordlist_raw,
         keyspace_limit=keyspace_limit,
     )
 

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -261,7 +261,6 @@ def extensive_crack(ctx: Any) -> None:
             ctx.hcatHashFile,
             max_expander_len=21,
             run_hybrid_on_expanded=False,
-            unattended=True,
         )
         ctx.hcatRecycle(ctx.hcatHashType, ctx.hcatHashFile, ctx.hcatFingerprintCount)
         ctx.hcatCombination(ctx.hcatHashType, ctx.hcatHashFile)

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -322,12 +322,35 @@ def fingerprint_crack(ctx: Any) -> None:
     finally:
         readline.set_completer(None)
 
+    while True:
+        limit_raw = input(
+            "\nSkip a combination step if it would exceed this many candidates "
+            "(default 50,000,000,000, 0 for no limit): "
+        ).strip()
+        if limit_raw == "":
+            keyspace_limit = None  # hcatFingerprint applies its own default
+            break
+        try:
+            keyspace_limit = int(limit_raw)
+        except ValueError:
+            print("Please enter a non-negative integer.")
+            continue
+        if keyspace_limit < 0:
+            print("Please enter a non-negative integer.")
+            continue
+        if keyspace_limit == 0:
+            print(
+                "[!] No limit: an oversized combination could run for a very long time."
+            )
+        break
+
     ctx.hcatFingerprint(
         ctx.hcatHashType,
         ctx.hcatHashFile,
         max_expander_len=max_expander_len,
         run_hybrid_on_expanded=True,
         dictionary_wordlist=wordlist_raw or None,
+        keyspace_limit=keyspace_limit,
     )
 
 

--- a/hate_crack/config_schema.py
+++ b/hate_crack/config_schema.py
@@ -144,6 +144,7 @@ CONFIG_SCHEMA: tuple[ConfigKey, ...] = (
         ["rockyou.txt", "rockyou.txt"],
     ),
     ConfigKey("HCAT_HYBRIDLIST", "hcatHybridlist", "csv_list", ["rockyou.txt"]),
+    ConfigKey("HCAT_FINGERPRINT_WORDLIST", "hcatFingerprintWordlist", "str", ""),
     ConfigKey(
         "HCAT_MIDDLE_COMBINATOR_MASKS",
         "hcatMiddleCombinatorMasks",

--- a/hate_crack/config_schema.py
+++ b/hate_crack/config_schema.py
@@ -144,7 +144,7 @@ CONFIG_SCHEMA: tuple[ConfigKey, ...] = (
         ["rockyou.txt", "rockyou.txt"],
     ),
     ConfigKey("HCAT_HYBRIDLIST", "hcatHybridlist", "csv_list", ["rockyou.txt"]),
-    ConfigKey("HCAT_FINGERPRINT_WORDLIST", "hcatFingerprintWordlist", "str", ""),
+    ConfigKey("HCAT_FINGERPRINT_WORDLIST", "hcatFingerprintWordlist", "csv_list", []),
     ConfigKey(
         "HCAT_MIDDLE_COMBINATOR_MASKS",
         "hcatMiddleCombinatorMasks",

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2602,99 +2602,224 @@ def hcatRosettaMask(hcatHashType, hcatHashFile, description):
     _run_hcat_cmd(cmd, attack_name="Rosetta Mask", hash_file=hcatHashFile)
 
 
+_FINGERPRINT_KEYSPACE_LIMIT = 50_000_000_000
+
+
+def _fingerprint_expander_chain(max_expander_len):
+    """Escalating substring lengths to expand at, small to big.
+
+    E.g. max_expander_len=21 -> [7, 14, 21]; 24 -> [7, 14, 21, 24].
+    """
+    lengths = set(range(7, max_expander_len, 7))
+    lengths.add(max_expander_len)
+    return sorted(n for n in lengths if 7 <= n <= max_expander_len)
+
+
+def _fingerprint_keyspace_guard(left_path, right_path, label, unattended):
+    """Return True if a -a1 combination of left/right should proceed.
+
+    -a1's candidate count is exactly len(left) * len(right); on a
+    partially-cracked hash list this can run into the billions, so this
+    is checked before spending GPU time on it rather than after.
+    """
+    keyspace = lineCount(left_path) * lineCount(right_path)
+    if keyspace <= _FINGERPRINT_KEYSPACE_LIMIT:
+        return True
+    print(
+        f"[!] {label}: {keyspace:,} candidates exceeds the "
+        f"{_FINGERPRINT_KEYSPACE_LIMIT:,}-candidate guardrail."
+    )
+    if unattended:
+        print(f"[!] Skipping {label} (unattended mode).")
+        return False
+    return input(f"Proceed with {label} anyway? (y/N): ").strip().lower() == "y"
+
+
+def _fingerprint_expand_new(expander_len, hcatHashFile, new_plaintexts):
+    """Expand only newly-cracked plaintexts and merge the fragments into the
+    accumulating {hcatHashFile}.expanded file (deduped).
+
+    Only expanding the delta (not the whole cracked corpus) keeps each
+    convergence-loop iteration's cost proportional to what changed, since
+    the expander + combinator steps this feeds are the expensive part.
+    """
+    global hcatProcess
+
+    expander_bin = (
+        hcatExpanderBin if expander_len == 7 else f"expander{expander_len}.bin"
+    )
+    expander_path = os.path.join(hate_path, "hashcat-utils", "bin", expander_bin)
+    ensure_binary(
+        expander_path,
+        build_dir=os.path.join(hate_path, "hashcat-utils"),
+        name=expander_bin.replace(".bin", ""),
+    )
+
+    delta_path = f"{hcatHashFile}.working.new"
+    with open(delta_path, "w") as f:
+        f.write("\n".join(new_plaintexts) + "\n")
+
+    delta_expanded_path = f"{hcatHashFile}.expanded.delta"
+    with (
+        open(delta_path, "rb") as src,
+        open(delta_expanded_path, "wb") as dst,
+    ):
+        expander_proc = subprocess.Popen(
+            [expander_path], stdin=src, stdout=subprocess.PIPE
+        )
+        expander_stdout = expander_proc.stdout
+        if expander_stdout is None:
+            raise RuntimeError("expander stdout pipe was not created")
+        sort_proc = subprocess.Popen(
+            ["sort", "-u"],
+            stdin=expander_stdout,
+            stdout=dst,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+        hcatProcess = sort_proc
+        expander_stdout.close()
+        try:
+            sort_proc.wait()
+            expander_proc.wait()
+        except KeyboardInterrupt:
+            print("Killing PID {0}...".format(str(sort_proc.pid)))
+            sort_proc.kill()
+            expander_proc.kill()
+
+    expanded_path = f"{hcatHashFile}.expanded"
+    fragments = set()
+    if os.path.exists(expanded_path):
+        with open(expanded_path, errors="replace") as f:
+            fragments = {line.rstrip("\n") for line in f if line.strip()}
+    with open(delta_expanded_path, errors="replace") as f:
+        fragments |= {line.rstrip("\n") for line in f if line.strip()}
+    with open(expanded_path, "w") as f:
+        for fragment in sorted(fragments):
+            f.write(fragment + "\n")
+
+
+def _fingerprint_combine(hcatHashType, hcatHashFile, left, right, *, label, unattended):
+    """Run a -a1 combination of left+right, gated by the keyspace guardrail.
+
+    Every side gets a cheap -j/-k capitalize rule for free Capitalized
+    coverage of the raw fragments/dictionary words.
+    """
+    if not _fingerprint_keyspace_guard(left, right, label, unattended):
+        return
+    cmd = [
+        hcatBin,
+        "-m",
+        hcatHashType,
+        hcatHashFile,
+        "--session",
+        generate_session_id(),
+        "-o",
+        f"{hcatHashFile}.out",
+        "-a",
+        "1",
+        "-j",
+        "c",
+        "-k",
+        "c",
+        left,
+        right,
+    ]
+    if _should_use_optimized_kernel("hcatFingerprint"):
+        _insert_optimized_flag(cmd)
+    cmd.extend(shlex.split(hcatTuning))
+    _append_potfile_arg(cmd)
+    _run_hcat_cmd(cmd, attack_name="Fingerprint", hash_file=hcatHashFile)
+
+
 # Fingerprint Attack
 def hcatFingerprint(
     hcatHashType,
     hcatHashFile,
-    expander_len: int = 7,
+    max_expander_len: int = 21,
     run_hybrid_on_expanded: bool = False,
+    dictionary_wordlist: str | None = None,
+    unattended: bool = False,
 ):
     global hcatFingerprintCount
-    global hcatProcess
 
     try:
-        expander_len = int(expander_len)
+        max_expander_len = int(max_expander_len)
     except Exception:
-        expander_len = 7
-    if expander_len < 7 or expander_len > 36:
-        raise ValueError("expander_len must be an integer between 7 and 36")
+        max_expander_len = 21
+    if max_expander_len < 7 or max_expander_len > 36:
+        raise ValueError("max_expander_len must be an integer between 7 and 36")
 
-    crackedBefore = lineCount(hcatHashFile + ".out")
-    while True:
-        _write_delimited_field(
-            f"{hcatHashFile}.out", f"{hcatHashFile}.working", 2, last_field=True
-        )
-        expander_bin = (
-            hcatExpanderBin if expander_len == 7 else f"expander{expander_len}.bin"
-        )
-        expander_path = os.path.join(hate_path, "hashcat-utils", "bin", expander_bin)
-        ensure_binary(
-            expander_path,
-            build_dir=os.path.join(hate_path, "hashcat-utils"),
-            name=expander_bin.replace(".bin", ""),
-        )
-        with (
-            open(f"{hcatHashFile}.working", "rb") as src,
-            open(f"{hcatHashFile}.expanded", "wb") as dst,
-        ):
-            expander_proc = subprocess.Popen(
-                [expander_path], stdin=src, stdout=subprocess.PIPE
-            )
-            expander_stdout = expander_proc.stdout
-            if expander_stdout is None:
-                raise RuntimeError("expander stdout pipe was not created")
-            sort_proc = subprocess.Popen(
-                ["sort", "-u"],
-                stdin=expander_stdout,
-                stdout=dst,
-                env={**os.environ, "LC_ALL": "C"},
-            )
-            hcatProcess = sort_proc
-            expander_stdout.close()
-            try:
-                sort_proc.wait()
-                expander_proc.wait()
-            except KeyboardInterrupt:
-                print("Killing PID {0}...".format(str(sort_proc.pid)))
-                sort_proc.kill()
-                expander_proc.kill()
-        if lineCount(f"{hcatHashFile}.expanded") == 0:
-            print(
-                "[!] Skipping Fingerprint Attack: no candidates to expand "
-                "(no cracked passwords yet)."
-            )
-            break
-        fingerprint_cmd = [
-            hcatBin,
-            "-m",
-            hcatHashType,
-            hcatHashFile,
-            "--session",
-            generate_session_id(),
-            "-o",
-            f"{hcatHashFile}.out",
-            "-a",
-            "1",
-            f"{hcatHashFile}.expanded",
-            f"{hcatHashFile}.expanded",
-        ]
-        if _should_use_optimized_kernel("hcatFingerprint"):
-            _insert_optimized_flag(fingerprint_cmd)
-        fingerprint_cmd.extend(shlex.split(hcatTuning))
-        _append_potfile_arg(fingerprint_cmd)
-        _run_hcat_cmd(
-            fingerprint_cmd, attack_name="Fingerprint", hash_file=hcatHashFile
-        )
+    resolved_dict = None
+    if dictionary_wordlist:
+        candidate = _resolve_wordlist_path(dictionary_wordlist, hcatWordlists)
+        if os.path.isfile(candidate):
+            resolved_dict = candidate
+        else:
+            print(f"[!] Wordlist not found: {candidate}")
 
-        # Secondary attack: run hybrid on the expanded candidates (mode 6/7 variants).
-        # This is intentionally optional to avoid changing the "extensive" pipeline ordering.
-        if run_hybrid_on_expanded:
-            hcatHybrid(hcatHashType, hcatHashFile, [f"{hcatHashFile}.expanded"])
+    expanded_path = f"{hcatHashFile}.expanded"
+    open(expanded_path, "w").close()  # fresh accumulator for this attack run
 
-        crackedAfter = lineCount(hcatHashFile + ".out")
-        if crackedAfter == crackedBefore:
-            break
-        crackedBefore = crackedAfter
+    any_candidates = False
+    for expander_len in _fingerprint_expander_chain(max_expander_len):
+        seen_plaintexts: set[str] = set()
+        crackedBefore = lineCount(hcatHashFile + ".out")
+        while True:
+            _write_delimited_field(
+                f"{hcatHashFile}.out", f"{hcatHashFile}.working", 2, last_field=True
+            )
+            with open(f"{hcatHashFile}.working", errors="replace") as f:
+                current_plaintexts = {line.rstrip("\n") for line in f if line.strip()}
+            new_plaintexts = current_plaintexts - seen_plaintexts
+            if not new_plaintexts:
+                break
+            seen_plaintexts |= new_plaintexts
+
+            _fingerprint_expand_new(expander_len, hcatHashFile, sorted(new_plaintexts))
+            any_candidates = True
+
+            _fingerprint_combine(
+                hcatHashType,
+                hcatHashFile,
+                expanded_path,
+                expanded_path,
+                label=f"Fingerprint self-combination (length {expander_len})",
+                unattended=unattended,
+            )
+            if resolved_dict:
+                _fingerprint_combine(
+                    hcatHashType,
+                    hcatHashFile,
+                    expanded_path,
+                    resolved_dict,
+                    label=f"Fingerprint dictionary-combination (length {expander_len})",
+                    unattended=unattended,
+                )
+                _fingerprint_combine(
+                    hcatHashType,
+                    hcatHashFile,
+                    resolved_dict,
+                    expanded_path,
+                    label=f"Fingerprint dictionary-combination (length {expander_len})",
+                    unattended=unattended,
+                )
+
+            # Secondary attack: run hybrid on the expanded candidates (mode 6/7
+            # variants). Intentionally optional to avoid changing the
+            # "extensive" pipeline ordering.
+            if run_hybrid_on_expanded:
+                hcatHybrid(hcatHashType, hcatHashFile, [expanded_path])
+
+            crackedAfter = lineCount(hcatHashFile + ".out")
+            if crackedAfter == crackedBefore:
+                break
+            crackedBefore = crackedAfter
+
+    if not any_candidates:
+        print(
+            "[!] Skipping Fingerprint Attack: no candidates to expand "
+            "(no cracked passwords yet)."
+        )
     hcatFingerprintCount = lineCount(hcatHashFile + ".out") - hcatHashCracked
 
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2615,24 +2615,24 @@ def _fingerprint_expander_chain(max_expander_len):
     return sorted(n for n in lengths if 7 <= n <= max_expander_len)
 
 
-def _fingerprint_keyspace_guard(left_path, right_path, label, unattended):
+def _fingerprint_keyspace_guard(left_path, right_path, label):
     """Return True if a -a1 combination of left/right should proceed.
 
     -a1's candidate count is exactly len(left) * len(right); on a
     partially-cracked hash list this can run into the billions, so this
-    is checked before spending GPU time on it rather than after.
+    is checked before spending GPU time on it rather than after. Fingerprint
+    runs unattended for its whole duration (it's launched once, up front),
+    so an over-threshold combination is skipped with a warning rather than
+    blocking on a prompt mid-run.
     """
     keyspace = lineCount(left_path) * lineCount(right_path)
     if keyspace <= _FINGERPRINT_KEYSPACE_LIMIT:
         return True
     print(
         f"[!] {label}: {keyspace:,} candidates exceeds the "
-        f"{_FINGERPRINT_KEYSPACE_LIMIT:,}-candidate guardrail."
+        f"{_FINGERPRINT_KEYSPACE_LIMIT:,}-candidate guardrail. Skipping."
     )
-    if unattended:
-        print(f"[!] Skipping {label} (unattended mode).")
-        return False
-    return input(f"Proceed with {label} anyway? (y/N): ").strip().lower() == "y"
+    return False
 
 
 def _fingerprint_expand_new(expander_len, hcatHashFile, new_plaintexts):
@@ -2729,9 +2729,9 @@ def _fingerprint_run_combine(hcatHashType, hcatHashFile, left, right):
     _run_hcat_cmd(cmd, attack_name="Fingerprint", hash_file=hcatHashFile)
 
 
-def _fingerprint_combine(hcatHashType, hcatHashFile, left, right, *, label, unattended):
+def _fingerprint_combine(hcatHashType, hcatHashFile, left, right, *, label):
     """Run a -a1 combination of left+right, gated by the keyspace guardrail."""
-    if not _fingerprint_keyspace_guard(left, right, label, unattended):
+    if not _fingerprint_keyspace_guard(left, right, label):
         return
     _fingerprint_run_combine(hcatHashType, hcatHashFile, left, right)
 
@@ -2743,7 +2743,6 @@ def hcatFingerprint(
     max_expander_len: int = 21,
     run_hybrid_on_expanded: bool = False,
     dictionary_wordlist: str | None = None,
-    unattended: bool = False,
 ):
     global hcatFingerprintCount
 
@@ -2789,7 +2788,6 @@ def hcatFingerprint(
                 expanded_path,
                 expanded_path,
                 label=f"Fingerprint self-combination (length {expander_len})",
-                unattended=unattended,
             )
             if resolved_dict:
                 # Both orders share the same candidate count (len(a)*len(b)
@@ -2799,7 +2797,7 @@ def hcatFingerprint(
                     f"Fingerprint dictionary-combination (length {expander_len})"
                 )
                 if _fingerprint_keyspace_guard(
-                    expanded_path, resolved_dict, dict_label, unattended
+                    expanded_path, resolved_dict, dict_label
                 ):
                     _fingerprint_run_combine(
                         hcatHashType, hcatHashFile, expanded_path, resolved_dict

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2698,14 +2698,12 @@ def _fingerprint_expand_new(expander_len, hcatHashFile, new_plaintexts):
             f.write(fragment + "\n")
 
 
-def _fingerprint_combine(hcatHashType, hcatHashFile, left, right, *, label, unattended):
-    """Run a -a1 combination of left+right, gated by the keyspace guardrail.
+def _fingerprint_run_combine(hcatHashType, hcatHashFile, left, right):
+    """Run a -a1 combination of left+right (no guardrail check — caller's job).
 
     Every side gets a cheap -j/-k capitalize rule for free Capitalized
     coverage of the raw fragments/dictionary words.
     """
-    if not _fingerprint_keyspace_guard(left, right, label, unattended):
-        return
     cmd = [
         hcatBin,
         "-m",
@@ -2729,6 +2727,13 @@ def _fingerprint_combine(hcatHashType, hcatHashFile, left, right, *, label, unat
     cmd.extend(shlex.split(hcatTuning))
     _append_potfile_arg(cmd)
     _run_hcat_cmd(cmd, attack_name="Fingerprint", hash_file=hcatHashFile)
+
+
+def _fingerprint_combine(hcatHashType, hcatHashFile, left, right, *, label, unattended):
+    """Run a -a1 combination of left+right, gated by the keyspace guardrail."""
+    if not _fingerprint_keyspace_guard(left, right, label, unattended):
+        return
+    _fingerprint_run_combine(hcatHashType, hcatHashFile, left, right)
 
 
 # Fingerprint Attack
@@ -2787,22 +2792,21 @@ def hcatFingerprint(
                 unattended=unattended,
             )
             if resolved_dict:
-                _fingerprint_combine(
-                    hcatHashType,
-                    hcatHashFile,
-                    expanded_path,
-                    resolved_dict,
-                    label=f"Fingerprint dictionary-combination (length {expander_len})",
-                    unattended=unattended,
+                # Both orders share the same candidate count (len(a)*len(b)
+                # == len(b)*len(a)), so the guardrail is checked once and its
+                # answer applied to both instead of prompting twice.
+                dict_label = (
+                    f"Fingerprint dictionary-combination (length {expander_len})"
                 )
-                _fingerprint_combine(
-                    hcatHashType,
-                    hcatHashFile,
-                    resolved_dict,
-                    expanded_path,
-                    label=f"Fingerprint dictionary-combination (length {expander_len})",
-                    unattended=unattended,
-                )
+                if _fingerprint_keyspace_guard(
+                    expanded_path, resolved_dict, dict_label, unattended
+                ):
+                    _fingerprint_run_combine(
+                        hcatHashType, hcatHashFile, expanded_path, resolved_dict
+                    )
+                    _fingerprint_run_combine(
+                        hcatHashType, hcatHashFile, resolved_dict, expanded_path
+                    )
 
             # Secondary attack: run hybrid on the expanded candidates (mode 6/7
             # variants). Intentionally optional to avoid changing the

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1069,6 +1069,7 @@ pipalPath = config_parser["pipalPath"]
 hcatDictionaryWordlist = config_parser["hcatDictionaryWordlist"]
 hcatHybridlist = config_parser["hcatHybridlist"]
 hcatCombinationWordlist = config_parser["hcatCombinationWordlist"]
+hcatFingerprintWordlist = config_parser["hcatFingerprintWordlist"]
 hcatMiddleCombinatorMasks = config_parser["hcatMiddleCombinatorMasks"]
 hcatMiddleBaseList = config_parser["hcatMiddleBaseList"]
 hcatThoroughCombinatorMasks = config_parser["hcatThoroughCombinatorMasks"]
@@ -1256,6 +1257,9 @@ hcatCombinationWordlist = _normalize_wordlist_setting(
     hcatCombinationWordlist, wordlists_dir
 )
 hcatHybridlist = _normalize_wordlist_setting(hcatHybridlist, wordlists_dir)
+hcatFingerprintWordlist = _normalize_wordlist_setting(
+    hcatFingerprintWordlist, wordlists_dir
+)
 hcatMiddleBaseList = _normalize_wordlist_setting(hcatMiddleBaseList, wordlists_dir)
 hcatThoroughBaseList = _normalize_wordlist_setting(hcatThoroughBaseList, wordlists_dir)
 hcatGoodMeasureBaseList = _normalize_wordlist_setting(
@@ -2759,6 +2763,12 @@ def hcatFingerprint(
 
     if keyspace_limit is None:
         keyspace_limit = _FINGERPRINT_KEYSPACE_LIMIT
+
+    # No explicit choice from the caller falls back to the configured
+    # default (if any); an explicit "" (declined at the prompt) does not,
+    # so a user can still opt out of a configured default.
+    if dictionary_wordlist is None:
+        dictionary_wordlist = hcatFingerprintWordlist
 
     resolved_dict = None
     if dictionary_wordlist:

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2615,7 +2615,7 @@ def _fingerprint_expander_chain(max_expander_len):
     return sorted(n for n in lengths if 7 <= n <= max_expander_len)
 
 
-def _fingerprint_keyspace_guard(left_path, right_path, label):
+def _fingerprint_keyspace_guard(left_path, right_path, label, limit):
     """Return True if a -a1 combination of left/right should proceed.
 
     -a1's candidate count is exactly len(left) * len(right); on a
@@ -2623,14 +2623,17 @@ def _fingerprint_keyspace_guard(left_path, right_path, label):
     is checked before spending GPU time on it rather than after. Fingerprint
     runs unattended for its whole duration (it's launched once, up front),
     so an over-threshold combination is skipped with a warning rather than
-    blocking on a prompt mid-run.
+    blocking on a prompt mid-run -- ``limit`` is instead decided once,
+    up front, by the caller (falsy/0 means no limit).
     """
+    if not limit:
+        return True
     keyspace = lineCount(left_path) * lineCount(right_path)
-    if keyspace <= _FINGERPRINT_KEYSPACE_LIMIT:
+    if keyspace <= limit:
         return True
     print(
         f"[!] {label}: {keyspace:,} candidates exceeds the "
-        f"{_FINGERPRINT_KEYSPACE_LIMIT:,}-candidate guardrail. Skipping."
+        f"{limit:,}-candidate guardrail. Skipping."
     )
     return False
 
@@ -2729,9 +2732,9 @@ def _fingerprint_run_combine(hcatHashType, hcatHashFile, left, right):
     _run_hcat_cmd(cmd, attack_name="Fingerprint", hash_file=hcatHashFile)
 
 
-def _fingerprint_combine(hcatHashType, hcatHashFile, left, right, *, label):
+def _fingerprint_combine(hcatHashType, hcatHashFile, left, right, *, label, limit):
     """Run a -a1 combination of left+right, gated by the keyspace guardrail."""
-    if not _fingerprint_keyspace_guard(left, right, label):
+    if not _fingerprint_keyspace_guard(left, right, label, limit):
         return
     _fingerprint_run_combine(hcatHashType, hcatHashFile, left, right)
 
@@ -2743,6 +2746,7 @@ def hcatFingerprint(
     max_expander_len: int = 21,
     run_hybrid_on_expanded: bool = False,
     dictionary_wordlist: str | None = None,
+    keyspace_limit: int | None = None,
 ):
     global hcatFingerprintCount
 
@@ -2752,6 +2756,9 @@ def hcatFingerprint(
         max_expander_len = 21
     if max_expander_len < 7 or max_expander_len > 36:
         raise ValueError("max_expander_len must be an integer between 7 and 36")
+
+    if keyspace_limit is None:
+        keyspace_limit = _FINGERPRINT_KEYSPACE_LIMIT
 
     resolved_dict = None
     if dictionary_wordlist:
@@ -2788,6 +2795,7 @@ def hcatFingerprint(
                 expanded_path,
                 expanded_path,
                 label=f"Fingerprint self-combination (length {expander_len})",
+                limit=keyspace_limit,
             )
             if resolved_dict:
                 # Both orders share the same candidate count (len(a)*len(b)
@@ -2797,7 +2805,7 @@ def hcatFingerprint(
                     f"Fingerprint dictionary-combination (length {expander_len})"
                 )
                 if _fingerprint_keyspace_guard(
-                    expanded_path, resolved_dict, dict_label
+                    expanded_path, resolved_dict, dict_label, keyspace_limit
                 ):
                     _fingerprint_run_combine(
                         hcatHashType, hcatHashFile, expanded_path, resolved_dict

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2766,9 +2766,18 @@ def hcatFingerprint(
 
     # No explicit choice from the caller falls back to the configured
     # default (if any); an explicit "" (declined at the prompt) does not,
-    # so a user can still opt out of a configured default.
+    # so a user can still opt out of a configured default. Only one
+    # wordlist is combined per run, so extra configured entries are noted
+    # and ignored rather than silently dropped.
     if dictionary_wordlist is None:
-        dictionary_wordlist = hcatFingerprintWordlist
+        if len(hcatFingerprintWordlist) > 1:
+            print(
+                "[!] hcatFingerprintWordlist has multiple entries; using the "
+                f"first ({hcatFingerprintWordlist[0]}), ignoring the rest."
+            )
+        dictionary_wordlist = (
+            hcatFingerprintWordlist[0] if hcatFingerprintWordlist else None
+        )
 
     resolved_dict = None
     if dictionary_wordlist:

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -125,7 +125,11 @@ class TestExtensiveCrack:
             ctx.hcatHashType, ctx.hcatHashFile, 4 * 60 * 60
         )
         ctx.hcatFingerprint.assert_called_once_with(
-            ctx.hcatHashType, ctx.hcatHashFile, 7, run_hybrid_on_expanded=False
+            ctx.hcatHashType,
+            ctx.hcatHashFile,
+            max_expander_len=21,
+            run_hybrid_on_expanded=False,
+            unattended=True,
         )
         ctx.hcatCombination.assert_called_once_with(ctx.hcatHashType, ctx.hcatHashFile)
         ctx.hcatHybrid.assert_called_once_with(ctx.hcatHashType, ctx.hcatHashFile)

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -129,7 +129,6 @@ class TestExtensiveCrack:
             ctx.hcatHashFile,
             max_expander_len=21,
             run_hybrid_on_expanded=False,
-            unattended=True,
         )
         ctx.hcatCombination.assert_called_once_with(ctx.hcatHashType, ctx.hcatHashFile)
         ctx.hcatHybrid.assert_called_once_with(ctx.hcatHashType, ctx.hcatHashFile)

--- a/tests/test_config_json_example.py
+++ b/tests/test_config_json_example.py
@@ -33,6 +33,7 @@ EXPECTED_KEYS = {
     "hcatDictionaryWordlist",
     "hcatCombinationWordlist",
     "hcatHybridlist",
+    "hcatFingerprintWordlist",
     "hcatMiddleCombinatorMasks",
     "hcatMiddleBaseList",
     "hcatThoroughCombinatorMasks",

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -48,8 +48,8 @@ def test_defaults_only_matches_schema(tmp_path, monkeypatch):
     assert isinstance(result, ConfigLoadResult)
     expected_keys = {entry.legacy for entry in CONFIG_SCHEMA}
     assert set(result.config.keys()) == expected_keys
-    # 14 .env-homed integration keys + 37 config.json-homed settings.
-    assert len(expected_keys) == 51
+    # 14 .env-homed integration keys + 38 config.json-homed settings.
+    assert len(expected_keys) == 52
     for entry in CONFIG_SCHEMA:
         # path-typed defaults are expanded by load_config()'s uniform
         # post-merge normalization pass (see _normalize_path_values), so a

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -128,7 +128,7 @@ def test_type_counts_match_config_json_example_value_types():
     Scoped to the ``home="json"`` keys, since those are exactly the ones
     config.json.example documents.
 
-    ``list`` splits into ``csv_list`` (5) and ``charset`` (2):
+    ``list`` splits into ``csv_list`` (6) and ``charset`` (2):
     hcatMiddleCombinatorMasks and hcatThoroughCombinatorMasks are lists of
     single characters (including a literal "," and " ") that csv_list's
     join/split/strip rules cannot represent losslessly, so they get the
@@ -161,14 +161,14 @@ def test_type_counts_match_config_json_example_value_types():
     list_derived = schema_type_counts.get("csv_list", 0) + schema_type_counts.get(
         "charset", 0
     )
-    assert list_derived == json_type_counts.get("list", 0) == 7
-    assert schema_type_counts.get("csv_list", 0) == 5
+    assert list_derived == json_type_counts.get("list", 0) == 8
+    assert schema_type_counts.get("csv_list", 0) == 6
     assert schema_type_counts.get("charset", 0) == 2
     # str splits into str/path; the two must sum to the JSON str count.
     str_and_path = schema_type_counts.get("str", 0) + schema_type_counts.get("path", 0)
-    assert str_and_path == json_type_counts.get("str_or_path", 0) == 16
+    assert str_and_path == json_type_counts.get("str_or_path", 0) == 15
     assert schema_type_counts.get("path", 0) == 3
-    assert schema_type_counts.get("str", 0) == 13
+    assert schema_type_counts.get("str", 0) == 12
 
 
 def test_defaults_match_config_json_example():

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -98,10 +98,10 @@ def test_env_homed_key_set_is_pinned():
     assert {entry.env for entry in ENV_KEYS} == EXPECTED_ENV_HOMED
 
 
-def test_key_counts_are_fourteen_and_thirty_seven():
+def test_key_counts_are_fourteen_and_thirty_eight():
     assert len(ENV_KEYS) == 14
-    assert len(JSON_KEYS) == 37
-    assert len(CONFIG_SCHEMA) == 51
+    assert len(JSON_KEYS) == 38
+    assert len(CONFIG_SCHEMA) == 52
 
 
 def test_every_key_has_exactly_one_home():
@@ -166,9 +166,9 @@ def test_type_counts_match_config_json_example_value_types():
     assert schema_type_counts.get("charset", 0) == 2
     # str splits into str/path; the two must sum to the JSON str count.
     str_and_path = schema_type_counts.get("str", 0) + schema_type_counts.get("path", 0)
-    assert str_and_path == json_type_counts.get("str_or_path", 0) == 15
+    assert str_and_path == json_type_counts.get("str_or_path", 0) == 16
     assert schema_type_counts.get("path", 0) == 3
-    assert schema_type_counts.get("str", 0) == 12
+    assert schema_type_counts.get("str", 0) == 13
 
 
 def test_defaults_match_config_json_example():

--- a/tests/test_fingerprint_expander_and_hybrid.py
+++ b/tests/test_fingerprint_expander_and_hybrid.py
@@ -261,6 +261,64 @@ def test_hcatFingerprint_combines_against_dictionary_in_both_orders(
     )
 
 
+def test_hcatFingerprint_dictionary_guard_prompts_once_not_per_direction(
+    monkeypatch, tmp_path
+):
+    """expanded+dict and dict+expanded have the same candidate count, so an
+    over-threshold keyspace must prompt once and apply the answer to both
+    invocations, not ask twice for what is the same decision."""
+    import hate_crack.main as hc_main
+
+    importlib.reload(hc_main)
+
+    hashfile = tmp_path / "hashes.txt"
+    (tmp_path / "hashes.txt.out").write_text("deadbeef:Summer2025!\n")
+    dict_path = tmp_path / "words.txt"
+    dict_path.write_text("winter\n")
+
+    _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
+    # Large enough that both self- and dictionary-combination exceed the
+    # keyspace guardrail threshold.
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 300_000)
+    monkeypatch.setattr(hc_main, "hcatWordlists", str(tmp_path))
+
+    input_calls = []
+
+    def fake_input(prompt=""):
+        input_calls.append(prompt)
+        return "y"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    seen = {"popen_args": []}
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
+
+    hc_main.hcatFingerprint(
+        "1000",
+        str(hashfile),
+        max_expander_len=7,
+        dictionary_wordlist=str(dict_path),
+    )
+
+    hashcat_cmds = [args for args in seen["popen_args"] if args[0] == "hashcat"]
+    expanded_path = f"{hashfile}.expanded"
+
+    # Both dictionary-combination directions still ran (guard was answered
+    # "y" once and applied to both).
+    assert any(
+        _combination_operands(c) == (expanded_path, str(dict_path))
+        for c in hashcat_cmds
+    )
+    assert any(
+        _combination_operands(c) == (str(dict_path), expanded_path)
+        for c in hashcat_cmds
+    )
+
+    # One prompt for self-combination, one for the dictionary-combination
+    # pair — not three.
+    assert len(input_calls) == 2, input_calls
+
+
 def test_hcatFingerprint_warns_and_skips_missing_dictionary(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/test_fingerprint_expander_and_hybrid.py
+++ b/tests/test_fingerprint_expander_and_hybrid.py
@@ -30,7 +30,7 @@ def test_fingerprint_crack_prompts_for_max_expander_len_and_enables_hybrid(
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
-        hcatFingerprintWordlist="",
+        hcatFingerprintWordlist=[],
     )
 
     responses = iter(["24", "", ""])
@@ -55,7 +55,7 @@ def test_fingerprint_crack_passes_wordlist_when_provided(monkeypatch):
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
-        hcatFingerprintWordlist="",
+        hcatFingerprintWordlist=[],
     )
 
     responses = iter(["", "rockyou.txt", ""])
@@ -77,7 +77,7 @@ def test_fingerprint_crack_passes_custom_keyspace_limit(monkeypatch):
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
-        hcatFingerprintWordlist="",
+        hcatFingerprintWordlist=[],
     )
 
     responses = iter(["", "", "200000000000"])
@@ -99,7 +99,7 @@ def test_fingerprint_crack_zero_keyspace_limit_means_no_limit(monkeypatch, capsy
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
-        hcatFingerprintWordlist="",
+        hcatFingerprintWordlist=[],
     )
 
     responses = iter(["", "", "0"])
@@ -122,7 +122,7 @@ def test_fingerprint_crack_accepts_configured_default_wordlist(monkeypatch):
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
-        hcatFingerprintWordlist="/wordlists/rockyou.txt",
+        hcatFingerprintWordlist=["/wordlists/rockyou.txt"],
     )
 
     # max_expander_len, "use configured default?" (accept), keyspace limit.
@@ -147,7 +147,7 @@ def test_fingerprint_crack_declining_configured_default_falls_back_to_manual_ent
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
-        hcatFingerprintWordlist="/wordlists/rockyou.txt",
+        hcatFingerprintWordlist=["/wordlists/rockyou.txt"],
     )
 
     # max_expander_len, "use configured default?" (decline), manual entry
@@ -471,7 +471,7 @@ def test_hcatFingerprint_falls_back_to_configured_wordlist_when_none_passed(
     _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
     monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
     monkeypatch.setattr(hc_main, "hcatWordlists", str(tmp_path))
-    monkeypatch.setattr(hc_main, "hcatFingerprintWordlist", str(dict_path))
+    monkeypatch.setattr(hc_main, "hcatFingerprintWordlist", [str(dict_path)])
 
     seen = {"popen_args": []}
     monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
@@ -503,7 +503,7 @@ def test_hcatFingerprint_explicit_empty_dictionary_skips_configured_default(
     _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
     monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
     monkeypatch.setattr(hc_main, "hcatWordlists", str(tmp_path))
-    monkeypatch.setattr(hc_main, "hcatFingerprintWordlist", str(dict_path))
+    monkeypatch.setattr(hc_main, "hcatFingerprintWordlist", [str(dict_path)])
 
     seen = {"popen_args": []}
     monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))

--- a/tests/test_fingerprint_expander_and_hybrid.py
+++ b/tests/test_fingerprint_expander_and_hybrid.py
@@ -30,6 +30,7 @@ def test_fingerprint_crack_prompts_for_max_expander_len_and_enables_hybrid(
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
+        hcatFingerprintWordlist="",
     )
 
     responses = iter(["24", "", ""])
@@ -38,7 +39,7 @@ def test_fingerprint_crack_prompts_for_max_expander_len_and_enables_hybrid(
 
     assert seen["max_expander_len"] == 24
     assert seen["run_hybrid_on_expanded"] is True
-    assert seen["dictionary_wordlist"] is None
+    assert seen["dictionary_wordlist"] == ""
     assert seen["keyspace_limit"] is None
 
 
@@ -54,6 +55,7 @@ def test_fingerprint_crack_passes_wordlist_when_provided(monkeypatch):
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
+        hcatFingerprintWordlist="",
     )
 
     responses = iter(["", "rockyou.txt", ""])
@@ -75,6 +77,7 @@ def test_fingerprint_crack_passes_custom_keyspace_limit(monkeypatch):
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
+        hcatFingerprintWordlist="",
     )
 
     responses = iter(["", "", "200000000000"])
@@ -96,6 +99,7 @@ def test_fingerprint_crack_zero_keyspace_limit_means_no_limit(monkeypatch, capsy
         hcatHashType="1000",
         hcatHashFile="dummy.hash",
         hcatFingerprint=fake_hcatFingerprint,
+        hcatFingerprintWordlist="",
     )
 
     responses = iter(["", "", "0"])
@@ -104,6 +108,56 @@ def test_fingerprint_crack_zero_keyspace_limit_means_no_limit(monkeypatch, capsy
 
     assert seen["keyspace_limit"] == 0
     assert "No limit" in capsys.readouterr().out
+
+
+def test_fingerprint_crack_accepts_configured_default_wordlist(monkeypatch):
+    from hate_crack import attacks
+
+    seen = {}
+
+    def fake_hcatFingerprint(hash_type, hash_file, max_expander_len, **kwargs):
+        seen["dictionary_wordlist"] = kwargs.get("dictionary_wordlist")
+
+    ctx = SimpleNamespace(
+        hcatHashType="1000",
+        hcatHashFile="dummy.hash",
+        hcatFingerprint=fake_hcatFingerprint,
+        hcatFingerprintWordlist="/wordlists/rockyou.txt",
+    )
+
+    # max_expander_len, "use configured default?" (accept), keyspace limit.
+    responses = iter(["", "", ""])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(responses))
+    attacks.fingerprint_crack(ctx)
+
+    assert seen["dictionary_wordlist"] == "/wordlists/rockyou.txt"
+
+
+def test_fingerprint_crack_declining_configured_default_falls_back_to_manual_entry(
+    monkeypatch,
+):
+    from hate_crack import attacks
+
+    seen = {}
+
+    def fake_hcatFingerprint(hash_type, hash_file, max_expander_len, **kwargs):
+        seen["dictionary_wordlist"] = kwargs.get("dictionary_wordlist")
+
+    ctx = SimpleNamespace(
+        hcatHashType="1000",
+        hcatHashFile="dummy.hash",
+        hcatFingerprint=fake_hcatFingerprint,
+        hcatFingerprintWordlist="/wordlists/rockyou.txt",
+    )
+
+    # max_expander_len, "use configured default?" (decline), manual entry
+    # (skip), keyspace limit.
+    responses = iter(["", "n", "", ""])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(responses))
+    attacks.fingerprint_crack(ctx)
+
+    # Declining must not silently fall back to the config default anyway.
+    assert seen["dictionary_wordlist"] == ""
 
 
 class _SimulatingFakePopen:
@@ -398,6 +452,72 @@ def test_hcatFingerprint_warns_and_skips_missing_dictionary(
         for cmd in hashcat_cmds
     )
     assert "Wordlist not found" in capsys.readouterr().out
+
+
+def test_hcatFingerprint_falls_back_to_configured_wordlist_when_none_passed(
+    monkeypatch, tmp_path
+):
+    """dictionary_wordlist=None (the default -- e.g. extensive_crack's call,
+    which can't prompt) picks up hcatFingerprintWordlist from config."""
+    import hate_crack.main as hc_main
+
+    importlib.reload(hc_main)
+
+    hashfile = tmp_path / "hashes.txt"
+    (tmp_path / "hashes.txt.out").write_text("deadbeef:Summer2025!\n")
+    dict_path = tmp_path / "words.txt"
+    dict_path.write_text("winter\n")
+
+    _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
+    monkeypatch.setattr(hc_main, "hcatWordlists", str(tmp_path))
+    monkeypatch.setattr(hc_main, "hcatFingerprintWordlist", str(dict_path))
+
+    seen = {"popen_args": []}
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
+
+    hc_main.hcatFingerprint("1000", str(hashfile), max_expander_len=7)
+
+    hashcat_cmds = [args for args in seen["popen_args"] if args[0] == "hashcat"]
+    expanded_path = f"{hashfile}.expanded"
+    assert any(
+        _combination_operands(c) == (expanded_path, str(dict_path))
+        for c in hashcat_cmds
+    )
+
+
+def test_hcatFingerprint_explicit_empty_dictionary_skips_configured_default(
+    monkeypatch, tmp_path
+):
+    """dictionary_wordlist="" (declined at the prompt) must not fall back to
+    the configured default -- only the None default does."""
+    import hate_crack.main as hc_main
+
+    importlib.reload(hc_main)
+
+    hashfile = tmp_path / "hashes.txt"
+    (tmp_path / "hashes.txt.out").write_text("deadbeef:Summer2025!\n")
+    dict_path = tmp_path / "words.txt"
+    dict_path.write_text("winter\n")
+
+    _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
+    monkeypatch.setattr(hc_main, "hcatWordlists", str(tmp_path))
+    monkeypatch.setattr(hc_main, "hcatFingerprintWordlist", str(dict_path))
+
+    seen = {"popen_args": []}
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
+
+    hc_main.hcatFingerprint(
+        "1000", str(hashfile), max_expander_len=7, dictionary_wordlist=""
+    )
+
+    hashcat_cmds = [args for args in seen["popen_args"] if args[0] == "hashcat"]
+    expanded_path = f"{hashfile}.expanded"
+    assert not any(
+        _combination_operands(c) == (expanded_path, str(dict_path))
+        for c in hashcat_cmds
+    )
 
 
 def test_fingerprint_expander_chain_escalates_by_seven():

--- a/tests/test_fingerprint_expander_and_hybrid.py
+++ b/tests/test_fingerprint_expander_and_hybrid.py
@@ -4,18 +4,26 @@ import io
 from types import SimpleNamespace
 
 
-def test_fingerprint_crack_prompts_for_expander_len_and_enables_hybrid(monkeypatch):
+def test_fingerprint_crack_prompts_for_max_expander_len_and_enables_hybrid(
+    monkeypatch,
+):
     from hate_crack import attacks
 
     seen = {}
 
     def fake_hcatFingerprint(
-        hash_type, hash_file, expander_len, run_hybrid_on_expanded=False
+        hash_type,
+        hash_file,
+        max_expander_len,
+        run_hybrid_on_expanded=False,
+        dictionary_wordlist=None,
+        unattended=False,
     ):
         seen["hash_type"] = hash_type
         seen["hash_file"] = hash_file
-        seen["expander_len"] = expander_len
+        seen["max_expander_len"] = max_expander_len
         seen["run_hybrid_on_expanded"] = run_hybrid_on_expanded
+        seen["dictionary_wordlist"] = dictionary_wordlist
 
     ctx = SimpleNamespace(
         hcatHashType="1000",
@@ -23,47 +31,52 @@ def test_fingerprint_crack_prompts_for_expander_len_and_enables_hybrid(monkeypat
         hcatFingerprint=fake_hcatFingerprint,
     )
 
-    monkeypatch.setattr(builtins, "input", lambda _prompt="": "24")
+    responses = iter(["24", ""])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(responses))
     attacks.fingerprint_crack(ctx)
 
-    assert seen["expander_len"] == 24
+    assert seen["max_expander_len"] == 24
     assert seen["run_hybrid_on_expanded"] is True
+    assert seen["dictionary_wordlist"] is None
 
 
-def test_hcatFingerprint_uses_selected_expander_and_calls_hybrid(monkeypatch, tmp_path):
-    monkeypatch.setenv("HATE_CRACK_SKIP_INIT", "1")
+def test_fingerprint_crack_passes_wordlist_when_provided(monkeypatch):
+    from hate_crack import attacks
 
-    import hate_crack.main as hc_main
+    seen = {}
 
-    importlib.reload(hc_main)
+    def fake_hcatFingerprint(hash_type, hash_file, max_expander_len, **kwargs):
+        seen["dictionary_wordlist"] = kwargs.get("dictionary_wordlist")
 
-    hashfile = tmp_path / "hashes.txt"
-    out_path = tmp_path / "hashes.txt.out"
-    out_path.write_text("deadbeef:Accordbookkeeping2025!:x\n")
+    ctx = SimpleNamespace(
+        hcatHashType="1000",
+        hcatHashFile="dummy.hash",
+        hcatFingerprint=fake_hcatFingerprint,
+    )
 
-    # Constant lineCount makes the while-loop terminate after one iteration
-    # (crackedAfter == crackedBefore) and keeps the empty-.expanded guard
-    # quiet (1 != 0). Avoids coupling to the exact number of lineCount
-    # call sites inside hcatFingerprint and _run_hcat_cmd.
-    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
-    monkeypatch.setattr(hc_main, "hcatHashCracked", 0)
+    responses = iter(["", "rockyou.txt"])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(responses))
+    attacks.fingerprint_crack(ctx)
 
-    # Avoid any filesystem/executable checks in unit test.
-    monkeypatch.setattr(hc_main, "ensure_binary", lambda binary_path, **_k: binary_path)
+    assert seen["dictionary_wordlist"] == "rockyou.txt"
 
-    seen = {"popen_args": [], "hybrid_calls": []}
 
-    def fake_hybrid(hash_type, hash_file, wordlists=None):
-        seen["hybrid_calls"].append((hash_type, hash_file, wordlists))
+class _SimulatingFakePopen:
+    """Popen stand-in that actually runs expander/sort logic against real
+    stdin/stdout file handles, and no-ops any other command (hashcat)."""
 
-    monkeypatch.setattr(hc_main, "hcatHybrid", fake_hybrid)
+    def __init__(self, seen):
+        self.seen = seen
 
-    class FakePopen:
-        def __init__(self, args, stdin=None, stdout=None, text=False, **_kwargs):
+    def __call__(self, args, stdin=None, stdout=None, text=False, **_kwargs):
+        return self._Proc(args, stdin, stdout, self.seen)
+
+    class _Proc:
+        def __init__(self, args, stdin, stdout, seen):
             self.args = args
-            self.pid = 123
+            self.pid = 1234
             self.stdout = None
-            seen["popen_args"].append(args)
+            seen["popen_args"].append(list(args))
 
             cmd0 = args[0]
             if cmd0 == "sort":
@@ -74,12 +87,8 @@ def test_hcatFingerprint_uses_selected_expander_and_calls_hybrid(monkeypatch, tm
                 stdout.flush()
             elif isinstance(cmd0, str) and "expander" in cmd0:
                 data = stdin.read() if stdin is not None else b""
-                # Identity "expansion" is enough for this test; we just need the
-                # pipeline to create the .expanded file and complete.
                 self.stdout = io.BytesIO(data)
-            else:
-                # hashcat invocation: do nothing
-                pass
+            # else: hashcat invocation — no-op.
 
         def wait(self, timeout=None):
             return 0
@@ -87,44 +96,88 @@ def test_hcatFingerprint_uses_selected_expander_and_calls_hybrid(monkeypatch, tm
         def kill(self):
             return None
 
-    monkeypatch.setattr(hc_main.subprocess, "Popen", FakePopen)
 
-    # Run with expander24 and ensure secondary hybrid gets the expanded file.
+def _combination_operands(cmd):
+    """The two wordlist operands of a -a1 combine, which sit right after
+    -j/-k regardless of what -O/potfile flags got appended afterward."""
+    idx = cmd.index("-k")
+    return (cmd[idx + 2], cmd[idx + 3])
+
+
+def _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile):
+    monkeypatch.setenv("HATE_CRACK_SKIP_INIT", "1")
+    monkeypatch.setattr(hc_main, "hcatHashCracked", 0)
+    monkeypatch.setattr(hc_main, "ensure_binary", lambda binary_path, **_k: binary_path)
+    monkeypatch.setattr(hc_main, "hate_path", str(tmp_path))
     monkeypatch.setattr(hc_main, "hcatHashFile", str(hashfile))
-    hc_main.hcatFingerprint(
-        "1000", str(hashfile), expander_len=24, run_hybrid_on_expanded=True
-    )
-
-    assert any(
-        isinstance(args[0], str) and args[0].endswith("expander24.bin")
-        for args in seen["popen_args"]
-    )
-
-    assert seen["hybrid_calls"] == [
-        ("1000", str(hashfile), [f"{hashfile}.expanded"]),
-    ]
+    monkeypatch.setattr(hc_main, "generate_session_id", lambda: "test_session")
+    monkeypatch.setattr(hc_main, "hcatBin", "hashcat")
+    monkeypatch.setattr(hc_main, "hcatTuning", "")
 
 
-def test_hcatFingerprint_skips_hashcat_and_hybrid_when_expanded_is_empty(
+def test_hcatFingerprint_escalates_through_length_chain_and_calls_hybrid_per_step(
     monkeypatch, tmp_path
 ):
-    """If the expander pipeline yields an empty {hash}.expanded file (e.g.
-    nothing has been cracked yet), hcatFingerprint must NOT invoke hashcat
-    and must NOT call the secondary hybrid attack. Otherwise we waste a
-    session running combinator against two empty wordlists."""
-    monkeypatch.setenv("HATE_CRACK_SKIP_INIT", "1")
-
     import hate_crack.main as hc_main
 
     importlib.reload(hc_main)
 
     hashfile = tmp_path / "hashes.txt"
-    # Empty .out simulates "no cracks yet" — the documented trigger for the bug.
+    out_path = tmp_path / "hashes.txt.out"
+    out_path.write_text("deadbeef:Accordbookkeeping2025!\n")
+
+    _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
+    # Constant lineCount makes each length's while-loop converge after one
+    # iteration (crackedAfter == crackedBefore) and keeps the keyspace guard
+    # well under its threshold.
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
+
+    seen = {"popen_args": [], "hybrid_calls": []}
+
+    def fake_hybrid(hash_type, hash_file, wordlists=None):
+        seen["hybrid_calls"].append((hash_type, hash_file, wordlists))
+
+    monkeypatch.setattr(hc_main, "hcatHybrid", fake_hybrid)
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
+
+    hc_main.hcatFingerprint(
+        "1000", str(hashfile), max_expander_len=24, run_hybrid_on_expanded=True
+    )
+
+    # Chain for max_expander_len=24 is [7, 14, 21, 24]; length 7 uses the
+    # configured hcatExpanderBin rather than a literal "expander7.bin".
+    expected_binaries = [
+        hc_main.hcatExpanderBin,
+        "expander14.bin",
+        "expander21.bin",
+        "expander24.bin",
+    ]
+    for binary in expected_binaries:
+        assert any(
+            isinstance(args[0], str) and args[0].endswith(binary)
+            for args in seen["popen_args"]
+        ), f"{binary} never invoked"
+
+    assert (
+        seen["hybrid_calls"] == [("1000", str(hashfile), [f"{hashfile}.expanded"])] * 4
+    )
+
+
+def test_hcatFingerprint_skips_hashcat_and_hybrid_when_nothing_cracked(
+    monkeypatch, tmp_path
+):
+    """If .out has no cracked plaintexts, hcatFingerprint must not invoke
+    hashcat or the secondary hybrid attack."""
+    import hate_crack.main as hc_main
+
+    importlib.reload(hc_main)
+
+    hashfile = tmp_path / "hashes.txt"
     out_path = tmp_path / "hashes.txt.out"
     out_path.write_text("")
 
-    monkeypatch.setattr(hc_main, "hcatHashCracked", 0)
-    monkeypatch.setattr(hc_main, "ensure_binary", lambda binary_path, **_k: binary_path)
+    _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 0)
 
     seen = {"popen_args": [], "hybrid_calls": []}
 
@@ -132,48 +185,168 @@ def test_hcatFingerprint_skips_hashcat_and_hybrid_when_expanded_is_empty(
         seen["hybrid_calls"].append((hash_type, hash_file, wordlists))
 
     monkeypatch.setattr(hc_main, "hcatHybrid", fake_hybrid)
-
-    class FakePopen:
-        def __init__(self, args, stdin=None, stdout=None, text=False, **_kwargs):
-            self.args = args
-            self.pid = 123
-            self.stdout = None
-            seen["popen_args"].append(args)
-
-            cmd0 = args[0]
-            if cmd0 == "sort":
-                data = stdin.read() if stdin is not None else b""
-                lines = sorted(set(data.splitlines()))
-                for ln in lines:
-                    stdout.write(ln + b"\n")
-                stdout.flush()
-            elif isinstance(cmd0, str) and "expander" in cmd0:
-                # Identity passthrough of empty stdin → empty stdout.
-                data = stdin.read() if stdin is not None else b""
-                self.stdout = io.BytesIO(data)
-            else:
-                # hashcat invocation: must never reach here in this test.
-                pass
-
-        def wait(self, timeout=None):
-            return 0
-
-        def kill(self):
-            return None
-
-    monkeypatch.setattr(hc_main.subprocess, "Popen", FakePopen)
-    monkeypatch.setattr(hc_main, "hcatHashFile", str(hashfile))
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
 
     hc_main.hcatFingerprint(
-        "1000", str(hashfile), expander_len=7, run_hybrid_on_expanded=True
+        "1000", str(hashfile), max_expander_len=7, run_hybrid_on_expanded=True
     )
 
-    # No hashcat invocation: identify by the -a flag, which only the hashcat
-    # command carries (expander has 1 arg; sort uses -u).
     hashcat_invocations = [args for args in seen["popen_args"] if "-a" in args]
-    assert hashcat_invocations == [], (
-        f"hashcat was invoked with empty .expanded: {hashcat_invocations}"
+    assert hashcat_invocations == []
+    assert seen["hybrid_calls"] == []
+
+
+def test_hcatFingerprint_self_combination_uses_capitalize_rule(monkeypatch, tmp_path):
+    import hate_crack.main as hc_main
+
+    importlib.reload(hc_main)
+
+    hashfile = tmp_path / "hashes.txt"
+    (tmp_path / "hashes.txt.out").write_text("deadbeef:Summer2025!\n")
+
+    _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
+
+    seen = {"popen_args": []}
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
+
+    hc_main.hcatFingerprint("1000", str(hashfile), max_expander_len=7)
+
+    hashcat_cmds = [args for args in seen["popen_args"] if args[0] == "hashcat"]
+    assert hashcat_cmds, "No hashcat invocation captured"
+    for cmd in hashcat_cmds:
+        assert cmd[cmd.index("-j") + 1] == "c"
+        assert cmd[cmd.index("-k") + 1] == "c"
+
+
+def test_hcatFingerprint_combines_against_dictionary_in_both_orders(
+    monkeypatch, tmp_path
+):
+    import hate_crack.main as hc_main
+
+    importlib.reload(hc_main)
+
+    hashfile = tmp_path / "hashes.txt"
+    (tmp_path / "hashes.txt.out").write_text("deadbeef:Summer2025!\n")
+    dict_path = tmp_path / "words.txt"
+    dict_path.write_text("winter\n")
+
+    _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
+    monkeypatch.setattr(hc_main, "hcatWordlists", str(tmp_path))
+
+    seen = {"popen_args": []}
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
+
+    hc_main.hcatFingerprint(
+        "1000",
+        str(hashfile),
+        max_expander_len=7,
+        dictionary_wordlist=str(dict_path),
     )
 
-    # No secondary hybrid pass on an empty wordlist.
-    assert seen["hybrid_calls"] == []
+    hashcat_cmds = [args for args in seen["popen_args"] if args[0] == "hashcat"]
+    expanded_path = f"{hashfile}.expanded"
+
+    assert any(
+        _combination_operands(c) == (expanded_path, expanded_path) for c in hashcat_cmds
+    )
+    assert any(
+        _combination_operands(c) == (expanded_path, str(dict_path))
+        for c in hashcat_cmds
+    )
+    assert any(
+        _combination_operands(c) == (str(dict_path), expanded_path)
+        for c in hashcat_cmds
+    )
+
+
+def test_hcatFingerprint_warns_and_skips_missing_dictionary(
+    monkeypatch, tmp_path, capsys
+):
+    import hate_crack.main as hc_main
+
+    importlib.reload(hc_main)
+
+    hashfile = tmp_path / "hashes.txt"
+    (tmp_path / "hashes.txt.out").write_text("deadbeef:Summer2025!\n")
+
+    _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
+    monkeypatch.setattr(hc_main, "hcatWordlists", str(tmp_path))
+
+    seen = {"popen_args": []}
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
+
+    hc_main.hcatFingerprint(
+        "1000",
+        str(hashfile),
+        max_expander_len=7,
+        dictionary_wordlist="does-not-exist.txt",
+    )
+
+    hashcat_cmds = [args for args in seen["popen_args"] if args[0] == "hashcat"]
+    expanded_path = f"{hashfile}.expanded"
+    assert all(
+        _combination_operands(cmd) == (expanded_path, expanded_path)
+        for cmd in hashcat_cmds
+    )
+    assert "Wordlist not found" in capsys.readouterr().out
+
+
+def test_fingerprint_expander_chain_escalates_by_seven():
+    from hate_crack import main as hc_main
+
+    assert hc_main._fingerprint_expander_chain(7) == [7]
+    assert hc_main._fingerprint_expander_chain(21) == [7, 14, 21]
+    assert hc_main._fingerprint_expander_chain(24) == [7, 14, 21, 24]
+    assert hc_main._fingerprint_expander_chain(36) == [7, 14, 21, 28, 35, 36]
+
+
+class TestFingerprintKeyspaceGuard:
+    def test_under_threshold_proceeds_without_prompting(self, monkeypatch):
+        from hate_crack import main as hc_main
+
+        monkeypatch.setattr(hc_main, "lineCount", lambda _p: 100)
+        monkeypatch.setattr(
+            builtins,
+            "input",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("should not prompt")
+            ),
+        )
+
+        assert hc_main._fingerprint_keyspace_guard(
+            "left", "right", "label", unattended=False
+        )
+
+    def test_over_threshold_unattended_skips_without_prompting(self, monkeypatch):
+        from hate_crack import main as hc_main
+
+        monkeypatch.setattr(hc_main, "lineCount", lambda _p: 300_000)
+        monkeypatch.setattr(
+            builtins,
+            "input",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("should not prompt")
+            ),
+        )
+
+        assert not hc_main._fingerprint_keyspace_guard(
+            "left", "right", "label", unattended=True
+        )
+
+    def test_over_threshold_interactive_prompts_and_honours_answer(self, monkeypatch):
+        from hate_crack import main as hc_main
+
+        monkeypatch.setattr(hc_main, "lineCount", lambda _p: 300_000)
+
+        monkeypatch.setattr(builtins, "input", lambda *_a, **_k: "y")
+        assert hc_main._fingerprint_keyspace_guard(
+            "left", "right", "label", unattended=False
+        )
+
+        monkeypatch.setattr(builtins, "input", lambda *_a, **_k: "n")
+        assert not hc_main._fingerprint_keyspace_guard(
+            "left", "right", "label", unattended=False
+        )

--- a/tests/test_fingerprint_expander_and_hybrid.py
+++ b/tests/test_fingerprint_expander_and_hybrid.py
@@ -17,12 +17,14 @@ def test_fingerprint_crack_prompts_for_max_expander_len_and_enables_hybrid(
         max_expander_len,
         run_hybrid_on_expanded=False,
         dictionary_wordlist=None,
+        keyspace_limit=None,
     ):
         seen["hash_type"] = hash_type
         seen["hash_file"] = hash_file
         seen["max_expander_len"] = max_expander_len
         seen["run_hybrid_on_expanded"] = run_hybrid_on_expanded
         seen["dictionary_wordlist"] = dictionary_wordlist
+        seen["keyspace_limit"] = keyspace_limit
 
     ctx = SimpleNamespace(
         hcatHashType="1000",
@@ -30,13 +32,14 @@ def test_fingerprint_crack_prompts_for_max_expander_len_and_enables_hybrid(
         hcatFingerprint=fake_hcatFingerprint,
     )
 
-    responses = iter(["24", ""])
+    responses = iter(["24", "", ""])
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(responses))
     attacks.fingerprint_crack(ctx)
 
     assert seen["max_expander_len"] == 24
     assert seen["run_hybrid_on_expanded"] is True
     assert seen["dictionary_wordlist"] is None
+    assert seen["keyspace_limit"] is None
 
 
 def test_fingerprint_crack_passes_wordlist_when_provided(monkeypatch):
@@ -53,11 +56,54 @@ def test_fingerprint_crack_passes_wordlist_when_provided(monkeypatch):
         hcatFingerprint=fake_hcatFingerprint,
     )
 
-    responses = iter(["", "rockyou.txt"])
+    responses = iter(["", "rockyou.txt", ""])
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(responses))
     attacks.fingerprint_crack(ctx)
 
     assert seen["dictionary_wordlist"] == "rockyou.txt"
+
+
+def test_fingerprint_crack_passes_custom_keyspace_limit(monkeypatch):
+    from hate_crack import attacks
+
+    seen = {}
+
+    def fake_hcatFingerprint(hash_type, hash_file, max_expander_len, **kwargs):
+        seen["keyspace_limit"] = kwargs.get("keyspace_limit")
+
+    ctx = SimpleNamespace(
+        hcatHashType="1000",
+        hcatHashFile="dummy.hash",
+        hcatFingerprint=fake_hcatFingerprint,
+    )
+
+    responses = iter(["", "", "200000000000"])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(responses))
+    attacks.fingerprint_crack(ctx)
+
+    assert seen["keyspace_limit"] == 200_000_000_000
+
+
+def test_fingerprint_crack_zero_keyspace_limit_means_no_limit(monkeypatch, capsys):
+    from hate_crack import attacks
+
+    seen = {}
+
+    def fake_hcatFingerprint(hash_type, hash_file, max_expander_len, **kwargs):
+        seen["keyspace_limit"] = kwargs.get("keyspace_limit")
+
+    ctx = SimpleNamespace(
+        hcatHashType="1000",
+        hcatHashFile="dummy.hash",
+        hcatFingerprint=fake_hcatFingerprint,
+    )
+
+    responses = iter(["", "", "0"])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(responses))
+    attacks.fingerprint_crack(ctx)
+
+    assert seen["keyspace_limit"] == 0
+    assert "No limit" in capsys.readouterr().out
 
 
 class _SimulatingFakePopen:
@@ -284,9 +330,9 @@ def test_hcatFingerprint_dictionary_guard_checked_once_not_per_direction(
     guard_calls = []
     real_guard = hc_main._fingerprint_keyspace_guard
 
-    def counting_guard(left, right, label):
+    def counting_guard(left, right, label, limit):
         guard_calls.append(label)
-        return real_guard(left, right, label)
+        return real_guard(left, right, label, limit)
 
     monkeypatch.setattr(hc_main, "_fingerprint_keyspace_guard", counting_guard)
 
@@ -376,7 +422,9 @@ class TestFingerprintKeyspaceGuard:
             ),
         )
 
-        assert hc_main._fingerprint_keyspace_guard("left", "right", "label")
+        assert hc_main._fingerprint_keyspace_guard(
+            "left", "right", "label", 50_000_000_000
+        )
 
     def test_over_threshold_skips_without_prompting(self, monkeypatch):
         """Fingerprint is launched once and left to run; a keyspace guard
@@ -393,4 +441,21 @@ class TestFingerprintKeyspaceGuard:
             ),
         )
 
-        assert not hc_main._fingerprint_keyspace_guard("left", "right", "label")
+        assert not hc_main._fingerprint_keyspace_guard(
+            "left", "right", "label", 50_000_000_000
+        )
+
+    def test_falsy_limit_means_no_limit(self, monkeypatch):
+        from hate_crack import main as hc_main
+
+        monkeypatch.setattr(hc_main, "lineCount", lambda _p: 300_000)
+        monkeypatch.setattr(
+            builtins,
+            "input",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("should not prompt")
+            ),
+        )
+
+        assert hc_main._fingerprint_keyspace_guard("left", "right", "label", 0)
+        assert hc_main._fingerprint_keyspace_guard("left", "right", "label", None)

--- a/tests/test_fingerprint_expander_and_hybrid.py
+++ b/tests/test_fingerprint_expander_and_hybrid.py
@@ -17,7 +17,6 @@ def test_fingerprint_crack_prompts_for_max_expander_len_and_enables_hybrid(
         max_expander_len,
         run_hybrid_on_expanded=False,
         dictionary_wordlist=None,
-        unattended=False,
     ):
         seen["hash_type"] = hash_type
         seen["hash_file"] = hash_file
@@ -261,12 +260,12 @@ def test_hcatFingerprint_combines_against_dictionary_in_both_orders(
     )
 
 
-def test_hcatFingerprint_dictionary_guard_prompts_once_not_per_direction(
+def test_hcatFingerprint_dictionary_guard_checked_once_not_per_direction(
     monkeypatch, tmp_path
 ):
     """expanded+dict and dict+expanded have the same candidate count, so an
-    over-threshold keyspace must prompt once and apply the answer to both
-    invocations, not ask twice for what is the same decision."""
+    over-threshold keyspace must be checked (and skipped) once for the pair,
+    not once per direction."""
     import hate_crack.main as hc_main
 
     importlib.reload(hc_main)
@@ -282,13 +281,14 @@ def test_hcatFingerprint_dictionary_guard_prompts_once_not_per_direction(
     monkeypatch.setattr(hc_main, "lineCount", lambda _p: 300_000)
     monkeypatch.setattr(hc_main, "hcatWordlists", str(tmp_path))
 
-    input_calls = []
+    guard_calls = []
+    real_guard = hc_main._fingerprint_keyspace_guard
 
-    def fake_input(prompt=""):
-        input_calls.append(prompt)
-        return "y"
+    def counting_guard(left, right, label):
+        guard_calls.append(label)
+        return real_guard(left, right, label)
 
-    monkeypatch.setattr(builtins, "input", fake_input)
+    monkeypatch.setattr(hc_main, "_fingerprint_keyspace_guard", counting_guard)
 
     seen = {"popen_args": []}
     monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
@@ -303,20 +303,22 @@ def test_hcatFingerprint_dictionary_guard_prompts_once_not_per_direction(
     hashcat_cmds = [args for args in seen["popen_args"] if args[0] == "hashcat"]
     expanded_path = f"{hashfile}.expanded"
 
-    # Both dictionary-combination directions still ran (guard was answered
-    # "y" once and applied to both).
-    assert any(
+    # Over threshold: self- and dictionary-combination are both skipped.
+    assert not any(
+        _combination_operands(c) == (expanded_path, expanded_path) for c in hashcat_cmds
+    )
+    assert not any(
         _combination_operands(c) == (expanded_path, str(dict_path))
         for c in hashcat_cmds
     )
-    assert any(
+    assert not any(
         _combination_operands(c) == (str(dict_path), expanded_path)
         for c in hashcat_cmds
     )
 
-    # One prompt for self-combination, one for the dictionary-combination
-    # pair — not three.
-    assert len(input_calls) == 2, input_calls
+    # One guard check for self-combination, one for the dictionary pair —
+    # not three (i.e. not one per direction).
+    assert len(guard_calls) == 2, guard_calls
 
 
 def test_hcatFingerprint_warns_and_skips_missing_dictionary(
@@ -374,11 +376,12 @@ class TestFingerprintKeyspaceGuard:
             ),
         )
 
-        assert hc_main._fingerprint_keyspace_guard(
-            "left", "right", "label", unattended=False
-        )
+        assert hc_main._fingerprint_keyspace_guard("left", "right", "label")
 
-    def test_over_threshold_unattended_skips_without_prompting(self, monkeypatch):
+    def test_over_threshold_skips_without_prompting(self, monkeypatch):
+        """Fingerprint is launched once and left to run; a keyspace guard
+        that blocks on input() mid-run has no one there to answer it, so an
+        over-threshold combination is always skipped, never asked about."""
         from hate_crack import main as hc_main
 
         monkeypatch.setattr(hc_main, "lineCount", lambda _p: 300_000)
@@ -390,21 +393,4 @@ class TestFingerprintKeyspaceGuard:
             ),
         )
 
-        assert not hc_main._fingerprint_keyspace_guard(
-            "left", "right", "label", unattended=True
-        )
-
-    def test_over_threshold_interactive_prompts_and_honours_answer(self, monkeypatch):
-        from hate_crack import main as hc_main
-
-        monkeypatch.setattr(hc_main, "lineCount", lambda _p: 300_000)
-
-        monkeypatch.setattr(builtins, "input", lambda *_a, **_k: "y")
-        assert hc_main._fingerprint_keyspace_guard(
-            "left", "right", "label", unattended=False
-        )
-
-        monkeypatch.setattr(builtins, "input", lambda *_a, **_k: "n")
-        assert not hc_main._fingerprint_keyspace_guard(
-            "left", "right", "label", unattended=False
-        )
+        assert not hc_main._fingerprint_keyspace_guard("left", "right", "label")

--- a/tests/test_optimized_kernel.py
+++ b/tests/test_optimized_kernel.py
@@ -1,5 +1,6 @@
 """Tests for optimized kernel system - covers gaps not in test_main_utils.py::TestOptimizedKernel."""
 
+import io
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,26 +49,33 @@ class TestHcatFingerprintOptimizedFlag:
     def test_fingerprint_includes_optimized_flag(self, main_module, tmp_path):
         hash_file = tmp_path / "hashes.txt"
         hash_file.write_text("")
-        (tmp_path / "hashes.txt.out").write_text("")
-        # hcatFingerprint opens .working and .expanded inside the loop; create them.
-        (tmp_path / "hashes.txt.working").write_text("")
-        (tmp_path / "hashes.txt.expanded").write_text("")
+        (tmp_path / "hashes.txt.out").write_text("deadbeef:password1\n")
 
         captured_cmds = []
 
-        def fake_popen(cmd, **kwargs):
+        def fake_popen(cmd, stdin=None, stdout=None, **_kwargs):
             captured_cmds.append(list(cmd))
+            cmd0 = cmd[0]
+            if cmd0 == "sort":
+                data = stdin.read() if stdin is not None else b""
+                for line in sorted(set(data.splitlines())):
+                    stdout.write(line + b"\n")
+                stdout.flush()
+                proc_stdout = None
+            elif isinstance(cmd0, str) and "expander" in cmd0:
+                data = stdin.read() if stdin is not None else b""
+                proc_stdout = io.BytesIO(data)
+            else:
+                proc_stdout = MagicMock()
             proc = MagicMock()
-            proc.stdout = MagicMock()
+            proc.stdout = proc_stdout
             proc.pid = 1234
             proc.wait.return_value = 0
             return proc
 
-        # lineCount call sequence:
-        #   call 1 (initial, before loop): 1  -> crackedBefore=1, crackedAfter=0 -> enter loop
-        #   call 2 (top of loop body):     1  -> crackedBefore=1
-        #   call 3 (bottom of loop body):  1  -> crackedAfter=1 -> exit loop (1==1)
-        #   call 4 (final hcatFingerprintCount assignment): 1
+        # Constant lineCount makes each escalation length's while-loop
+        # converge after one iteration (crackedAfter == crackedBefore) and
+        # keeps the keyspace guard well under its threshold.
         with (
             patch("hate_crack.main.subprocess.Popen", side_effect=fake_popen),
             patch.object(main_module, "hcatBin", "hashcat"),
@@ -76,8 +84,7 @@ class TestHcatFingerprintOptimizedFlag:
             patch.object(main_module, "hate_path", str(tmp_path)),
             patch.object(main_module, "hcatExpanderBin", "expander.bin"),
             patch.object(main_module, "hcatHashCracked", 0),
-            patch("hate_crack.main.lineCount", side_effect=[1, 1, 1, 1]),
-            patch("hate_crack.main._write_delimited_field"),
+            patch("hate_crack.main.lineCount", lambda _p: 1),
             patch("hate_crack.main.ensure_binary"),
             patch("hate_crack.main.generate_session_id", return_value="test_session"),
         ):

--- a/tests/test_sort_locale.py
+++ b/tests/test_sort_locale.py
@@ -107,7 +107,7 @@ def test_hcatFingerprint_sort_uses_C_locale(monkeypatch, tmp_path):
 
     calls = _collect_sort_calls(monkeypatch, hc_main)
     hc_main.hcatFingerprint(
-        "1000", str(hashfile), expander_len=7, run_hybrid_on_expanded=False
+        "1000", str(hashfile), max_expander_len=7, run_hybrid_on_expanded=False
     )
 
     sort_calls = _sort_calls(calls)


### PR DESCRIPTION
## Summary

The [fingerprint attack wiki](https://hashcat.net/wiki/doku.php?id=fingerprint_attack) describes combining expander output "with itself OR with dictionary entries," escalating from small to big dictionaries. `hcatFingerprint` only ever self-combined a single fixed expander length, re-expanded the whole cracked corpus every convergence-loop iteration, and had no bound on the resulting `-a1` keyspace (which is O(n²) in fragment count). This closes those gaps:

- **Escalating expander length**: `hcatFingerprint` now chains through `7 → 14 → 21 → ...` up to a configurable ceiling (default 21, was a single fixed value), running each length to convergence before advancing. `expander_len` is renamed `max_expander_len` to reflect this.
- **Incremental expansion**: each convergence-loop iteration now expands only newly-cracked plaintexts and merges into the accumulating `.expanded` file, instead of re-running the expander over the entire growing corpus every time.
- **Dictionary combination**: a new optional `dictionary_wordlist` combines expanded fragments against a real wordlist in both orders (`expanded+dict`, `dict+expanded`), in addition to self-combination. `fingerprint_crack` (menu item 5) prompts for it (blank to skip); `extensive_crack` leaves it unset since it can't prompt mid-chain.
- **Combinator-side rules**: every `-a1` combination gets a cheap `-j c -k c` capitalize rule on both sides for free `Capitalized`-variant coverage.
- **Keyspace guardrail**: before each `-a1` call, candidate count (`left_lines * right_lines`) is checked against a 50B threshold. Over it, the standalone Fingerprint Attack asks to proceed (`y/N`); the unattended `extensive_crack` pipeline prints the same warning and skips that combination step instead of blocking on `input()`.

## Test plan
- [x] Rewrote `tests/test_fingerprint_expander_and_hybrid.py`: length-chain escalation, incremental-expansion, dictionary combination (both orders + missing-wordlist warning), `-j`/`-k` rule flags, `_fingerprint_expander_chain` unit tests, `_fingerprint_keyspace_guard` unit tests (under threshold, unattended auto-skip, interactive y/N)
- [x] Updated `tests/test_optimized_kernel.py`, `tests/test_attacks_behavior.py`, `tests/test_sort_locale.py` for the renamed/new `hcatFingerprint` signature
- [x] `python -m pytest tests/ -q` — 2389 passed, 46 skipped
- [x] `uv run ruff check` / `uv run ruff format --check` — clean