### PR TITLE
fix: preserve raw bytes when writing hex-decoded plaintexts to .hcmask

### DIFF
--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2989,7 +2989,10 @@ def hcatRosettaMask(hcatHashType, hcatHashFile, description):
         return
 
     hcmask_path = f"{hcatHashFile}.hcmask"
-    with open(hcmask_path, "w", encoding="utf-8") as f:
+    # latin-1, matching hcatSmartMask's .hcmask write: keeps any byte >= 0x80
+    # an LLM backend might emit in a mask literal from being re-encoded into
+    # a different, multi-byte UTF-8 sequence.
+    with open(hcmask_path, "w", encoding="latin-1") as f:
         f.writelines(f"{mask}\n" for mask in valid_masks)
     print(f"Generated {len(valid_masks)} mask(s) -> {hcmask_path}")
 
@@ -3549,7 +3552,12 @@ def hcatSmartMask(
                 continue
 
             hcmask_path = f"{hcatHashFile}.smartmask{index}.hcmask"
-            with open(hcmask_path, "w", encoding="utf-8") as f:
+            # latin-1: fixed-run literals and charsets come from decoded
+            # $HEX[...] plaintexts, where each character already represents
+            # one raw byte (see convert_hex). UTF-8 would re-encode any byte
+            # >= 0x80 into a different, multi-byte sequence, corrupting the
+            # exact bytes hashcat needs to try.
+            with open(hcmask_path, "w", encoding="latin-1") as f:
                 f.writelines(f"{line}\n" for line in lines)
 
             cmd = [
@@ -7508,12 +7516,16 @@ def convert_hex(working_file):
         for line in f:
             match = re.search(regex, line.rstrip("\n"))
             if match:
-                try:
-                    processed_words.append(
-                        binascii.unhexlify(match.group(1)).decode("iso-8859-9")
-                    )
-                except UnicodeDecodeError:
-                    pass
+                # latin-1, not iso-8859-9: matches the byte-preserving convention
+                # the rest of the codebase already uses (see
+                # hate_crack.plaintext.decode_hex_wrapper) -- one raw byte maps
+                # to one character, which callers that write these characters
+                # back out to a hashcat-facing file (e.g. hcatSmartMask's
+                # .hcmask) must re-encode with the same codec to round-trip
+                # the original bytes exactly.
+                processed_words.append(
+                    binascii.unhexlify(match.group(1)).decode("latin-1")
+                )
             else:
                 processed_words.append(line.rstrip("\n"))
 

--- a/tests/test_hcat_rosetta_mask.py
+++ b/tests/test_hcat_rosetta_mask.py
@@ -70,6 +70,28 @@ def test_writes_hcmask_file_and_runs_mask_attack(tmp_path):
     assert hcmask_path in cmd
 
 
+def test_hcmask_file_preserves_high_bytes_in_generated_mask_literals(tmp_path):
+    """A mask literal containing a byte >= 0x80 must reach the .hcmask file
+    as that exact byte, not a UTF-8 re-encoding of it -- see the identical
+    concern in hcatSmartMask's own .hcmask write."""
+    hash_file = tmp_path / "hashes.txt"
+    hash_file.touch()
+
+    with (
+        rosetta_mask_globals(),
+        mock.patch(
+            "hate_crack.main.llm.generate_masks",
+            return_value=["Sömmer?d?d?d"],  # "ö" -> single byte 0xF6 in latin-1
+        ),
+        mock.patch("subprocess.Popen", return_value=_make_proc()),
+    ):
+        hc_main.hcatRosettaMask("0", str(hash_file), "a mask with a literal stem")
+
+    raw_bytes = (tmp_path / "hashes.txt.hcmask").read_bytes()
+    assert b"S\xf6mmer" in raw_bytes  # the original single byte, not \xc3\xb6
+    assert b"\xc3\xb6" not in raw_bytes
+
+
 def test_tuning_and_potfile_reach_the_command(tmp_path):
     hash_file = tmp_path / "hashes.txt"
     hash_file.touch()

--- a/tests/test_smart_mask.py
+++ b/tests/test_smart_mask.py
@@ -387,6 +387,38 @@ def test_hcatSmartMask_decodes_hex_wrapped_plaintext(monkeypatch, tmp_path):
     assert len(popen_calls) == 1  # the $HEX[...] entry still joined the cluster
 
 
+def test_hcatSmartMask_hcmask_file_preserves_high_bytes_from_hex_wrapper(
+    monkeypatch, tmp_path
+):
+    """A cracked plaintext containing a byte >= 0x80 (why hashcat had to
+    $HEX[...]-wrap it in the first place) must reach the .hcmask file as
+    that exact byte. Writing the file as UTF-8 would re-encode it into a
+    different, multi-byte sequence that hashcat would never match."""
+    import hate_crack.main as hc_main
+
+    importlib.reload(hc_main)
+
+    hashfile = tmp_path / "hashes.txt"
+    plain_stem = "Sömmer"  # "ö" (U+00F6) -> single byte 0xF6 in latin-1
+    hex_lines = "\n".join(
+        f"h{i}:$HEX[{(plain_stem + digits).encode('latin-1').hex()}]"
+        for i, digits in enumerate(["432", "559", "134"])
+    )
+    (tmp_path / "hashes.txt.out").write_text(hex_lines + "\n")
+    _install_smart_mask_test_env(monkeypatch, hc_main, hashfile)
+    monkeypatch.setattr(hc_main, "lineCount", lambda _p: 3)
+
+    popen_calls = []
+    monkeypatch.setattr(hc_main.subprocess, "Popen", _NoopPopen(popen_calls))
+
+    hc_main.hcatSmartMask("1000", str(hashfile))
+
+    hcmask_path = tmp_path / "hashes.txt.smartmask1.hcmask"
+    raw_bytes = hcmask_path.read_bytes()
+    assert b"S\xf6mmer" in raw_bytes  # the original single byte, not UTF-8's \xc3\xb6
+    assert b"\xc3\xb6" not in raw_bytes
+
+
 def test_hcatSmartMask_keyspace_guard_skips_oversized_template(
     monkeypatch, tmp_path, capsys
 ):


### PR DESCRIPTION
## Summary
- `convert_hex()` decoded `$HEX[...]`-wrapped cracked plaintexts as `iso-8859-9` instead of the byte-preserving `latin-1` convention `hate_crack.plaintext.decode_hex_wrapper` already established elsewhere in the codebase.
- `hcatSmartMask` and `hcatRosettaMask` both wrote their generated `.hcmask` files with `encoding="utf-8"`. Since each decoded character already represents one raw byte (0-255), writing it back out as UTF-8 re-encodes any byte >= 0x80 into a different, multi-byte sequence.
- Together, a Smart Mask cluster built from a password hashcat had to `$HEX[]`-wrap (i.e. anything with a non-ASCII byte) would generate a `.hcmask` file containing the wrong bytes -- the attack could never match the real candidate.
- Fixed by standardizing on `latin-1` for both the hex-decode step and both `.hcmask` file writes, so the byte round-trips exactly.

## Test plan
- [x] Added `test_hcatSmartMask_hcmask_file_preserves_high_bytes_from_hex_wrapper` -- hex-wraps a password containing a genuine high byte, runs `hcatSmartMask`, and asserts the `.hcmask` file's raw bytes match the original byte rather than a UTF-8 re-encoding.
- [x] Added `test_hcmask_file_preserves_high_bytes_in_generated_mask_literals` (hcatRosettaMask) as defense-in-depth for the same class of bug.
- [x] Full suite passes: `uv run pytest -q` (2860 passed, 46 skipped).
- [x] `uv run ruff format --check` / `uv run ruff check` clean.
- [x] `uv run ty check --exit-zero-on-warning hate_crack` exits 0 (53 pre-existing warnings, no new errors).