### PR TITLE
feat(hashview): add Download All Rules menu option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Added
+- **A "Download All Rules" option in the Hashview interactive menu.** Previously the menu could only download one rule file at a time by ID; the new option lists every rule the Hashview API knows about and downloads each one, reporting per-rule success/failure counts instead of aborting the batch on the first error. Backed by a new `HashviewAPI.download_all_rules()` method.
+
 ## [2.33.1] - 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ Menu options:
 - **(2) Upload Wordlist** - Upload a wordlist file to Hashview
 - **(3) Download Wordlist** - Download a wordlist from Hashview
 - **Download Rule** - Download a rule file from Hashview (decompressed to plaintext, ready for `hashcat -r`)
+- **Download All Rules** - Download every rule file listed by Hashview in one pass; per-rule failures are reported without aborting the rest
 - **(4) Download Left Hashes** - Download remaining uncracked hashes (prompts to switch for cracking)
 - **(5) Download Found Hashes** - Download already-cracked hashes with cleartext passwords (for reference/analysis)
 - **(6) Upload Hashfile and Create Job** - Upload new hashfile and create a cracking job

--- a/hate_crack/api.py
+++ b/hate_crack/api.py
@@ -2210,6 +2210,37 @@ class HashviewAPI:
             f.write(content)
         return {"output_file": output_file, "size": os.path.getsize(output_file)}
 
+    def download_all_rules(self):
+        """Download every rule file the Hashview API lists (/v1/rules).
+
+        One rule failing to download (e.g. a 404 on a stale listing) must not
+        abort the rest, so each rule's outcome is collected individually
+        rather than raised.
+        """
+        rules = self.list_rules()
+        results = []
+        for rule in rules:
+            rule_id = rule.get("id")
+            rule_name = rule.get("name")
+            if rule_id is None:
+                results.append(
+                    {"id": rule_id, "name": rule_name, "error": "missing id"}
+                )
+                continue
+            try:
+                download_result = self.download_rules(rule_id, rule_name)
+                results.append(
+                    {
+                        "id": rule_id,
+                        "name": rule_name,
+                        "output_file": download_result["output_file"],
+                        "size": download_result["size"],
+                    }
+                )
+            except Exception as e:
+                results.append({"id": rule_id, "name": rule_name, "error": str(e)})
+        return results
+
     def create_customer(self, name):
         url = f"{self.base_url}/v1/customers/add"
         headers = {"Content-Type": "application/json"}

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -7541,6 +7541,7 @@ def hashview_api():
             menu_options.append(("upload_wordlist", "Upload Wordlist"))
             menu_options.append(("download_wordlist", "Download Wordlist"))
             menu_options.append(("download_rules", "Download Rule"))
