### PR TITLE
fix(coverage): prompt once for a batch of rule files, not once per file

### DIFF
--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -205,6 +205,10 @@ def quick_crack(ctx: Any) -> None:
     if selected_rules is None:
         return
 
+    # Shared across every chain below so the "skip already-covered ground?"
+    # prompt fires once for the whole selection instead of once per rule
+    # file -- see hate_crack.main._apply_coverage.
+    coverage_decision: dict = {}
     for chain in selected_rules:
         ctx.hcatQuickDictionary(
             ctx.hcatHashType,
@@ -212,6 +216,7 @@ def quick_crack(ctx: Any) -> None:
             chain,
             wordlist_choice,
             attack_name="Quick Crack",
+            coverage_decision=coverage_decision,
         )
 
 
@@ -229,6 +234,10 @@ def loopback_attack(ctx: Any) -> None:
     if selected_rules is None:
         return
 
+    # Shared across every chain below so the "skip already-covered ground?"
+    # prompt fires once for the whole selection instead of once per rule
+    # file -- see hate_crack.main._apply_coverage.
+    coverage_decision: dict = {}
     for chain in selected_rules:
         ctx.hcatQuickDictionary(
             ctx.hcatHashType,
@@ -237,6 +246,7 @@ def loopback_attack(ctx: Any) -> None:
             empty_wordlist,
             loopback=True,
             attack_name="Loopback",
+            coverage_decision=coverage_decision,
         )
 
 

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1641,12 +1641,19 @@ def _prompt_coverage_filter(plan, attack_name: str, spec=None) -> bool:
     return answer.lower() not in ("n", "no")
 
 
-def _apply_coverage(cmd, spec, attack_name: str):
+def _apply_coverage(cmd, spec, attack_name: str, decision_cache: dict | None = None):
     """Resolve coverage for a pending run.
 
     Returns ``None`` when the whole run is a repeat and should be skipped, or
     ``(cmd, plan, temp_paths)`` otherwise. ``plan`` is ``None`` when coverage
     could not be established, which means neither filter nor record.
+
+    ``decision_cache``, when given, lets a caller that issues several related
+    runs in a row -- one hashcat invocation per rule file selected against
+    the same wordlist, say -- ask the "skip already-covered ground?" question
+    only once. The first call with overlap prompts and stores its answer in
+    the shared dict; every later call sharing that same dict reuses it
+    without prompting again, even though each has its own, different plan.
     """
     store = _coverage_store()
     plan = _coverage.plan_run(spec, store.covered, store=store)
@@ -1656,7 +1663,14 @@ def _apply_coverage(cmd, spec, attack_name: str):
     if not plan.has_overlap:
         return cmd, plan, []
 
-    if not _prompt_coverage_filter(plan, attack_name, spec):
+    if decision_cache is not None and "apply_filtering" in decision_cache:
+        apply_filtering = decision_cache["apply_filtering"]
+    else:
+        apply_filtering = _prompt_coverage_filter(plan, attack_name, spec)
+        if decision_cache is not None:
+            decision_cache["apply_filtering"] = apply_filtering
+
+    if not apply_filtering:
         print("[*] Running everything, as requested.")
         return cmd, plan, []
 
