### PR TITLE
fix(coverage): prime the batch decision from an aggregate view up front

### DIFF
--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -205,10 +205,14 @@ def quick_crack(ctx: Any) -> None:
     if selected_rules is None:
         return
 
-    # Shared across every chain below so the "skip already-covered ground?"
-    # prompt fires once for the whole selection instead of once per rule
-    # file -- see hate_crack.main._apply_coverage.
-    coverage_decision: dict = {}
+    # Primed once, up front, against the combined coverage across every
+    # selected rule file -- so the "skip already-covered ground?" prompt (if
+    # any) reflects the whole batch and fires before any hashcat invocation,
+    # not just the first chain's own numbers. See
+    # hate_crack.main._prime_coverage_decision / _apply_coverage.
+    coverage_decision = ctx._prime_coverage_decision(
+        ctx.hcatHashFile, selected_rules, wordlist_choice, "Quick Crack"
+    )
     for chain in selected_rules:
         ctx.hcatQuickDictionary(
             ctx.hcatHashType,
@@ -234,10 +238,18 @@ def loopback_attack(ctx: Any) -> None:
     if selected_rules is None:
         return
 
-    # Shared across every chain below so the "skip already-covered ground?"
-    # prompt fires once for the whole selection instead of once per rule
-    # file -- see hate_crack.main._apply_coverage.
-    coverage_decision: dict = {}
+    # Primed once, up front, against the combined coverage across every
+    # selected rule file -- so the "skip already-covered ground?" prompt (if
+    # any) reflects the whole batch and fires before any hashcat invocation,
+    # not just the first chain's own numbers. See
+    # hate_crack.main._prime_coverage_decision / _apply_coverage.
+    coverage_decision = ctx._prime_coverage_decision(
+        ctx.hcatHashFile,
+        selected_rules,
+        empty_wordlist,
+        "Loopback",
+        loopback=True,
+    )
     for chain in selected_rules:
         ctx.hcatQuickDictionary(
             ctx.hcatHashType,

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1674,20 +1674,9 @@ def _apply_coverage(cmd, spec, attack_name: str, decision_cache: dict | None = N
     only once. The first call with overlap prompts and stores its answer in
     the shared dict; every later call sharing that same dict reuses it
     without prompting again, even though each has its own, different plan.
-
-    ``decision_cache["plans"]``, when present (populated by
-    ``_prime_coverage_decision``), supplies this spec's ``RunPlan`` directly
-    instead of recomputing it. Diffing a multi-million-line rule file against
-    the covered set hashes every one of its lines, so recomputing it here
-    after already computing it once while priming the aggregate decision
-    would pay that cost twice for every file in the batch.
     """
     store = _coverage_store()
-    plan = None
-    if decision_cache is not None:
-        plan = decision_cache.get("plans", {}).get(spec)
-    if plan is None:
-        plan = _coverage.plan_run(spec, store.covered, store=store)
+    plan = _coverage.plan_run(spec, store.covered, store=store)
     if plan.is_inert:
         return cmd, None, []
 
@@ -3003,76 +2992,71 @@ def _quick_dictionary_coverage(hash_file, chains, wordlists, loopback):
     )
 
 
+def _prompt_skip_covered_batch(attack_name: str, num_chains: int) -> bool:
+    """Ask, without pre-computing any counts, whether to skip already-tried
+    rule lines across a whole batch of selected rule files, or run every one
+    of them in full.
+
+    Only reached when ``attack_name`` has run against this hash file before
+    (see ``_prime_coverage_decision``); a fresh engagement never sees this.
+    Default is yes, matching ``_prompt_coverage_filter``.
+    """
+    plural = "" if num_chains == 1 else "s"
+    print(
+        f"\n[*] {attack_name or 'This attack'} has run against this hash file before."
+    )
+    if non_interactive:
+        return True
+    try:
+        answer = input(
+            f"[?] Skip rule lines already tried in the {num_chains} selected "
+            f"rule file{plural}, or run everything? [Y/n]: "
+        ).strip()
+    except EOFError:
+        print("[*] No input available; taking the default and filtering.")
+        return True
+    return answer.lower() not in ("n", "no")
+
+
 def _prime_coverage_decision(
     hash_file, chains, wordlists, attack_name: str, loopback: bool = False
 ) -> dict:
-    """Compute one combined coverage view across every chain about to run,
-    and if there is overlap anywhere in it, ask the "skip already-covered
-    ground?" question exactly once for the whole batch, before any of it
-    runs.
+    """Ask once, up front, whether to skip already-covered rule lines for
+    this whole batch of selected rule files -- before any of it runs, and
+    without diffing any of them first.
 
-    Quick Crack and Loopback run one hashcat invocation per selected rule
-    file/chain against the same wordlist. Passing the returned dict to
-    every subsequent ``_run_hcat_cmd(..., coverage_decision=...)`` call
-    reuses this one decision (see ``_apply_coverage``) -- but without this,
-    that first call's *own* possibly-unrepresentative numbers (a huge rule
-    file that happens to be fully covered, say) drove the only prompt an
-    operator saw, rather than a true picture of the whole selection.
+    Finding the exact overlap for a display like "N of M rules already
+    covered" means reading and hashing every selected rule file's lines,
+    which for a large batch (YOLO across dozens of files, some
+    multi-million lines) is exactly the slow, silent-feeling step an
+    operator should not have to wait through just to be asked a yes/no
+    question. So this checks only whether ``attack_name`` has ever run
+    against this hash file before -- one cheap store lookup, no file
+    reading -- and, if so, asks plainly. The real per-file diffing still
+    happens lazily, once per chain, inside ``_apply_coverage`` exactly as
+    it always has; this only decides up front whether that filtering is
+    wanted.
 
-    Returns an empty dict when there is nothing to prime -- no coverage
-    store, nothing in the batch is covered yet, or a record-only (loopback)
-    batch, which never has overlap to report -- so the batch behaves exactly
-    as if coverage were untouched.
-
-    The ``RunPlan`` computed here for each chain is handed back under the
-    ``"plans"`` key so ``_apply_coverage`` can reuse it instead of diffing
-    the same rule file against the covered set a second time once the batch
-    actually starts running (see its docstring). That reuse is why this
-    function always returns those plans, even when there is nothing to
-    prompt about.
+    Returns an empty dict when there is nothing to ask about: coverage is
+    disabled, the batch is empty, it is a record-only (loopback) run that
+    can never overlap, or ``attack_name`` has never run against this hash
+    file before -- so a fresh engagement never sees the prompt.
     """
     if not _coverage_enabled or not chains or loopback:
         return {}
 
-    if len(chains) > 1:
-        print(
-            f"[*] Checking coverage across {len(chains)} selected rule "
-            "files before starting..."
-        )
+    target = _coverage.target_id(hash_file)
+    if target is None:
+        return {}
 
-    store = _coverage_store()
-    plan_cache: dict = {}
-    plans = []
-    first_spec = None
-    for chain in chains:
-        spec = _quick_dictionary_coverage(hash_file, chain, wordlists, loopback)
-        if first_spec is None:
-            first_spec = spec
-        plan = _coverage.plan_run(spec, store.covered, store=store)
-        plan_cache[spec] = plan
-        if not plan.is_inert:
-            plans.append(plan)
-
-    decision: dict = {"plans": plan_cache}
-
-    if not plans:
-        return decision
-
-    total_count = sum(plan.total_count for plan in plans)
-    covered_count = sum(plan.covered_count for plan in plans)
-    if covered_count == 0:
-        return decision
-
-    aggregate = _coverage.RunPlan(
-        kind=plans[0].kind,
-        skip=covered_count == total_count,
-        covered_count=covered_count,
-        total_count=total_count,
+    has_run_before = any(
+        attack == attack_name and runs
+        for attack, _entries, runs in _coverage_store().summary(target)["by_attack"]
     )
-    decision["apply_filtering"] = _prompt_coverage_filter(
-        aggregate, attack_name, first_spec
-    )
-    return decision
+    if not has_run_before:
+        return {}
+
+    return {"apply_filtering": _prompt_skip_covered_batch(attack_name, len(chains))}
 
 
 def _valid_hcmask(mask: object) -> bool:

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1674,9 +1674,20 @@ def _apply_coverage(cmd, spec, attack_name: str, decision_cache: dict | None = N
     only once. The first call with overlap prompts and stores its answer in
     the shared dict; every later call sharing that same dict reuses it
     without prompting again, even though each has its own, different plan.
+
+    ``decision_cache["plans"]``, when present (populated by
+    ``_prime_coverage_decision``), supplies this spec's ``RunPlan`` directly
+    instead of recomputing it. Diffing a multi-million-line rule file against
+    the covered set hashes every one of its lines, so recomputing it here
+    after already computing it once while priming the aggregate decision
+    would pay that cost twice for every file in the batch.
     """
     store = _coverage_store()
-    plan = _coverage.plan_run(spec, store.covered, store=store)
+    plan = None
+    if decision_cache is not None:
+        plan = decision_cache.get("plans", {}).get(spec)
+    if plan is None:
+        plan = _coverage.plan_run(spec, store.covered, store=store)
     if plan.is_inert:
         return cmd, None, []
 
@@ -3009,13 +3020,28 @@ def _prime_coverage_decision(
     operator saw, rather than a true picture of the whole selection.
 
     Returns an empty dict when there is nothing to prime -- no coverage
-    store, or nothing in the batch is covered yet -- so the batch behaves
-    exactly as if coverage were untouched.
+    store, nothing in the batch is covered yet, or a record-only (loopback)
+    batch, which never has overlap to report -- so the batch behaves exactly
+    as if coverage were untouched.
+
+    The ``RunPlan`` computed here for each chain is handed back under the
+    ``"plans"`` key so ``_apply_coverage`` can reuse it instead of diffing
+    the same rule file against the covered set a second time once the batch
+    actually starts running (see its docstring). That reuse is why this
+    function always returns those plans, even when there is nothing to
+    prompt about.
     """
-    if not _coverage_enabled or not chains:
+    if not _coverage_enabled or not chains or loopback:
         return {}
 
+    if len(chains) > 1:
+        print(
+            f"[*] Checking coverage across {len(chains)} selected rule "
+            "files before starting..."
+        )
+
     store = _coverage_store()
+    plan_cache: dict = {}
     plans = []
     first_spec = None
     for chain in chains:
@@ -3023,16 +3049,19 @@ def _prime_coverage_decision(
         if first_spec is None:
             first_spec = spec
         plan = _coverage.plan_run(spec, store.covered, store=store)
+        plan_cache[spec] = plan
         if not plan.is_inert:
             plans.append(plan)
 
+    decision: dict = {"plans": plan_cache}
+
     if not plans:
-        return {}
+        return decision
 
     total_count = sum(plan.total_count for plan in plans)
     covered_count = sum(plan.covered_count for plan in plans)
     if covered_count == 0:
-        return {}
+        return decision
 
     aggregate = _coverage.RunPlan(
         kind=plans[0].kind,
@@ -3040,9 +3069,10 @@ def _prime_coverage_decision(
         covered_count=covered_count,
         total_count=total_count,
     )
-    return {
-        "apply_filtering": _prompt_coverage_filter(aggregate, attack_name, first_spec)
-    }
+    decision["apply_filtering"] = _prompt_coverage_filter(
+        aggregate, attack_name, first_spec
+    )
+    return decision
 
 
 def _valid_hcmask(mask: object) -> bool:

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1586,6 +1586,26 @@ def _coverage_overlap_scope(plan, spec) -> str:
     return f"this hash file with {shown}"
 
 
+def _coverage_spec_label(spec) -> str:
+    """A short, human name for what one coverage spec's own run covers.
+
+    A batch (Quick Crack/Loopback selecting several rule files) issues one
+    ``_apply_coverage`` call per file against the same wordlist and hash
+    file, so without this every per-run message -- "skipping", "running
+    everything", "running N new entries" -- reads identically no matter
+    which file it is about.
+    """
+    if spec.rule_files:
+        return " + ".join(os.path.basename(path) for path in spec.rule_files)
+    if spec.mask_files:
+        return " + ".join(os.path.basename(path) for path in spec.mask_files)
+    if spec.masks:
+        return ", ".join(spec.masks)
+    if spec.wordlists:
+        return ", ".join(os.path.basename(path) for path in spec.wordlists)
+    return "this run"
+
+
 def _prompt_coverage_filter(plan, attack_name: str, spec=None) -> bool:
     """Ask whether to skip the already-covered entries. Default is yes.
 
@@ -1670,13 +1690,15 @@ def _apply_coverage(cmd, spec, attack_name: str, decision_cache: dict | None = N
         if decision_cache is not None:
             decision_cache["apply_filtering"] = apply_filtering
 
+    label = _coverage_spec_label(spec)
+
     if not apply_filtering:
-        print("[*] Running everything, as requested.")
+        print(f"[*] Running everything in {label}, as requested.")
         return cmd, plan, []
 
     if plan.skip:
         print(
-            f"[*] Skipping {attack_name or 'this attack'}: every "
+            f"[*] Skipping {attack_name or 'this attack'} ({label}): every "
             f"{plan.kind or 'entry'} in it has already been run against this "
             "hash file."
         )
@@ -1702,7 +1724,7 @@ def _apply_coverage(cmd, spec, attack_name: str, decision_cache: dict | None = N
         cmd = _replace_rule_arg(cmd, plan.source_path, replacement, plan.kind)
 
     print(
-        f"[*] Coverage: running {len(plan.filtered_entries)} new "
+        f"[*] Coverage ({label}): running {len(plan.filtered_entries)} new "
         f"{plan.kind} entr{'y' if len(plan.filtered_entries) == 1 else 'ies'} "
         f"and skipping {plan.covered_count} already covered."
     )

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2970,6 +2970,59 @@ def _quick_dictionary_coverage(hash_file, chains, wordlists, loopback):
     )
 
 
+def _prime_coverage_decision(
+    hash_file, chains, wordlists, attack_name: str, loopback: bool = False
+) -> dict:
+    """Compute one combined coverage view across every chain about to run,
+    and if there is overlap anywhere in it, ask the "skip already-covered
+    ground?" question exactly once for the whole batch, before any of it
+    runs.
+
+    Quick Crack and Loopback run one hashcat invocation per selected rule
+    file/chain against the same wordlist. Passing the returned dict to
+    every subsequent ``_run_hcat_cmd(..., coverage_decision=...)`` call
+    reuses this one decision (see ``_apply_coverage``) -- but without this,
+    that first call's *own* possibly-unrepresentative numbers (a huge rule
+    file that happens to be fully covered, say) drove the only prompt an
+    operator saw, rather than a true picture of the whole selection.
+
+    Returns an empty dict when there is nothing to prime -- no coverage
+    store, or nothing in the batch is covered yet -- so the batch behaves
+    exactly as if coverage were untouched.
+    """
+    if not _coverage_enabled or not chains:
+        return {}
+
+    store = _coverage_store()
+    plans = []
+    first_spec = None
+    for chain in chains:
+        spec = _quick_dictionary_coverage(hash_file, chain, wordlists, loopback)
+        if first_spec is None:
+            first_spec = spec
+        plan = _coverage.plan_run(spec, store.covered, store=store)
+        if not plan.is_inert:
+            plans.append(plan)
+
+    if not plans:
+        return {}
+
+    total_count = sum(plan.total_count for plan in plans)
+    covered_count = sum(plan.covered_count for plan in plans)
+    if covered_count == 0:
+        return {}
+
+    aggregate = _coverage.RunPlan(
+        kind=plans[0].kind,
+        skip=covered_count == total_count,
+        covered_count=covered_count,
+        total_count=total_count,
+    )
+    return {
+        "apply_filtering": _prompt_coverage_filter(aggregate, attack_name, first_spec)
+    }
+
+
 def _valid_hcmask(mask: object) -> bool:
     """Is *mask* a syntactically valid hashcat brute-force mask (or hcmask line)?
 

--- a/tests/test_attacks_behavior.py
+++ b/tests/test_attacks_behavior.py
@@ -144,6 +144,41 @@ class TestLoopbackAttack:
             "every call in the batch must share the same decision object"
         )
 
+    def test_coverage_decision_is_primed_before_any_run(self, tmp_path: Path) -> None:
+        """The aggregate coverage prompt (if any) must be computed from every
+        selected rule file up front -- before the first hashcat invocation --
+        rather than reactively from whichever chain happens to run first.
+        See hate_crack.main._prime_coverage_decision."""
+        ctx = _make_ctx()
+        ctx.hcatWordlists = str(tmp_path / "wordlists")
+        ctx.rulesDirectory = str(tmp_path / "rules")
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "best66.rule").write_text("")
+        (rules_dir / "d3ad0ne.rule").write_text("")
+        ctx.list_rule_files.return_value = ["best66.rule", "d3ad0ne.rule"]
+
+        call_order = []
+        ctx._prime_coverage_decision.side_effect = lambda *a, **k: (
+            call_order.append("prime") or {}
+        )
+        ctx.hcatQuickDictionary.side_effect = lambda *a, **k: call_order.append("run")
+
+        with patch("builtins.input", return_value="1,2"):
+            loopback_attack(ctx)
+
+        assert call_order == ["prime", "run", "run"]
+        ctx._prime_coverage_decision.assert_called_once_with(
+            ctx.hcatHashFile,
+            [
+                "-r " + str(rules_dir / "best66.rule"),
+                "-r " + str(rules_dir / "d3ad0ne.rule"),
+            ],
+            os.path.join(ctx.hcatWordlists, "empty.txt"),
+            "Loopback",
+            loopback=True,
+        )
+
 
 class TestExtensiveCrack:
     def test_calls_all_attack_methods(self) -> None:

--- a/tests/test_coverage_wiring.py
+++ b/tests/test_coverage_wiring.py
@@ -279,6 +279,100 @@ def test_shared_decision_cache_honors_a_declined_prompt(main_module, store, env)
     assert launched[1][launched[1].index("-r") + 1] == str(partial_b)
 
 
+# --- priming an aggregate decision up front --------------------------------
+
+
+def test_prime_coverage_decision_prompts_once_with_aggregate_counts(
+    main_module, store, env, capsys
+):
+    """Priming must sum covered/total across every selected chain and show
+    ONE prompt reflecting that combined picture, before any chain runs."""
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env))  # fully covers "c", "$1", "u"
+
+    partial_a = env["tmp"] / "partial_a.rule"
+    partial_a.write_text("c\n$1\nq\n")  # 2 of 3 already covered
+    partial_b = env["tmp"] / "partial_b.rule"
+    partial_b.write_text("c\nz\n")  # 1 of 2 already covered
+
+    prompts = []
+
+    def counting_input(prompt=""):
+        prompts.append(prompt)
+        return "y"
+
+    with (
+        patch.object(main_module, "_coverage_enabled", True),
+        patch("builtins.input", counting_input),
+    ):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"],
+            [f"-r {partial_a}", f"-r {partial_b}"],
+            env["wordlist"],
+            "Quick Crack",
+        )
+
+    assert decision == {"apply_filtering": True}
+    assert len(prompts) == 1, "one prompt for the whole batch, not per chain"
+    out = capsys.readouterr().out
+    assert "3 of 5 rules" in out, (
+        "aggregate must sum both partials' covered/total counts"
+    )
+
+
+def test_prime_coverage_decision_is_empty_when_nothing_is_covered(
+    main_module, store, env
+):
+    fresh_a = env["tmp"] / "fresh_a.rule"
+    fresh_a.write_text("l\n")
+    fresh_b = env["tmp"] / "fresh_b.rule"
+    fresh_b.write_text("u\n")
+
+    with patch.object(main_module, "_coverage_enabled", True):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"],
+            [f"-r {fresh_a}", f"-r {fresh_b}"],
+            env["wordlist"],
+            "Quick Crack",
+        )
+
+    assert decision == {}
+
+
+def test_prime_coverage_decision_honors_a_declined_prompt(main_module, store, env):
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env))  # fully covers "c", "$1", "u"
+
+    partial_a = env["tmp"] / "partial_a.rule"
+    partial_a.write_text("c\n$1\nq\n")
+
+    with (
+        patch.object(main_module, "_coverage_enabled", True),
+        patch("builtins.input", lambda *a: "n"),
+    ):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"], [f"-r {partial_a}"], env["wordlist"], "Quick Crack"
+        )
+
+    assert decision == {"apply_filtering": False}
+
+
+def test_prime_coverage_decision_disabled_flag_is_a_noop(main_module, store, env):
+    with patch.object(main_module, "_coverage_enabled", False):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"], [f"-r {env['rules']}"], env["wordlist"], "Quick Crack"
+        )
+    assert decision == {}
+
+
+def test_prime_coverage_decision_empty_chain_list_is_a_noop(main_module, store, env):
+    with patch.object(main_module, "_coverage_enabled", True):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"], [], env["wordlist"], "Quick Crack"
+        )
+    assert decision == {}
+
+
 # --- opting out ------------------------------------------------------------
 
 