+            menu_options.append(("download_all_rules", "Download All Rules"))
             menu_options.append(
                 (
                     "download_hashes",
@@ -7835,6 +7836,30 @@ def hashview_api():
                     print(f"  File: {download_result['output_file']}")
                 except Exception as e:
                     print(f"\n✗ Error downloading rule: {str(e)}")
+
+            elif option_key == "download_all_rules":
+                # Download every rule file listed by the Hashview API
+                try:
+                    results = api_harness.download_all_rules()
+                except Exception as e:
+                    print(f"\n✗ Error fetching rules: {str(e)}")
+                    continue
+
+                if not results:
+                    print("\nNo rules found.")
+                    continue
+
+                succeeded = [r for r in results if "error" not in r]
+                failed = [r for r in results if "error" in r]
+                for r in succeeded:
+                    print(f"\n✓ Downloaded {r['size']} bytes: {r['output_file']}")
+                for r in failed:
+                    print(f"\n✗ Error downloading rule {r.get('id')}: {r['error']}")
+                print(
+                    f"\n{'=' * 60}\n"
+                    f"Downloaded {len(succeeded)} of {len(results)} rules"
+                    f"{f' ({len(failed)} failed)' if failed else ''}"
+                )
 
             elif option_key == "upload_hashfile_job":
                 # Upload hashfile and create job

--- a/tests/test_hashview.py
+++ b/tests/test_hashview.py
@@ -518,6 +518,84 @@ class TestHashviewAPI:
         with pytest.raises(HTTPError):
             api.download_rules(99999999, os.path.join(str(tmp_path), "x.rule"))
 
+    def test_download_all_rules_downloads_each_listed_rule(self, api, tmp_path):
+        """Every rule from list_rules() is downloaded via download_rules()."""
+        with (
+            patch.object(
+                api,
+                "list_rules",
+                return_value=[
+                    {"id": 4, "name": "best64.rule", "size": 77},
+                    {"id": 9, "name": "d3ad0ne.rule", "size": 500},
+                ],
+            ),
+            patch.object(
+                api,
+                "download_rules",
+                side_effect=lambda rid, out: {
+                    "output_file": os.path.join(str(tmp_path), out),
+                    "size": rid,
+                },
+            ) as mock_download,
+        ):
+            results = api.download_all_rules()
+
+        assert mock_download.call_args_list == [
+            ((4, "best64.rule"),),
+            ((9, "d3ad0ne.rule"),),
+        ]
+        assert results == [
+            {
+                "id": 4,
+                "name": "best64.rule",
+                "output_file": os.path.join(str(tmp_path), "best64.rule"),
+                "size": 4,
+            },
+            {
+                "id": 9,
+                "name": "d3ad0ne.rule",
+                "output_file": os.path.join(str(tmp_path), "d3ad0ne.rule"),
+                "size": 9,
+            },
+        ]
+
+    def test_download_all_rules_collects_per_rule_failures(self, api):
+        """One rule 404ing must not abort the rest of the batch."""
+        from requests.exceptions import HTTPError
+
+        with (
+            patch.object(
+                api,
+                "list_rules",
+                return_value=[
+                    {"id": 4, "name": "best64.rule"},
+                    {"id": 99999999, "name": "stale.rule"},
+                ],
+            ),
+            patch.object(
+                api,
+                "download_rules",
+                side_effect=[
+                    {"output_file": "/tmp/best64.rule", "size": 77},
+                    HTTPError("404"),
+                ],
+            ),
+        ):
+            results = api.download_all_rules()
+
+        assert results[0] == {
+            "id": 4,
+            "name": "best64.rule",
+            "output_file": "/tmp/best64.rule",
+            "size": 77,
+        }
+        assert results[1]["id"] == 99999999
+        assert "404" in results[1]["error"]
+
+    def test_download_all_rules_returns_empty_list_when_no_rules(self, api):
+        with patch.object(api, "list_rules", return_value=[]):
+            assert api.download_all_rules() == []
+
     def test_upload_cracked_hashes_success(self, api, tmp_path):
         """Uploading cracked hashes with valid lines (mocked transport)."""
         cracked_file = tmp_path / "cracked.txt"

--- a/tests/test_hashview_download_all_rules_menu.py
+++ b/tests/test_hashview_download_all_rules_menu.py
@@ -1,0 +1,110 @@
+"""Interactive-menu coverage for the "Download All Rules" Hashview option."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def main_module(hc_module):
+    return hc_module._main
+
+
+def _pick_by_text(choices):
+    """Build an interactive_menu stand-in that pops one wanted label per call.
+
+    A genexpr predicate that calls next() on a shared iterator is evaluated
+    once per candidate item, not once per menu invocation, so a plain
+    iterator silently desyncs; popping outside the predicate avoids that.
+    """
+
+    def _pick(items, **kwargs):
+        wanted = choices.pop(0)
+        return next(key for key, text in items if text == wanted)
+
+    return _pick
+
+
+def _drive_menu(main_module, monkeypatch, download_all_rules_return):
+    monkeypatch.setattr(main_module, "hcatHashFile", None)
+    monkeypatch.setattr(main_module, "hashview_api_key", "k", raising=False)
+    monkeypatch.setattr(main_module, "hashview_url", "http://x", raising=False)
+
+    harness = MagicMock()
+    harness.download_all_rules.return_value = download_all_rules_return
+
+    monkeypatch.setattr(
+        main_module,
+        "interactive_menu",
+        _pick_by_text(["Download All Rules", "Back to Main Menu"]),
+        raising=False,
+    )
+
+    with patch.object(main_module, "HashviewAPI", return_value=harness):
+        main_module.hashview_api()
+
+    return harness
+
+
+def test_download_all_rules_calls_harness_once(main_module, monkeypatch):
+    harness = _drive_menu(
+        main_module,
+        monkeypatch,
+        [
+            {
+                "id": 4,
+                "name": "best64.rule",
+                "output_file": "/tmp/best64.rule",
+                "size": 77,
+            }
+        ],
+    )
+    harness.download_all_rules.assert_called_once_with()
+
+
+def test_download_all_rules_reports_success_and_failure_counts(
+    main_module, monkeypatch, capsys
+):
+    _drive_menu(
+        main_module,
+        monkeypatch,
+        [
+            {
+                "id": 4,
+                "name": "best64.rule",
+                "output_file": "/tmp/best64.rule",
+                "size": 77,
+            },
+            {"id": 5, "name": "stale.rule", "error": "404"},
+        ],
+    )
+    out = capsys.readouterr().out
+    assert "Downloaded 77 bytes: /tmp/best64.rule" in out
+    assert "Error downloading rule 5: 404" in out
+    assert "Downloaded 1 of 2 rules (1 failed)" in out
+
+
+def test_download_all_rules_handles_no_rules(main_module, monkeypatch, capsys):
+    _drive_menu(main_module, monkeypatch, [])
+    assert "No rules found." in capsys.readouterr().out
+
+
+def test_download_all_rules_reports_fetch_error(main_module, monkeypatch, capsys):
+    monkeypatch.setattr(main_module, "hcatHashFile", None)
+    monkeypatch.setattr(main_module, "hashview_api_key", "k", raising=False)
+    monkeypatch.setattr(main_module, "hashview_url", "http://x", raising=False)
+
+    harness = MagicMock()
+    harness.download_all_rules.side_effect = Exception("boom")
+
+    monkeypatch.setattr(
+        main_module,
+        "interactive_menu",
+        _pick_by_text(["Download All Rules", "Back to Main Menu"]),
+        raising=False,
+    )
+
+    with patch.object(main_module, "HashviewAPI", return_value=harness):
+        main_module.hashview_api()
+
+    assert "Error fetching rules: boom" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Adds `HashviewAPI.download_all_rules()`, which lists every rule from `/v1/rules` and downloads each one, collecting per-rule failures instead of aborting the batch.
- Wires a new "Download All Rules" option into the interactive Hashview menu (`hashview_api()` in `main.py`), alongside the existing single-rule "Download Rule" option.
- Updates README and CHANGELOG.

## Test plan
- [x] `HATE_CRACK_SKIP_INIT=1 uv run pytest -v` (3137 passed, 41 skipped)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check --exit-zero-on-warning hate_crack`
- [x] `bandit -r hate_crack -c pyproject.toml -b .bandit-baseline.json` (no issues)
- [x] `pip-audit --ignore-vuln PYSEC-2026-2447` (no known vulnerabilities)
- [x] Added unit tests for `download_all_rules()` (success, per-rule failure, empty list) and interactive-menu coverage for the new option

🤖 Generated with [Claude Code](https://claude.com/claude-code)