@@ -1793,6 +1807,7 @@ def _run_hcat_cmd(
     hash_file: str | None = None,
     *,
     coverage=None,
+    coverage_decision: dict | None = None,
     stdin=None,
     companion_procs=None,
     reraise_interrupt: bool = False,
@@ -1807,6 +1822,12 @@ def _run_hcat_cmd(
     functions pass it explicitly. Omitting it disables coverage for that
     invocation, which is how dynamic candidate generators opt out.
 
+    ``coverage_decision`` is an optional shared dict a caller passes to
+    several calls in a row -- e.g. one hashcat invocation per rule file
+    selected against the same wordlist -- so the "skip already-covered
+    ground?" prompt fires once for that whole batch rather than once per
+    invocation. See :func:`_apply_coverage`.
+
     Coverage is recorded only on clean completion, so a ctrl-C or a hashcat
     error never leaves the store claiming ground that was not covered.
     """
@@ -1816,7 +1837,7 @@ def _run_hcat_cmd(
     global _hcat_launch_count, _coverage_skip_count
 
     if coverage is not None and _coverage_enabled:
-        applied = _apply_coverage(cmd, coverage, attack_name)
+        applied = _apply_coverage(cmd, coverage, attack_name, coverage_decision)
         if applied is None:
             _coverage_skip_count += 1
             return
@@ -2883,6 +2904,7 @@ def hcatQuickDictionary(
     use_potfile_path=True,
     potfile_path=None,
     attack_name="Quick Dictionary",
+    coverage_decision: dict | None = None,
 ):
     global hcatProcess
     cmd = [
@@ -2918,6 +2940,7 @@ def hcatQuickDictionary(
         coverage=_quick_dictionary_coverage(
             hcatHashFile, hcatChains, wordlists, loopback
         ),
+        coverage_decision=coverage_decision,
     )
 
 

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -115,6 +115,35 @@ class TestLoopbackAttack:
         empty_wordlist_arg = call_args[0][3]
         assert empty_wordlist_arg.endswith("empty.txt")
 
+    def test_multiple_selected_rules_share_one_coverage_decision(
+        self, tmp_path: Path
+    ) -> None:
+        """Selecting several rule files (e.g. "1,2") runs hcatQuickDictionary
+        once per file, but all of them must share the same coverage_decision
+        dict so the "skip already-covered ground?" prompt fires only once
+        for the whole selection -- see hate_crack.main._apply_coverage."""
+        ctx = _make_ctx()
+        ctx.hcatWordlists = str(tmp_path / "wordlists")
+        ctx.rulesDirectory = str(tmp_path / "rules")
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "best66.rule").write_text("")
+        (rules_dir / "d3ad0ne.rule").write_text("")
+        ctx.list_rule_files.return_value = ["best66.rule", "d3ad0ne.rule"]
+
+        with patch("builtins.input", return_value="1,2"):
+            loopback_attack(ctx)
+
+        assert ctx.hcatQuickDictionary.call_count == 2
+        decisions = [
+            call.kwargs.get("coverage_decision")
+            for call in ctx.hcatQuickDictionary.call_args_list
+        ]
+        assert decisions[0] is not None
+        assert decisions[0] is decisions[1], (
+            "every call in the batch must share the same decision object"
+        )
+
 
 class TestExtensiveCrack:
     def test_calls_all_attack_methods(self) -> None:

--- a/tests/test_coverage_wiring.py
+++ b/tests/test_coverage_wiring.py
@@ -188,6 +188,97 @@ def test_no_prompt_when_there_is_no_overlap(main_module, store, env):
         main_module._run_hcat_cmd(cmd, attack_name="Dictionary", coverage=_spec(env))
 
 
+def test_shared_decision_cache_prompts_only_once(main_module, store, env):
+    """Two rule files run back to back against the same wordlist -- as Quick
+    Crack and Loopback do via a shared coverage_decision dict -- must ask
+    the 'skip already-covered ground?' question once, and reuse that answer
+    to filter each run's own overlap without asking again."""
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env))  # fully covers "c", "$1", "u"
+
+    partial_a = env["tmp"] / "partial_a.rule"
+    partial_a.write_text("c\n$1\nq\n")  # 2 of 3 already covered
+    partial_b = env["tmp"] / "partial_b.rule"
+    partial_b.write_text("c\nz\n")  # 1 of 2 already covered
+
+    prompts = []
+
+    def counting_input(prompt=""):
+        prompts.append(prompt)
+        return "y"
+
+    seen_rules = []
+
+    def fake_popen(cmd, **kwargs):
+        if "-r" in cmd:
+            seen_rules.append(ac.read_entries(cmd[cmd.index("-r") + 1]))
+        return FakePopen(cmd)
+
+    decision_cache: dict = {}
+    with (
+        patch.object(main_module.subprocess, "Popen", fake_popen),
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module, "non_interactive", False),
+        patch("builtins.input", counting_input),
+    ):
+        main_module._run_hcat_cmd(
+            ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial_a)],
+            attack_name="Quick Crack",
+            coverage=_spec(env, rule_files=(str(partial_a),)),
+            coverage_decision=decision_cache,
+        )
+        main_module._run_hcat_cmd(
+            ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial_b)],
+            attack_name="Quick Crack",
+            coverage=_spec(env, rule_files=(str(partial_b),)),
+            coverage_decision=decision_cache,
+        )
+
+    assert len(prompts) == 1, "the second run must reuse the first's answer"
+    assert seen_rules == [["q"], ["z"]], "each run's own overlap must still be filtered"
+
+
+def test_shared_decision_cache_honors_a_declined_prompt(main_module, store, env):
+    """Declining the one shared prompt must make every run in the batch run
+    unfiltered, not just the first."""
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env))  # fully covers "c", "$1", "u"
+
+    partial_a = env["tmp"] / "partial_a.rule"
+    partial_a.write_text("c\n$1\nq\n")
+    partial_b = env["tmp"] / "partial_b.rule"
+    partial_b.write_text("c\nz\n")
+
+    launched = []
+
+    def fake_popen(cmd, **kwargs):
+        launched.append(list(cmd))
+        return FakePopen(cmd)
+
+    decision_cache: dict = {}
+    with (
+        patch.object(main_module.subprocess, "Popen", fake_popen),
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module, "non_interactive", False),
+        patch("builtins.input", lambda *a: "n"),
+    ):
+        main_module._run_hcat_cmd(
+            ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial_a)],
+            attack_name="Quick Crack",
+            coverage=_spec(env, rule_files=(str(partial_a),)),
+            coverage_decision=decision_cache,
+        )
+        main_module._run_hcat_cmd(
+            ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial_b)],
+            attack_name="Quick Crack",
+            coverage=_spec(env, rule_files=(str(partial_b),)),
+            coverage_decision=decision_cache,
+        )
+
+    assert launched[0][launched[0].index("-r") + 1] == str(partial_a)
+    assert launched[1][launched[1].index("-r") + 1] == str(partial_b)
+
+
 # --- opting out ------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Quick Crack and Loopback let an operator select several rule files to run sequentially against one wordlist, each becoming its own `hcatQuickDictionary`/`_run_hcat_cmd` invocation.