--- a/tests/test_coverage_wiring.py
+++ b/tests/test_coverage_wiring.py
@@ -406,7 +406,7 @@ def test_prime_coverage_decision_prompts_once_with_aggregate_counts(
             "Quick Crack",
         )
 
-    assert decision == {"apply_filtering": True}
+    assert decision.get("apply_filtering") is True
     assert len(prompts) == 1, "one prompt for the whole batch, not per chain"
     out = capsys.readouterr().out
     assert "3 of 5 rules" in out, (
@@ -430,7 +430,9 @@ def test_prime_coverage_decision_is_empty_when_nothing_is_covered(
             "Quick Crack",
         )
 
-    assert decision == {}
+    assert "apply_filtering" not in decision, (
+        "no overlap anywhere means nothing to ask about"
+    )
 
 
 def test_prime_coverage_decision_honors_a_declined_prompt(main_module, store, env):
@@ -448,7 +450,7 @@ def test_prime_coverage_decision_honors_a_declined_prompt(main_module, store, en
             env["hashes"], [f"-r {partial_a}"], env["wordlist"], "Quick Crack"
         )
 
-    assert decision == {"apply_filtering": False}
+    assert decision.get("apply_filtering") is False
 
 
 def test_prime_coverage_decision_disabled_flag_is_a_noop(main_module, store, env):
@@ -465,6 +467,107 @@ def test_prime_coverage_decision_empty_chain_list_is_a_noop(main_module, store, 
             env["hashes"], [], env["wordlist"], "Quick Crack"
         )
     assert decision == {}
+
+
+def test_prime_coverage_decision_skips_priming_for_loopback(main_module, store, env):
+    """record_only specs never have overlap to report, so priming a loopback
+    batch would only pay the cost of diffing every rule file for a prompt
+    that can never fire. Skip the work entirely."""
+    calls = []
+    real_plan_run = main_module._coverage.plan_run
+
+    def counting_plan_run(spec, *a, **k):
+        calls.append(spec)
+        return real_plan_run(spec, *a, **k)
+
+    with (
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module._coverage, "plan_run", counting_plan_run),
+    ):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"],
+            [f"-r {env['rules']}"],
+            env["wordlist"],
+            "Loopback",
+            loopback=True,
+        )
+
+    assert decision == {}
+    assert calls == [], "loopback priming must not diff any rule file"
+
+
+def test_priming_avoids_recomputing_the_plan_for_the_real_run(main_module, store, env):
+    """Once _prime_coverage_decision has diffed a rule file to build the
+    aggregate, _apply_coverage must reuse that plan instead of diffing the
+    same (potentially multi-million-line) file a second time."""
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env))  # fully covers "c", "$1", "u"
+
+    partial_a = env["tmp"] / "partial_a.rule"
+    partial_a.write_text("c\n$1\nq\n")
+    partial_b = env["tmp"] / "partial_b.rule"
+    partial_b.write_text("c\nz\n")
+
+    calls = []
+    real_plan_run = main_module._coverage.plan_run
+
+    def counting_plan_run(spec, *a, **k):
+        calls.append(spec)
+        return real_plan_run(spec, *a, **k)
+
+    with (
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module._coverage, "plan_run", counting_plan_run),
+        patch("builtins.input", lambda *a: "y"),
+    ):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"],
+            [f"-r {partial_a}", f"-r {partial_b}"],
+            env["wordlist"],
+            "Quick Crack",
+        )
+        assert len(calls) == 2, "priming diffs each chain exactly once"
+
+        with (
+            patch.object(
+                main_module.subprocess, "Popen", lambda cmd, **kw: FakePopen(cmd)
+            ),
+            patch.object(main_module, "non_interactive", False),
+        ):
+            main_module._run_hcat_cmd(
+                ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial_a)],
+                attack_name="Quick Crack",
+                coverage=_spec(env, rule_files=(str(partial_a),)),
+                coverage_decision=decision,
+            )
+            main_module._run_hcat_cmd(
+                ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial_b)],
+                attack_name="Quick Crack",
+                coverage=_spec(env, rule_files=(str(partial_b),)),
+                coverage_decision=decision,
+            )
+
+    assert len(calls) == 2, (
+        "the real runs must reuse the primed plans, not diff each file again"
+    )
+
+
+def test_priming_a_multi_file_batch_prints_a_progress_notice(
+    main_module, store, env, capsys
+):
+    """A large YOLO-style selection can take real wall-clock time to diff --
+    say something before going silent, or it reads as hung."""
+    other = env["tmp"] / "other.rule"
+    other.write_text("l\n")
+    with patch.object(main_module, "_coverage_enabled", True):
+        main_module._prime_coverage_decision(
+            env["hashes"],
+            [f"-r {env['rules']}", f"-r {other}"],
+            env["wordlist"],
+            "Quick Crack",
+        )
+    out = capsys.readouterr().out
+    assert "Checking coverage across 2 selected rule files" in out
 
 
 # --- opting out ------------------------------------------------------------

