### PR TITLE
fix: decode $HEX[...] wrapped plaintexts in hcatTopMask and hcatFingerprint

### DIFF
--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2099,6 +2099,23 @@ def _write_delimited_field(
         return False
 
 
+def _extract_cracked_plaintexts(source_path, working_path):
+    """Extract the plaintext field from a cracked-hash file into
+    working_path, decoding any $HEX[...] wrapping in the process.
+
+    hashcat wraps a cracked plaintext in $HEX[...] whenever it contains a
+    byte that would break the outfile's colon-delimited format (non-UTF-8
+    bytes, control characters, a literal ":" in the password) -- common for
+    hash modes that allow full Unicode, like NTLM. A caller that reads
+    working_path afterward without this decode step gets that literal
+    wrapper text instead of the real password.
+    """
+    _write_delimited_field(source_path, working_path, 2, last_field=True)
+    converted = convert_hex(working_path)
+    with open(working_path, "w") as working:
+        working.writelines("\n".join(converted))
+
+
 def _write_field_sorted_unique(input_path, output_path, field_index, delimiter=":"):
     try:
         with (
@@ -2480,9 +2497,7 @@ def _valid_hcmask(mask: object) -> bool:
 def hcatTopMask(hcatHashType, hcatHashFile, hcatTargetTime):
     global hcatMaskCount
     global hcatProcess
-    _write_delimited_field(
-        f"{hcatHashFile}.out", f"{hcatHashFile}.working", 2, last_field=True
-    )
+    _extract_cracked_plaintexts(f"{hcatHashFile}.out", f"{hcatHashFile}.working")
     hcatProcess = subprocess.Popen(
         [
             sys.executable,
@@ -2795,8 +2810,8 @@ def hcatFingerprint(
         seen_plaintexts: set[str] = set()
         crackedBefore = lineCount(hcatHashFile + ".out")
         while True:
-            _write_delimited_field(
-                f"{hcatHashFile}.out", f"{hcatHashFile}.working", 2, last_field=True
+            _extract_cracked_plaintexts(
+                f"{hcatHashFile}.out", f"{hcatHashFile}.working"
             )
             with open(f"{hcatHashFile}.working", errors="replace") as f:
                 current_plaintexts = {line.rstrip("\n") for line in f if line.strip()}
@@ -4914,14 +4929,7 @@ def hcatLMtoNT():
         out_path=f"{hcatHashFile}.lm.cracked",
     )
 
-    _write_delimited_field(
-        f"{hcatHashFile}.lm.cracked", f"{hcatHashFile}.working", 2, last_field=True
-    )
-    converted = convert_hex("{hash_file}.working".format(hash_file=hcatHashFile))
-    with open(
-        "{hash_file}.working".format(hash_file=hcatHashFile), mode="w"
-    ) as working:
-        working.writelines("\n".join(converted))
+    _extract_cracked_plaintexts(f"{hcatHashFile}.lm.cracked", f"{hcatHashFile}.working")
     combine_path = os.path.join(hate_path, "hashcat-utils", "bin", hcatCombinatorBin)
     with open(f"{hcatHashFile}.combined", "wb") as combined_out:
         combine_proc = subprocess.Popen(
@@ -4981,13 +4989,7 @@ def hcatRecycle(hcatHashType, hcatHashFile, hcatNewPasswords):
     global hcatProcess
     working_file = hcatHashFile + ".working"
     if hcatNewPasswords > 0:
-        _write_delimited_field(f"{hcatHashFile}.out", working_file, 2, last_field=True)
-
-        converted = convert_hex(working_file)
-
-        # Overwrite working file with updated converted words
-        with open(working_file, "w") as f:
-            f.write("\n".join(converted))
+        _extract_cracked_plaintexts(f"{hcatHashFile}.out", working_file)
         for rule in hcatRules:
             rule_path = get_rule_path(rule)
             cmd = [

--- a/tests/test_fingerprint_expander_and_hybrid.py
+++ b/tests/test_fingerprint_expander_and_hybrid.py
@@ -318,6 +318,36 @@ def test_hcatFingerprint_self_combination_uses_capitalize_rule(monkeypatch, tmp_
         assert cmd[cmd.index("-k") + 1] == "c"
 
 
+def test_hcatFingerprint_decodes_hex_wrapped_plaintext_before_expanding(
+    monkeypatch, tmp_path
+):
+    """The expander binary has no $HEX[...] awareness of its own -- a
+    wrapped plaintext must be decoded before it reaches .expanded, or the
+    fingerprint attack rotates substrings of the literal wrapper text
+    instead of the real password."""
+    import hate_crack.main as hc_main
+
+    importlib.reload(hc_main)
+
+    hashfile = tmp_path / "hashes.txt"
+    # "Sömmer2025!" (non-ASCII "ö") -> hashcat wraps it as $HEX[...].
+    plain = "Sömmer2025!"
+    hex_plain = plain.encode("iso-8859-9").hex()
+    (tmp_path / "hashes.txt.out").write_text(f"deadbeef:$HEX[{hex_plain}]\n")
+
+    _install_fingerprint_test_env(monkeypatch, hc_main, tmp_path, hashfile)
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 1)
+
+    seen = {"popen_args": []}
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _SimulatingFakePopen(seen))
+
+    hc_main.hcatFingerprint("1000", str(hashfile), max_expander_len=7)
+
+    fragments = (tmp_path / "hashes.txt.expanded").read_text()
+    assert "Sömmer" in fragments
+    assert "$HEX[" not in fragments
+
+
 def test_hcatFingerprint_combines_against_dictionary_in_both_orders(
     monkeypatch, tmp_path
 ):

--- a/tests/test_hashcat_wrappers.py
+++ b/tests/test_hashcat_wrappers.py
@@ -591,6 +591,39 @@ class TestHcatRecycle:
         assert "/fake/best66.rule" in cmd
 
 
+class TestHcatTopMask:
+    def test_decodes_hex_wrapped_plaintext_before_statsgen(self, main_module, tmp_path):
+        """statsgen.py has no $HEX[...] awareness of its own -- a wrapped
+        plaintext must be decoded before it reaches .working, or mask
+        statistics get derived from the literal wrapper text."""
+        hash_file = str(tmp_path / "hashes.txt")
+        # "Sommer2025!" (non-ASCII "ö") -> hashcat wraps it as $HEX[...].
+        plain = "Sömmer2025!"
+        hex_plain = plain.encode("iso-8859-9").hex()
+        (tmp_path / "hashes.txt.out").write_text(
+            f"deadbeef:$HEX[{hex_plain}]\nfeedface:plainpass\n"
+        )
+        mock_proc = _make_mock_proc()
+
+        with (
+            patch.object(main_module, "hcatBin", "hashcat"),
+            patch.object(main_module, "hcatTuning", ""),
+            patch.object(main_module, "hcatPotfilePath", ""),
+            patch.object(main_module, "hate_path", str(tmp_path)),
+            patch.object(main_module, "hcatHashCracked", 0),
+            patch.object(
+                main_module, "generate_session_id", return_value="test_session"
+            ),
+            patch("hate_crack.main.subprocess.Popen", return_value=mock_proc),
+        ):
+            main_module.hcatTopMask("1000", hash_file, 3600)
+
+        working_lines = (tmp_path / "hashes.txt.working").read_text().splitlines()
+        assert plain in working_lines
+        assert "plainpass" in working_lines
+        assert not any(line.startswith("$HEX[") for line in working_lines)
+
+
 class TestHcatGoodMeasure:
     def test_popen_called_at_least_once(self, main_module, tmp_path):
         hash_file = str(tmp_path / "hashes.txt")


### PR DESCRIPTION
## Summary

hashcat wraps a cracked plaintext in `$HEX[...]` whenever it contains a byte that would break the outfile's colon-delimited format — non-UTF-8 bytes, control characters, a literal `:` in the password. Common for hash modes that allow full Unicode, like NTLM.

`hcatLMtoNT` and `hcatRecycle` already decoded this via `convert_hex()` before using the extracted plaintext. `hcatTopMask` (feeding `PACK/statsgen.py`) and `hcatFingerprint` (feeding the expander binary) did not — neither tool has any `$HEX[...]` awareness of its own, so a wrapped password reached them as the literal wrapper text, polluting Top Mask's mask statistics and producing junk fingerprint fragments for exactly the passwords (Unicode, special characters) where the attack would otherwise be most useful.

## Changes
- Factored the extract-then-decode sequence into `_extract_cracked_plaintexts()` and switched all four call sites (`hcatLMtoNT`, `hcatRecycle`, `hcatTopMask`, `hcatFingerprint`) to it, so a future fifth caller can't repeat the same omission by hand.

## Test plan
- [x] `TestHcatTopMask::test_decodes_hex_wrapped_plaintext_before_statsgen` — writes a `$HEX[...]`-wrapped Unicode plaintext to `.out`, verifies `.working` (fed to `statsgen.py`) contains the decoded password, not the literal wrapper
- [x] `test_hcatFingerprint_decodes_hex_wrapped_plaintext_before_expanding` — same check for `.expanded` (fed to the expander binary)
- [x] `python -m pytest tests/ -q` — 2400 passed, 46 skipped
- [x] `uv run ruff check` / `uv run ruff format --check` — clean