- Coverage's "skip already-covered ground?" prompt fires per `_run_hcat_cmd` call, so a multi-rule-file selection paused the attack chain once per file instead of once for the whole batch -- exactly as reported.
- `_run_hcat_cmd`/`_apply_coverage` now take an optional `coverage_decision` dict. The first call with overlap prompts as before and stores its answer there; every later call sharing that same dict reuses the answer without prompting again, while still computing and applying its own plan's filtering (a rule file that's 90% covered still only runs its untried 10%, even though it didn't ask).
- `quick_crack` and `loopback_attack` each create one such dict before their rule-selection loop and pass it to every `hcatQuickDictionary` call in that loop.
- Declining the shared prompt ("run everything") also applies to the whole batch, not just the first file.

## Test plan
- [x] `test_shared_decision_cache_prompts_only_once` -- two rule files with independent partial overlap against the same wordlist prompt exactly once, and each still gets its own overlap filtered.
- [x] `test_shared_decision_cache_honors_a_declined_prompt` -- declining the one shared prompt runs every file in the batch unfiltered.
- [x] `test_multiple_selected_rules_share_one_coverage_decision` -- `loopback_attack` with a "1,2" rule selection calls `hcatQuickDictionary` twice, both times with the *same* `coverage_decision` object (identity check).
- [x] Full suite: `uv run pytest -q` (3006 passed, 46 skipped).
- [x] `uv run ruff format --check` / `uv run ruff check` clean.
- [x] `uv run ty check --exit-zero-on-warning hate_crack` exits 0.