--- a/tests/test_coverage_wiring.py
+++ b/tests/test_coverage_wiring.py
@@ -173,6 +173,60 @@ def test_declining_the_prompt_runs_everything(main_module, store, env):
     assert launched[0][launched[0].index("-r") + 1] == env["rules"]
 
 
+def test_skip_message_cites_the_rule_file(main_module, store, env, capsys):
+    """A batch that skips several rule files back to back must say which
+    file each skip is about, not just repeat an identical generic line."""
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env))
+    _run(main_module, cmd, _spec(env))  # second run: full repeat, gets skipped
+    out = capsys.readouterr().out
+    assert f"Skipping Dictionary ({os.path.basename(env['rules'])})" in out
+
+
+def test_chained_rules_are_cited_together(main_module, store, env, capsys):
+    chained = env["tmp"] / "chained.rule"
+    chained.write_text("l\n")
+    cmd = [
+        "hashcat",
+        env["hashes"],
+        env["wordlist"],
+        "-r",
+        env["rules"],
+        "-r",
+        str(chained),
+    ]
+    _run(main_module, cmd, _spec(env, rule_files=(env["rules"], str(chained))))
+    _run(main_module, cmd, _spec(env, rule_files=(env["rules"], str(chained))))
+    out = capsys.readouterr().out
+    assert (
+        f"Skipping Dictionary ({os.path.basename(env['rules'])} + chained.rule)" in out
+    )
+
+
+def test_declined_run_message_cites_the_rule_file(main_module, store, env, capsys):
+    partial = env["tmp"] / "partial.rule"
+    partial.write_text("c\n$1\n")
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial)]
+    _run(main_module, cmd, _spec(env, rule_files=(str(partial),)))
+
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env), answer="n")
+    out = capsys.readouterr().out
+    assert f"Running everything in {os.path.basename(env['rules'])}" in out
+
+
+def test_partial_overlap_message_cites_the_rule_file(main_module, store, env, capsys):
+    partial = env["tmp"] / "partial.rule"
+    partial.write_text("c\n$1\n")
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial)]
+    _run(main_module, cmd, _spec(env, rule_files=(str(partial),)))
+
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env))
+    out = capsys.readouterr().out
+    assert f"Coverage ({os.path.basename(env['rules'])}): running" in out
+
+
 def test_no_prompt_when_there_is_no_overlap(main_module, store, env):
     """A fresh engagement must not be interrupted by a question."""
     cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
@@ -236,6 +290,46 @@ def test_shared_decision_cache_prompts_only_once(main_module, store, env):
 
     assert len(prompts) == 1, "the second run must reuse the first's answer"
     assert seen_rules == [["q"], ["z"]], "each run's own overlap must still be filtered"
+
+
+def test_shared_decision_cache_skip_messages_cite_each_file(
+    main_module, store, env, capsys
+):
+    """The real-world case that prompted this: several rule files, all
+    already fully covered, skipped back to back under one shared decision.
+    Each skip line must name its own file -- otherwise a batch of N skips
+    all reads as the same indistinguishable line."""
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env))  # fully covers "c", "$1", "u"
+
+    full_a = env["tmp"] / "full_a.rule"
+    full_a.write_text("c\n$1\n")  # subset of what's covered -> fully covered
+    full_b = env["tmp"] / "full_b.rule"
+    full_b.write_text("u\n")  # also a subset -> fully covered
+
+    decision_cache: dict = {}
+    with (
+        patch.object(main_module.subprocess, "Popen", lambda cmd, **kw: FakePopen(cmd)),
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module, "non_interactive", False),
+        patch("builtins.input", lambda *a: "y"),
+    ):
+        main_module._run_hcat_cmd(
+            ["hashcat", env["hashes"], env["wordlist"], "-r", str(full_a)],
+            attack_name="Quick Crack",
+            coverage=_spec(env, rule_files=(str(full_a),)),
+            coverage_decision=decision_cache,
+        )
+        main_module._run_hcat_cmd(
+            ["hashcat", env["hashes"], env["wordlist"], "-r", str(full_b)],
+            attack_name="Quick Crack",
+            coverage=_spec(env, rule_files=(str(full_b),)),
+            coverage_decision=decision_cache,
+        )
+
+    out = capsys.readouterr().out
+    assert "Skipping Quick Crack (full_a.rule)" in out
+    assert "Skipping Quick Crack (full_b.rule)" in out
 
 
 def test_shared_decision_cache_honors_a_declined_prompt(main_module, store, env):

--- a/tests/test_coverage_wiring.py
+++ b/tests/test_coverage_wiring.py
@@ -376,18 +376,26 @@ def test_shared_decision_cache_honors_a_declined_prompt(main_module, store, env)
 # --- priming an aggregate decision up front --------------------------------
 
 
-def test_prime_coverage_decision_prompts_once_with_aggregate_counts(
+def test_prime_coverage_decision_asks_without_diffing_any_file(
     main_module, store, env, capsys
 ):
-    """Priming must sum covered/total across every selected chain and show
-    ONE prompt reflecting that combined picture, before any chain runs."""
+    """The whole point: decide whether to filter without reading/hashing any
+    of the selected rule files first -- only a cheap "has this attack run
+    against this hash file before?" lookup."""
     cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
-    _run(main_module, cmd, _spec(env))  # fully covers "c", "$1", "u"
+    _run(main_module, cmd, _spec(env), returncode=1)  # records "Dictionary" ran
 
-    partial_a = env["tmp"] / "partial_a.rule"
-    partial_a.write_text("c\n$1\nq\n")  # 2 of 3 already covered
-    partial_b = env["tmp"] / "partial_b.rule"
-    partial_b.write_text("c\nz\n")  # 1 of 2 already covered
+    huge_a = env["tmp"] / "huge_a.rule"
+    huge_a.write_text("q\n")
+    huge_b = env["tmp"] / "huge_b.rule"
+    huge_b.write_text("z\n")
+
+    calls = []
+    real_plan_run = main_module._coverage.plan_run
+
+    def counting_plan_run(spec, *a, **k):
+        calls.append(spec)
+        return real_plan_run(spec, *a, **k)
 
     prompts = []
 
@@ -397,57 +405,66 @@ def test_prime_coverage_decision_prompts_once_with_aggregate_counts(
 
     with (
         patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module._coverage, "plan_run", counting_plan_run),
         patch("builtins.input", counting_input),
     ):
         decision = main_module._prime_coverage_decision(
             env["hashes"],
-            [f"-r {partial_a}", f"-r {partial_b}"],
+            [f"-r {huge_a}", f"-r {huge_b}"],
             env["wordlist"],
-            "Quick Crack",
+            "Dictionary",
         )
 
+    assert calls == [], "priming must not diff any rule file"
     assert decision.get("apply_filtering") is True
-    assert len(prompts) == 1, "one prompt for the whole batch, not per chain"
+    assert len(prompts) == 1, "one prompt for the whole batch"
     out = capsys.readouterr().out
-    assert "3 of 5 rules" in out, (
-        "aggregate must sum both partials' covered/total counts"
-    )
+    assert "Dictionary has run against this hash file before" in out
+    assert "2 selected rule files" in prompts[0]
 
 
-def test_prime_coverage_decision_is_empty_when_nothing_is_covered(
+def test_prime_coverage_decision_is_a_noop_on_a_fresh_engagement(
     main_module, store, env
 ):
-    fresh_a = env["tmp"] / "fresh_a.rule"
-    fresh_a.write_text("l\n")
-    fresh_b = env["tmp"] / "fresh_b.rule"
-    fresh_b.write_text("u\n")
+    """Quick Crack has never run against this hash file, so there is nothing
+    to skip -- a fresh engagement must not be asked."""
+    with patch.object(main_module, "_coverage_enabled", True):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"], [f"-r {env['rules']}"], env["wordlist"], "Quick Crack"
+        )
+    assert decision == {}
+
+
+def test_prime_coverage_decision_is_scoped_to_the_attack_name(main_module, store, env):
+    """Some other attack having run before this hash file must not trigger
+    the prompt for an attack that has never run against it."""
+    cmd = ["hashcat", env["hashes"], env["wordlist"]]
+    with (
+        patch.object(main_module.subprocess, "Popen", lambda cmd, **kw: FakePopen(cmd)),
+        patch.object(main_module, "_coverage_enabled", True),
+    ):
+        main_module._run_hcat_cmd(cmd, attack_name="PRINCE", hash_file=env["hashes"])
 
     with patch.object(main_module, "_coverage_enabled", True):
         decision = main_module._prime_coverage_decision(
-            env["hashes"],
-            [f"-r {fresh_a}", f"-r {fresh_b}"],
-            env["wordlist"],
-            "Quick Crack",
+            env["hashes"], [f"-r {env['rules']}"], env["wordlist"], "Quick Crack"
         )
-
-    assert "apply_filtering" not in decision, (
-        "no overlap anywhere means nothing to ask about"
-    )
+    assert decision == {}
 
 
 def test_prime_coverage_decision_honors_a_declined_prompt(main_module, store, env):
     cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
-    _run(main_module, cmd, _spec(env))  # fully covers "c", "$1", "u"
+    _run(main_module, cmd, _spec(env), returncode=1)
 
-    partial_a = env["tmp"] / "partial_a.rule"
-    partial_a.write_text("c\n$1\nq\n")
+    other = env["tmp"] / "other.rule"
+    other.write_text("z\n")
 
     with (
         patch.object(main_module, "_coverage_enabled", True),
         patch("builtins.input", lambda *a: "n"),
     ):
         decision = main_module._prime_coverage_decision(
-            env["hashes"], [f"-r {partial_a}"], env["wordlist"], "Quick Crack"
+            env["hashes"], [f"-r {other}"], env["wordlist"], "Dictionary"
         )
 
     assert decision.get("apply_filtering") is False
@@ -469,21 +486,14 @@ def test_prime_coverage_decision_empty_chain_list_is_a_noop(main_module, store, 
     assert decision == {}
 
 
-def test_prime_coverage_decision_skips_priming_for_loopback(main_module, store, env):
-    """record_only specs never have overlap to report, so priming a loopback
-    batch would only pay the cost of diffing every rule file for a prompt
-    that can never fire. Skip the work entirely."""
-    calls = []
-    real_plan_run = main_module._coverage.plan_run
+def test_prime_coverage_decision_skips_the_lookup_for_loopback(main_module, store, env):
+    """record_only specs never have overlap to report, so a loopback batch
+    is never worth even the cheap existence check -- return early regardless
+    of whether "Loopback" has run against this hash file before."""
+    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
+    _run(main_module, cmd, _spec(env, record_only=True), returncode=1)
 
-    def counting_plan_run(spec, *a, **k):
-        calls.append(spec)
-        return real_plan_run(spec, *a, **k)
-
-    with (
-        patch.object(main_module, "_coverage_enabled", True),
-        patch.object(main_module._coverage, "plan_run", counting_plan_run),
-    ):
+    with patch.object(main_module, "_coverage_enabled", True):
         decision = main_module._prime_coverage_decision(
             env["hashes"],
             [f"-r {env['rules']}"],
@@ -493,81 +503,6 @@ def test_prime_coverage_decision_skips_priming_for_loopback(main_module, store, 
         )
 
     assert decision == {}
-    assert calls == [], "loopback priming must not diff any rule file"
-
-
-def test_priming_avoids_recomputing_the_plan_for_the_real_run(main_module, store, env):
-    """Once _prime_coverage_decision has diffed a rule file to build the
-    aggregate, _apply_coverage must reuse that plan instead of diffing the
-    same (potentially multi-million-line) file a second time."""
-    cmd = ["hashcat", env["hashes"], env["wordlist"], "-r", env["rules"]]
-    _run(main_module, cmd, _spec(env))  # fully covers "c", "$1", "u"
-
-    partial_a = env["tmp"] / "partial_a.rule"
-    partial_a.write_text("c\n$1\nq\n")
-    partial_b = env["tmp"] / "partial_b.rule"
-    partial_b.write_text("c\nz\n")
-
-    calls = []
-    real_plan_run = main_module._coverage.plan_run
-
-    def counting_plan_run(spec, *a, **k):
-        calls.append(spec)
-        return real_plan_run(spec, *a, **k)
-
-    with (
-        patch.object(main_module, "_coverage_enabled", True),
-        patch.object(main_module._coverage, "plan_run", counting_plan_run),
-        patch("builtins.input", lambda *a: "y"),
-    ):
-        decision = main_module._prime_coverage_decision(
-            env["hashes"],
-            [f"-r {partial_a}", f"-r {partial_b}"],
-            env["wordlist"],
-            "Quick Crack",
-        )
-        assert len(calls) == 2, "priming diffs each chain exactly once"
-
-        with (
-            patch.object(
-                main_module.subprocess, "Popen", lambda cmd, **kw: FakePopen(cmd)
-            ),
-            patch.object(main_module, "non_interactive", False),
-        ):
-            main_module._run_hcat_cmd(
-                ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial_a)],
-                attack_name="Quick Crack",
-                coverage=_spec(env, rule_files=(str(partial_a),)),
-                coverage_decision=decision,
-            )
-            main_module._run_hcat_cmd(
-                ["hashcat", env["hashes"], env["wordlist"], "-r", str(partial_b)],
-                attack_name="Quick Crack",
-                coverage=_spec(env, rule_files=(str(partial_b),)),
-                coverage_decision=decision,
-            )
-
-    assert len(calls) == 2, (
-        "the real runs must reuse the primed plans, not diff each file again"
-    )
-
-
-def test_priming_a_multi_file_batch_prints_a_progress_notice(
-    main_module, store, env, capsys
-):
-    """A large YOLO-style selection can take real wall-clock time to diff --
-    say something before going silent, or it reads as hung."""
-    other = env["tmp"] / "other.rule"
-    other.write_text("l\n")
-    with patch.object(main_module, "_coverage_enabled", True):
-        main_module._prime_coverage_decision(
-            env["hashes"],
-            [f"-r {env['rules']}", f"-r {other}"],
-            env["wordlist"],
-            "Quick Crack",
-        )
-    out = capsys.readouterr().out
-    assert "Checking coverage across 2 selected rule files" in out
 
 
 # --- opting out ------------------------------------------------------------

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -187,6 +187,7 @@ def _quick_crack_ctx(hc_module, wordlist_dir, tmp_path):
         list_wordlist_entries=hc_module.list_wordlist_entries,
         list_rule_files=hc_module.list_rule_files,
         hcatQuickDictionary=lambda *a, **k: calls.append((a, k)),
+        _prime_coverage_decision=lambda *a, **k: {},
     ), calls
 
 


### PR DESCRIPTION
## Summary
- Follows up on #294: instead of letting the first selected rule file's own coverage stats drive the batch's single deduplicated prompt, Quick Crack and Loopback now sum covered/total counts across every selected rule file up front, before any of them runs, and show one prompt reflecting that true aggregate.
- Adds `hate_crack.main._prime_coverage_decision(hash_file, chains, wordlists, attack_name, loopback=False)`, which builds a `CoverageSpec`/`RunPlan` per chain via the existing `_quick_dictionary_coverage`/`plan_run`, sums their counts into a synthetic `RunPlan`, and reuses `_prompt_coverage_filter` unchanged for the actual prompt/display logic.
- `quick_crack` and `loopback_attack` now call this helper before their `for chain in selected_rules:` loop and pass its returned (possibly pre-filled) `coverage_decision` dict into every `hcatQuickDictionary` call in the loop, so no hashcat invocation in the batch prompts on its own.

## Test plan
- [x] `uv run pytest -q` (3062 passed, 70 skipped)
- [x] `uv run ruff format --check hate_crack tests tools packaging hate_crack.py`
- [x] `uv run ruff check hate_crack tests tools packaging hate_crack.py`
- [x] `uv run ty check --exit-zero-on-warning hate_crack` (exit 0)
- [x] New regression tests: aggregate prompt fires once with combined counts (`test_prime_coverage_decision_prompts_once_with_aggregate_counts`), no-overlap batches stay silent, declining the prompt runs the whole batch unfiltered, and both `quick_crack`/`loopback_attack` call the primer before the first hashcat invocation (`test_coverage_decision_is_primed_before_any_run`).