### PR TITLE
fix(coverage): scope the batch prompt to the wordlist, and expand directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Dates are omitted for releases predating this file; see the git tags for exact t
 
 ## [Unreleased]
 
+### Fixed
+- **Attack coverage bucketed every Quick Crack together, so a brand-new wordlist with previously-used rules was flagged as already covered.** Two defects compounded, both reachable from the default answer at Quick Crack's wordlist prompt.
+
+  `_prime_coverage_decision` ignored the wordlists it was handed and asked the store only whether anything named "Quick Crack" had ever run against this hash file. Since a rule counts as covered only for the wordlist it ran against, selecting a fresh corpus produced "Quick Crack has run against this hash file before" with nothing recorded that could possibly be skipped. The question is now scoped to the wordlists, answered by a new `CoverageStore.has_prior_run()` against a new `run_wordlists` table — still without reading a single rule file, which is the property that prompt exists to preserve. Fingerprinting costs nothing extra overall, because `plan_run` computes the same memoized fingerprints moments later for the first chain.
+
+  The reason it never went away is that Quick Crack's default *is* a directory, and a directory has no content fingerprint — so every plan went inert, nothing was recorded and nothing was ever filterable, while the run was still logged and kept feeding the prompt. Quick Crack now expands a selected directory into the wordlists inside it, one level deep, the same fix `hcatHybrid` got for the same reason. hashcat reads exactly those files when handed the directory itself (verified against 7.1.2, which ignores subdirectories), so the candidate set is unchanged; it just becomes something coverage can key on. Dot-files and archives are dropped, which hashcat would not do — a Weakpass download leaves `.7z` and `.torrent` files in the wordlists directory and neither is a wordlist.
+
+  The expansion aborts the attack when it comes back empty — an empty wordlists directory, or one holding only subdirectories or only archives — instead of launching. Without a dictionary operand hashcat does not error: `-a 0` reads candidates from *stdin*, so the run would inherit the menu's terminal, consume the operator's keystrokes, and then report Exhausted on ctrl-D, which is exit 1, which is what records coverage. `hcatHybrid` already guarded its own expansion this way.
+
+  An existing engagement's store needs no migration and loses nothing: the new table arrives empty on the next connect, and an empty answer is "no prior run", which suppresses the spurious prompt rather than causing a wrong skip. `coverage forget` clears the new table too.
+
 ### Added
 - **A "Download All Rules" option in the Hashview interactive menu.** Previously the menu could only download one rule file at a time by ID; the new option lists every rule the Hashview API knows about and downloads each one, reporting per-rule success/failure counts instead of aborting the batch on the first error. Backed by a new `HashviewAPI.download_all_rules()` method.
 

--- a/README.md
+++ b/README.md
@@ -698,6 +698,16 @@ covered ground never requires restarting the tool.
 Attacks that are never filtered are still recorded as having run, which is what
 lets you answer "did I already run PRINCE against this target?".
 
+An attack that selects several rule files at once (Quick Crack, Loopback) asks
+the skip question **once for the whole batch, up front**, before any hashcat
+invocation. That question is deliberately cheap — it does not read or hash any
+of the selected rule files, since a YOLO batch can run to millions of lines and
+you should not wait through that to answer a yes/no. It asks the store only
+whether this attack has already run against this hash file **with one of these
+wordlists**; the per-entry diff still happens lazily, one rule file at a time,
+and decides what actually gets skipped. So a fresh corpus is never flagged, even
+when the rules on it have all run against a different one.
+
 Three deliberate limits:
 
 - **Coverage is recorded only when hashcat exhausts the keyspace** (exit 1). A
@@ -1043,6 +1053,17 @@ The YOLO, Middle, and Thorough Combinator attacks were previously at keys 10-12.
 -------------------------------------------------------------------
 #### Quick Crack
 Runs a dictionary attack against wordlists in your `hcatOptimizedWordlists` directory (falls back to `hcatWordlists` if not configured) and optionally applies rules. Multiple rules can be selected by comma-separated list, and chains can be created with the '+' symbol. Pressing Enter at the wordlist prompt uses the configured optimized wordlists directory as the default.
+
+Selecting a directory — including that default — expands to the wordlists
+directly inside it before hashcat runs. Subdirectories are not searched,
+matching hashcat's own behaviour for a directory in the dictionary position, and
+dot-files and `.7z`/`.torrent`/`.out` files are skipped, which hashcat would
+otherwise try to read. The candidates are the same either way; the expansion is
+what lets attack coverage track each wordlist separately, since a directory has
+no content fingerprint to key on. If the expansion finds nothing — an empty
+directory, or one holding only subdirectories or archives — the attack aborts
+rather than launching hashcat with no wordlist, which would put it in stdin
+mode and leave it reading the terminal.
 
 ```
 Which rule(s) would you like to run?

--- a/hate_crack/attack_coverage.py
+++ b/hate_crack/attack_coverage.py
@@ -84,6 +84,15 @@ _COVERED_IN_JSON = (
     "SELECT key FROM covered WHERE key IN (SELECT value FROM json_each(?))"
 )
 
+# "Has this attack run against this target with any of these wordlists?", as
+# one static statement. See CoverageStore.has_prior_run.
+_PRIOR_RUN_WITH_WORDLIST = (
+    "SELECT 1 FROM runs "
+    "JOIN run_wordlists ON run_wordlists.run_id = runs.id "
+    "WHERE runs.target = ? AND runs.attack = ? "
+    "AND run_wordlists.wordlist IN (SELECT value FROM json_each(?)) LIMIT 1"
+)
+
 # Schema notes, all measured at the realistic scale of ~191k keys (the
 # d3ad0ne+T0XlC pair over five wordlists, which is one Dictionary attack):
 #
@@ -123,6 +132,31 @@ CREATE TABLE IF NOT EXISTS covered (
 -- keys. It is the only secondary index here: each one is write amplification
 -- on a bulk insert of ~191k rows.
 CREATE INDEX IF NOT EXISTS covered_run ON covered (run_id);
+
+-- Which wordlists a run declared, by fingerprint. "Declared", not "enumerated":
+-- a wordlist-kind plan links every wordlist in the spec, including one that
+-- filtering then dropped from the command. That is deliberate -- a dropped
+-- wordlist was dropped for being covered already, so it has a row regardless --
+-- but it means a row here is not proof that this particular invocation read
+-- that file. Nothing keys coverage off these rows; only has_prior_run reads
+-- them, and only to decide whether to ask a question.
+--
+-- This exists so that "has
+-- this attack run against this target with this corpus before?" can be
+-- answered without reading a single rule file -- the question the up-front
+-- batch prompt asks, where diffing a YOLO-sized batch of rule files first is
+-- exactly the slow silent wait it was written to avoid. It cannot be answered
+-- from `covered`, whose keys hash the fingerprint in beyond recovery.
+--
+-- CREATE TABLE IF NOT EXISTS is the whole migration story for an engagement
+-- whose store predates this table: it appears on the next connect, empty, and
+-- an empty answer is "no prior run", which is the safe direction.
+CREATE TABLE IF NOT EXISTS run_wordlists (
+    run_id   INTEGER NOT NULL REFERENCES runs (id),
+    wordlist TEXT NOT NULL,
+    PRIMARY KEY (run_id, wordlist)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS run_wordlists_fp ON run_wordlists (wordlist);
 
 CREATE TABLE IF NOT EXISTS wordlist_fingerprints (
     path     TEXT PRIMARY KEY,
@@ -281,6 +315,49 @@ class CoverageStore:
             return None
         return cursor.lastrowid
 
+    def has_prior_run(
+        self, target: str, attack: str, wordlist_fps: Sequence[str]
+    ) -> bool:
+        """Has ``attack`` already run against ``target`` using any of these
+        wordlists?
+
+        "Any", not "all": one overlapping corpus is enough for per-entry
+        filtering to have something to skip, which is what the caller is really
+        asking about.
+
+        With no fingerprints -- a mask-only attack, or a caller that cannot
+        establish them -- this falls back to the coarser question of whether the
+        attack has run against the target at all, because that is the only one
+        the store can answer. Callers that *do* have wordlists must pass them:
+        the coarse answer is what made a brand-new corpus look like a repeat.
+
+        The fingerprints go over as one JSON parameter, the same static-SQL
+        shape :meth:`covered` uses and for the same reason -- an ``IN (?,?,?)``
+        clause would have to be built by interpolation and chunked under
+        SQLite's 999-parameter limit, and a Weakpass directory really can hold
+        hundreds of lists. Unlike :meth:`covered` this one has no JSON1
+        fallback: a SQLite built without it answers "no prior run", which costs
+        an operator one absent prompt rather than a wrong skip, because the
+        per-entry diff in ``plan_run`` still asks about any genuine overlap.
+        """
+        conn = self._connect()
+        if conn is None:
+            return False
+        try:
+            if not wordlist_fps:
+                row = conn.execute(
+                    "SELECT 1 FROM runs WHERE target = ? AND attack = ? LIMIT 1",
+                    (target, attack),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    _PRIOR_RUN_WITH_WORDLIST,
+                    (target, attack, json.dumps(list(wordlist_fps))),
+                ).fetchone()
+        except sqlite3.Error:
+            return False
+        return row is not None
+
     def record(
         self,
         keys: Iterable[str],
@@ -288,19 +365,37 @@ class CoverageStore:
         kind: str = "",
         attack: str = "",
         detail: str = "",
+        wordlist_fps: Sequence[str] = (),
     ) -> int:
         """Log a run and link its coverage. Returns newly-inserted key count.
 
         ``INSERT OR IGNORE`` means a repeat adds no keys and leaves the original
         run's link in place, so a key records when it was *first* covered and
         the store does not grow on repeats.
+
+        ``wordlist_fps`` are linked to the run so :meth:`has_prior_run` can
+        scope its answer to a corpus. They are recorded even when ``keys`` is
+        empty, because a run that added no new keys still establishes that this
+        attack has seen this corpus.
         """
         keys = list(keys)
         conn = self._connect()
         if conn is None:
             return 0
         run_id = self.log_run(target, attack=attack, kind=kind, detail=detail)
-        if run_id is None or not keys:
+        if run_id is None:
+            return 0
+        if wordlist_fps:
+            try:
+                conn.executemany(
+                    "INSERT OR IGNORE INTO run_wordlists (run_id, wordlist) "
+                    "VALUES (?, ?)",
+                    [(run_id, fingerprint) for fingerprint in wordlist_fps],
+                )
+                conn.commit()
+            except sqlite3.Error:
+                pass
+        if not keys:
             return 0
         try:
             cursor = conn.executemany(
@@ -324,6 +419,11 @@ class CoverageStore:
         try:
             cursor = conn.execute(
                 "DELETE FROM covered WHERE run_id IN "
+                "(SELECT id FROM runs WHERE target = ?)",
+                (target,),
+            )
+            conn.execute(
+                "DELETE FROM run_wordlists WHERE run_id IN "
                 "(SELECT id FROM runs WHERE target = ?)",
                 (target,),
             )
@@ -698,6 +798,10 @@ class RunPlan:
     source_path: str | None = None
     record_keys: list[str] = field(default_factory=list)
     target: str = ""
+    # Fingerprints of the wordlists this run enumerates, for the store to link
+    # to the run row. Carried separately from the keys because a "wordlist"-kind
+    # plan keys *on* them, so they cannot be recovered from the keying slots.
+    wordlist_fps: tuple[str, ...] = ()
 
     @property
     def has_overlap(self) -> bool:
@@ -784,6 +888,7 @@ def plan_run(
                 lookup=lookup,
                 source_path=None,
                 filterable=False,
+                run_wordlist_fps=wordlist_fps,
             )
         entries = read_entries(spec.rule_files[0])
         if not entries:
@@ -797,6 +902,7 @@ def plan_run(
             lookup=lookup,
             source_path=spec.rule_files[0],
             filterable=True,
+            run_wordlist_fps=wordlist_fps,
         )
 
     if spec.mask_files or spec.masks:
@@ -820,6 +926,7 @@ def plan_run(
             lookup=lookup,
             source_path=single_file,
             filterable=single_file is not None,
+            run_wordlist_fps=wordlist_fps,
         )
 
     if spec.wordlists:
@@ -834,6 +941,7 @@ def plan_run(
             source_path=None,
             filterable=True,
             display=list(spec.wordlists),
+            run_wordlist_fps=wordlist_fps,
         )
 
     return _INERT
@@ -850,6 +958,7 @@ def _plan_entries(
     source_path: str | None,
     filterable: bool,
     display: list[str] | None = None,
+    run_wordlist_fps: Sequence[str] = (),
 ) -> RunPlan:
     # A mask run has no wordlist, but still needs one slot to key against.
     slots = wordlist_fps or [""]
@@ -884,6 +993,7 @@ def _plan_entries(
             total_count=len(entries),
             source_path=source_path,
             target=target,
+            wordlist_fps=tuple(run_wordlist_fps),
         )
 
     return RunPlan(
@@ -895,4 +1005,5 @@ def _plan_entries(
         source_path=source_path,
         record_keys=record_keys,
         target=target,
+        wordlist_fps=tuple(run_wordlist_fps),
     )

--- a/hate_crack/attacks.py
+++ b/hate_crack/attacks.py
@@ -205,20 +205,28 @@ def quick_crack(ctx: Any) -> None:
     if selected_rules is None:
         return
 
+    # A directory selection becomes the wordlists inside it here, once, so the
+    # up-front prompt and every chain's run agree on what is being attacked.
+    # hashcat reads exactly these files when handed the directory itself, so
+    # the candidates are unchanged -- but a directory has no fingerprint, and
+    # coverage keyed on one that cannot be computed records nothing. See
+    # hate_crack.main._expand_wordlist_dirs.
+    wordlists = ctx._expand_wordlist_dirs(wordlist_choice)
+
     # Primed once, up front, against the combined coverage across every
     # selected rule file -- so the "skip already-covered ground?" prompt (if
     # any) reflects the whole batch and fires before any hashcat invocation,
     # not just the first chain's own numbers. See
     # hate_crack.main._prime_coverage_decision / _apply_coverage.
     coverage_decision = ctx._prime_coverage_decision(
-        ctx.hcatHashFile, selected_rules, wordlist_choice, "Quick Crack"
+        ctx.hcatHashFile, selected_rules, wordlists, "Quick Crack"
     )
     for chain in selected_rules:
         ctx.hcatQuickDictionary(
             ctx.hcatHashType,
             ctx.hcatHashFile,
             chain,
-            wordlist_choice,
+            wordlists,
             attack_name="Quick Crack",
             coverage_decision=coverage_decision,
         )

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -1887,6 +1887,7 @@ def _run_hcat_cmd(
             target=plan.target,
             kind=plan.kind,
             attack=attack_name,
+            wordlist_fps=plan.wordlist_fps,
         )
     elif completed and _coverage_enabled and attack_name and hash_file:
         # Attacks that carry no spec are never filtered, but the issue asks for
@@ -2916,6 +2917,59 @@ def hcatDictionary(hcatHashType, hcatHashFile):
     hcatDictionaryCount = lineCount(hcatHashFile + ".out") - hcatBruteCount
 
 
+def _expand_wordlist_dirs(wordlists):
+    """Expand any directory in *wordlists* into the files directly inside it.
+
+    hashcat accepts a directory in the dictionary position of a straight
+    (``-a 0``) run and reads the files directly inside it -- verified against
+    7.1.2, which ignores subdirectories. Passing it the directory and passing it
+    the expansion therefore run the identical candidate set, but the expansion
+    gives the coverage store one fingerprintable wordlist per file instead of a
+    directory it cannot fingerprint at all. That mattered more than it sounds:
+    an unfingerprintable wordlist makes the whole plan inert, so those passes
+    were recorded nowhere and never recognised on a repeat, while the run was
+    still logged -- which kept the up-front batch prompt firing forever with
+    nothing it could ever skip. hcatHybrid expands for the same reason.
+
+    One level only, matching hashcat. Dot-files and archives are dropped, which
+    hashcat would not do -- a Weakpass download leaves ``.7z`` and ``.torrent``
+    files in the wordlists directory and neither is a wordlist. Anything that is
+    not a directory passes through untouched, including a path that does not
+    exist: hashcat's own error names the file, and dropping it here would
+    silently shrink the attack instead of reporting it.
+    """
+    if isinstance(wordlists, (str, os.PathLike)):
+        selection = [os.fspath(wordlists)]
+    else:
+        selection = [os.fspath(path) for path in wordlists]
+
+    expanded: list[str] = []
+    for path in selection:
+        if not os.path.isdir(path):
+            expanded.append(path)
+            continue
+        files = [os.path.join(path, name) for name in list_wordlist_files(path)]
+        if files:
+            expanded.extend(files)
+        else:
+            print(
+                f"[!] No wordlists directly inside {path} "
+                "(subdirectories are not searched)"
+            )
+    # Order-preserving dedupe: the same list named twice is wasted passes, and
+    # a directory named alongside one of its own files would produce it twice.
+    expanded = list(dict.fromkeys(expanded))
+    if expanded and expanded != selection:
+        # Compared, not counted: a directory holding exactly one wordlist, and
+        # one whose archives were dropped, both leave the count unchanged while
+        # attacking something different from what was asked for. The operator
+        # should be told either way.
+        print(
+            f"[*] {len(selection)} entr(y/ies) expanded to {len(expanded)} wordlist(s)."
+        )
+    return expanded
+
+
 # Quick Dictionary Attack (Optional Chained Rules)
 def hcatQuickDictionary(
     hcatHashType,
@@ -2929,6 +2983,20 @@ def hcatQuickDictionary(
     coverage_decision: dict | None = None,
 ):
     global hcatProcess
+    # Done here rather than only in the handler so every caller gets it --
+    # including the scripted entry points, which never see the menu picker.
+    # Idempotent, so a handler that expanded already loses nothing by it.
+    wordlists = _expand_wordlist_dirs(wordlists)
+    if not wordlists:
+        # Launching without a dictionary operand does not fail: hashcat reads
+        # candidates from *stdin* in straight mode, so the run would inherit
+        # this terminal and silently consume the operator's keystrokes -- then
+        # report Exhausted on ctrl-D, and exit 1 is what records coverage, so a
+        # run that enumerated nothing would claim every rule line. Reachable
+        # from an ordinary empty or archives-only wordlists directory.
+        # hcatHybrid guards the same expansion the same way.
+        print("[!] No valid wordlists found. Aborting attack.")
+        return
     cmd = [
         hcatBin,
         "-m",
@@ -2939,10 +3007,7 @@ def hcatQuickDictionary(
         "-o",
         f"{hcatHashFile}.out",
     ]
-    if isinstance(wordlists, list):
-        cmd.extend(wordlists)
-    else:
-        cmd.append(wordlists)
+    cmd.extend(wordlists)
     if loopback:
         cmd.append("--loopback")
     if hcatChains:
@@ -3030,17 +3095,27 @@ def _prime_coverage_decision(
     which for a large batch (YOLO across dozens of files, some
     multi-million lines) is exactly the slow, silent-feeling step an
     operator should not have to wait through just to be asked a yes/no
-    question. So this checks only whether ``attack_name`` has ever run
-    against this hash file before -- one cheap store lookup, no file
-    reading -- and, if so, asks plainly. The real per-file diffing still
-    happens lazily, once per chain, inside ``_apply_coverage`` exactly as
-    it always has; this only decides up front whether that filtering is
+    question. So this asks the store only whether ``attack_name`` has run
+    against this hash file *with one of these wordlists* before -- no rule
+    file is read -- and, if so, asks plainly. The real per-file diffing
+    still happens lazily, once per chain, inside ``_apply_coverage`` exactly
+    as it always has; this only decides up front whether that filtering is
     wanted.
+
+    **The wordlists are part of the question, not decoration.** They used to
+    be ignored, leaving the store asked only whether anything by this attack
+    name had ever touched this hash file -- so selecting a brand-new corpus
+    produced the "has run before" prompt with nothing recorded that could
+    possibly be skipped, because a rule counts as covered only for the
+    wordlist it ran against. Fingerprinting the wordlists costs nothing extra
+    overall: ``plan_run`` computes the same fingerprints moments later for the
+    first chain, and they are memoized.
 
     Returns an empty dict when there is nothing to ask about: coverage is
     disabled, the batch is empty, it is a record-only (loopback) run that
-    can never overlap, or ``attack_name`` has never run against this hash
-    file before -- so a fresh engagement never sees the prompt.
+    can never overlap, or this attack has never run against this hash file
+    with any of these wordlists -- so a fresh engagement, or a fresh corpus,
+    never sees the prompt.
     """
     if not _coverage_enabled or not chains or loopback:
         return {}
@@ -3049,11 +3124,27 @@ def _prime_coverage_decision(
     if target is None:
         return {}
 
-    has_run_before = any(
-        attack == attack_name and runs
-        for attack, _entries, runs in _coverage_store().summary(target)["by_attack"]
-    )
-    if not has_run_before:
+    store = _coverage_store()
+    selection = _expand_wordlist_dirs(wordlists)
+    fingerprints = [
+        fingerprint
+        for fingerprint in (store.wordlist_fingerprint(path) for path in selection)
+        if fingerprint is not None
+    ]
+    if wordlists and not fingerprints:
+        # Wordlists were named but none can be fingerprinted -- they vanished,
+        # or a directory expanded to nothing. Either way plan_run will go inert
+        # for every chain and no filtering is possible, so asking whether to
+        # filter would be noise; this is the shape that used to prompt on every
+        # single run.
+        #
+        # Guarded on the *argument*, not on `selection`: an empty expansion
+        # would short-circuit `selection and ...` and fall through to
+        # has_prior_run's attack-name-only branch, which is the coarse question
+        # this function exists to stop asking.
+        return {}
+
+    if not store.has_prior_run(target, attack_name, fingerprints):
         return {}
 
     return {"apply_filtering": _prompt_skip_covered_batch(attack_name, len(chains))}

--- a/tests/test_coverage_wordlist_scope.py
+++ b/tests/test_coverage_wordlist_scope.py
@@ -1,0 +1,466 @@
+"""Coverage must be scoped to the wordlist that was actually run.
+
+Two defects motivated this file, both reachable from Quick Crack's default
+answer at the wordlist prompt -- the *optimized wordlist directory*:
+
+- ``_prime_coverage_decision`` asked the store only whether anything named
+  "Quick Crack" had ever run against this hash file, ignoring the wordlists it
+  was handed. Selecting a brand-new corpus therefore produced the "has run
+  against this hash file before" prompt with nothing recorded that could
+  possibly be skipped.
+- A directory has no content fingerprint, so a directory-valued wordlist made
+  every plan inert: nothing was recorded and nothing was ever filterable, yet
+  the run still landed in the history table -- which is what kept the first
+  defect firing forever.
+
+The store and planner halves live here together with the wiring, because the
+bug only appears when all three agree on the wordlist.
+"""
+
+import os
+
+from unittest.mock import patch
+
+import pytest
+
+from hate_crack import attack_coverage as ac
+
+
+@pytest.fixture
+def main_module(hc_module):
+    return hc_module._main
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    s = ac.CoverageStore(tmp_path / "cov.sqlite3")
+    monkeypatch.setattr(ac, "get_store", lambda: s)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def env(tmp_path):
+    hashes = tmp_path / "target.txt"
+    hashes.write_text("aad3b435b51404eeaad3b435b51404ee\n")
+    rules = tmp_path / "r.rule"
+    rules.write_text("c\n$1\nu\n")
+    lists = tmp_path / "lists"
+    lists.mkdir()
+    (lists / "a.txt").write_text("alpha\n")
+    (lists / "b.txt").write_text("bravo\n")
+    fresh = tmp_path / "fresh.txt"
+    fresh.write_text("charlie\n")
+    return {
+        "hashes": str(hashes),
+        "rules": str(rules),
+        "lists": str(lists),
+        "fresh": str(fresh),
+        "tmp": tmp_path,
+    }
+
+
+class FakePopen:
+    def __init__(self, cmd, returncode=1, **kwargs):
+        self.cmd = list(cmd)
+        self.pid = 4242
+        self.returncode = returncode
+
+    def wait(self):
+        return self.returncode
+
+    def kill(self):
+        pass
+
+
+# --- expanding a wordlist directory ---------------------------------------
+
+
+def test_expand_turns_a_directory_into_the_files_hashcat_would_read(
+    main_module, env, capsys
+):
+    expanded = main_module._expand_wordlist_dirs(env["lists"])
+    assert expanded == [
+        os.path.join(env["lists"], "a.txt"),
+        os.path.join(env["lists"], "b.txt"),
+    ]
+    assert "2 wordlist" in capsys.readouterr().out
+
+
+def test_expand_stops_at_one_level_like_hashcat_does(main_module, env):
+    """Verified against hashcat 7.1.2: a straight (-a 0) run given a directory
+    reads the files directly inside it and ignores subdirectories."""
+    nested = os.path.join(env["lists"], "sub")
+    os.mkdir(nested)
+    with open(os.path.join(nested, "deep.txt"), "w") as handle:
+        handle.write("delta\n")
+
+    expanded = main_module._expand_wordlist_dirs(env["lists"])
+
+    assert nested not in expanded
+    assert not any("deep.txt" in path for path in expanded)
+
+
+def test_expand_drops_archives_and_dot_files(main_module, env):
+    """A Weakpass download leaves .7z and .torrent files in the wordlists
+    directory. hashcat would try to read them as wordlists; we do not."""
+    for name in ("wl.7z", "wl.torrent", ".DS_Store"):
+        with open(os.path.join(env["lists"], name), "w") as handle:
+            handle.write("x\n")
+
+    expanded = main_module._expand_wordlist_dirs(env["lists"])
+
+    assert [os.path.basename(path) for path in expanded] == ["a.txt", "b.txt"]
+
+
+def test_expand_leaves_a_plain_file_alone(main_module, env, capsys):
+    assert main_module._expand_wordlist_dirs(env["fresh"]) == [env["fresh"]]
+    assert capsys.readouterr().out == "", "no notice when nothing expanded"
+
+
+def test_expand_is_idempotent(main_module, env):
+    once = main_module._expand_wordlist_dirs(env["lists"])
+    assert main_module._expand_wordlist_dirs(once) == once
+
+
+def test_expand_keeps_a_missing_path_so_hashcat_reports_it(main_module, env):
+    """Not our error to swallow: hashcat's own message names the file, and
+    dropping it here would silently shrink the attack instead.
+
+    Scoped to a path that does not exist. A directory that exists but cannot be
+    listed is a different case and is *not* kept -- ``_visible_entries`` says
+    "permission denied" and yields nothing, so the path is dropped after being
+    reported. That is why the empty-expansion guard below has to abort rather
+    than launch."""
+    missing = os.path.join(env["tmp"], "nope.txt")
+    assert main_module._expand_wordlist_dirs(missing) == [missing]
+
+
+def test_expand_reports_a_directory_holding_only_subdirectories(
+    main_module, env, capsys
+):
+    empty = env["tmp"] / "onlysubs"
+    empty.mkdir()
+    (empty / "inner").mkdir()
+
+    assert main_module._expand_wordlist_dirs(str(empty)) == []
+    assert "No wordlists directly inside" in capsys.readouterr().out
+
+
+# --- an expansion that comes back empty must abort, not launch ------------
+
+
+@pytest.mark.parametrize(
+    "shape",
+    ["only-subdirectories", "only-archives", "empty"],
+)
+def test_quick_dictionary_aborts_when_the_expansion_is_empty(
+    main_module, store, env, capsys, shape
+):
+    """Launching with no dictionary operand puts hashcat in *stdin mode*.
+
+    Verified against hashcat 7.1.2: ``-a 0`` with no wordlist argument is the
+    documented ``generator | hashcat`` path, not an error. _run_hcat_cmd passes
+    ``stdin=None``, so the child would inherit the menu's terminal and sit
+    consuming the operator's keystrokes -- then report Exhausted on ctrl-D,
+    which is exit 1, which would record every rule line as covered by a run
+    that enumerated nothing. hcatHybrid already guards this; this must too.
+    """
+    directory = env["tmp"] / f"empty-{shape}"
+    directory.mkdir()
+    if shape == "only-subdirectories":
+        (directory / "inner").mkdir()
+    elif shape == "only-archives":
+        (directory / "wl.7z").write_text("x\n")
+        (directory / ".gitkeep").write_text("")
+
+    launched = []
+    with (
+        patch.object(
+            main_module.subprocess,
+            "Popen",
+            lambda cmd, **kw: (launched.append(list(cmd)), FakePopen(cmd))[1],
+        ),
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module, "hcatBin", "hashcat"),
+        patch.object(main_module, "hcatTuning", ""),
+    ):
+        main_module.hcatQuickDictionary(
+            "1000",
+            env["hashes"],
+            f"-r {env['rules']}",
+            str(directory),
+            attack_name="Quick Crack",
+        )
+
+    assert launched == [], "hashcat must not launch without a dictionary operand"
+    assert "No valid wordlists" in capsys.readouterr().out
+
+
+def test_an_aborted_empty_expansion_records_no_coverage(main_module, store, env):
+    """The second half of the same defect: a stdin-mode run that the operator
+    ends with ctrl-D exits 1, and exit 1 is what records coverage."""
+    directory = env["tmp"] / "onlysubs"
+    directory.mkdir()
+    (directory / "inner").mkdir()
+
+    with (
+        patch.object(main_module.subprocess, "Popen", lambda cmd, **kw: FakePopen(cmd)),
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module, "hcatBin", "hashcat"),
+        patch.object(main_module, "hcatTuning", ""),
+    ):
+        main_module.hcatQuickDictionary(
+            "1000",
+            env["hashes"],
+            f"-r {env['rules']}",
+            str(directory),
+            attack_name="Quick Crack",
+        )
+
+    assert store.summary(ac.target_id(env["hashes"]))["runs"] == 0, (
+        "a run that enumerated nothing must claim no ground and no history"
+    )
+
+
+# --- a directory-valued wordlist must still be tracked --------------------
+
+
+def test_quick_dictionary_expands_a_directory_before_hashcat_sees_it(
+    main_module, store, env
+):
+    launched = []
+    with (
+        patch.object(
+            main_module.subprocess,
+            "Popen",
+            lambda cmd, **kw: (launched.append(list(cmd)), FakePopen(cmd))[1],
+        ),
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module, "hcatBin", "hashcat"),
+        patch.object(main_module, "hcatTuning", ""),
+    ):
+        main_module.hcatQuickDictionary(
+            "1000",
+            env["hashes"],
+            f"-r {env['rules']}",
+            env["lists"],
+            attack_name="Quick Crack",
+        )
+
+    assert env["lists"] not in launched[0], "the directory must not reach hashcat"
+    assert os.path.join(env["lists"], "a.txt") in launched[0]
+    assert os.path.join(env["lists"], "b.txt") in launched[0]
+
+
+def test_a_directory_wordlist_run_is_recorded_not_inert(main_module, store, env):
+    """The regression that made the prompt permanent: the plan went inert, so
+    a repeat of the very same directory and rule file was never recognised."""
+    with (
+        patch.object(main_module.subprocess, "Popen", lambda cmd, **kw: FakePopen(cmd)),
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module, "hcatBin", "hashcat"),
+        patch.object(main_module, "hcatTuning", ""),
+    ):
+        main_module.hcatQuickDictionary(
+            "1000",
+            env["hashes"],
+            f"-r {env['rules']}",
+            env["lists"],
+            attack_name="Quick Crack",
+        )
+
+    spec = ac.CoverageSpec(
+        hash_file=env["hashes"],
+        wordlists=tuple(main_module._expand_wordlist_dirs(env["lists"])),
+        rule_files=(env["rules"],),
+    )
+    plan = ac.plan_run(spec, store.covered, store=store)
+    assert plan.skip is True, "the same directory and rules is a full repeat"
+
+
+# --- the store's wordlist-scoped prior-run question ----------------------
+
+
+def test_has_prior_run_is_scoped_to_the_wordlists(store, env):
+    target = ac.target_id(env["hashes"])
+    fp_a = store.wordlist_fingerprint(os.path.join(env["lists"], "a.txt"))
+    fp_fresh = store.wordlist_fingerprint(env["fresh"])
+
+    store.record(["k1"], target=target, attack="Quick Crack", wordlist_fps=[fp_a])
+
+    assert store.has_prior_run(target, "Quick Crack", [fp_a]) is True
+    assert store.has_prior_run(target, "Quick Crack", [fp_fresh]) is False
+    assert store.has_prior_run(target, "Dictionary", [fp_a]) is False
+    assert store.has_prior_run("other-target", "Quick Crack", [fp_a]) is False
+
+
+def test_has_prior_run_matches_any_one_of_several_wordlists(store, env):
+    """One overlapping corpus is enough for filtering to have something to do,
+    so the question is "any", not "all"."""
+    target = ac.target_id(env["hashes"])
+    fp_a = store.wordlist_fingerprint(os.path.join(env["lists"], "a.txt"))
+    fp_fresh = store.wordlist_fingerprint(env["fresh"])
+
+    store.record(["k1"], target=target, attack="Quick Crack", wordlist_fps=[fp_a])
+
+    assert store.has_prior_run(target, "Quick Crack", [fp_fresh, fp_a]) is True
+
+
+def test_has_prior_run_falls_back_to_the_attack_name_without_wordlists(store, env):
+    """A mask-only attack has no wordlist to scope by; the older, coarser
+    question is the only one available and stays available."""
+    target = ac.target_id(env["hashes"])
+    store.log_run(target, attack="Top Mask")
+
+    assert store.has_prior_run(target, "Top Mask", []) is True
+    assert store.has_prior_run(target, "Quick Crack", []) is False
+
+
+def test_has_prior_run_survives_a_pre_existing_store(tmp_path, env):
+    """An existing engagement's database predates run_wordlists. It must open,
+    gain the table, and answer "no" rather than raising or prompting."""
+    path = tmp_path / "old.sqlite3"
+    old = ac.CoverageStore(path)
+    target = ac.target_id(env["hashes"])
+    old.log_run(target, attack="Quick Crack", kind="history")
+    old.close()
+
+    new = ac.CoverageStore(path)
+    fp = new.wordlist_fingerprint(env["fresh"])
+    try:
+        assert new.has_prior_run(target, "Quick Crack", [fp]) is False
+    finally:
+        new.close()
+
+
+# --- the up-front batch prompt -------------------------------------------
+
+
+def _prior_quick_crack(main_module, env, wordlists):
+    with (
+        patch.object(main_module.subprocess, "Popen", lambda cmd, **kw: FakePopen(cmd)),
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(main_module, "hcatBin", "hashcat"),
+        patch.object(main_module, "hcatTuning", ""),
+    ):
+        main_module.hcatQuickDictionary(
+            "1000",
+            env["hashes"],
+            f"-r {env['rules']}",
+            wordlists,
+            attack_name="Quick Crack",
+        )
+
+
+def test_prime_does_not_prompt_for_a_wordlist_never_used_before(
+    main_module, store, env
+):
+    """The reported bug: a new wordlist with previously-used rules was flagged
+    because the prompt keyed on the attack name alone."""
+    _prior_quick_crack(main_module, env, env["lists"])
+
+    def refuse(*a, **kw):
+        raise AssertionError("prompted about a wordlist that has never run")
+
+    with (
+        patch.object(main_module, "_coverage_enabled", True),
+        patch("builtins.input", refuse),
+    ):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"], [f"-r {env['rules']}"], [env["fresh"]], "Quick Crack"
+        )
+
+    assert decision == {}
+
+
+def test_prime_still_prompts_for_a_wordlist_that_has_run_before(
+    main_module, store, env, capsys
+):
+    _prior_quick_crack(main_module, env, env["lists"])
+
+    expanded = main_module._expand_wordlist_dirs(env["lists"])
+    with (
+        patch.object(main_module, "_coverage_enabled", True),
+        patch("builtins.input", lambda *a: "y"),
+    ):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"], [f"-r {env['rules']}"], expanded, "Quick Crack"
+        )
+
+    assert decision.get("apply_filtering") is True
+    assert "has run against this hash file before" in capsys.readouterr().out
+
+
+def test_prime_stays_quiet_when_no_wordlist_can_be_fingerprinted(
+    main_module, store, env
+):
+    """Nothing here can be fingerprinted, so every chain's plan will be inert
+    and no filtering is possible. Asking anyway is the noise that made this
+    prompt appear on every single run."""
+    _prior_quick_crack(main_module, env, env["lists"])
+    missing = str(env["tmp"] / "vanished.txt")
+
+    def refuse(*a, **kw):
+        raise AssertionError("prompted when no filtering is possible")
+
+    with (
+        patch.object(main_module, "_coverage_enabled", True),
+        patch("builtins.input", refuse),
+    ):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"], [f"-r {env['rules']}"], [missing], "Quick Crack"
+        )
+
+    assert decision == {}
+
+
+def test_prime_stays_quiet_when_the_selection_expands_to_nothing(
+    main_module, store, env
+):
+    """The empty-selection sibling of the case above. Guarding on the expansion
+    rather than on the argument let this short-circuit straight into
+    has_prior_run's attack-name-only fallback -- the exact coarse question this
+    fix exists to remove."""
+    _prior_quick_crack(main_module, env, env["lists"])
+    directory = env["tmp"] / "expands-to-nothing"
+    directory.mkdir()
+    (directory / "inner").mkdir()
+
+    def refuse(*a, **kw):
+        raise AssertionError("prompted on the attack name alone")
+
+    with (
+        patch.object(main_module, "_coverage_enabled", True),
+        patch("builtins.input", refuse),
+    ):
+        decision = main_module._prime_coverage_decision(
+            env["hashes"], [f"-r {env['rules']}"], str(directory), "Quick Crack"
+        )
+
+    assert decision == {}
+
+
+def test_prime_does_not_diff_a_rule_file_to_answer(main_module, store, env):
+    """Unchanged from before: the whole point of priming is that it decides
+    without reading or hashing any selected rule file."""
+    _prior_quick_crack(main_module, env, env["lists"])
+    expanded = main_module._expand_wordlist_dirs(env["lists"])
+
+    read = []
+    real_read_entries = ac.read_entries
+
+    with (
+        patch.object(main_module, "_coverage_enabled", True),
+        patch.object(
+            main_module._coverage,
+            "read_entries",
+            lambda path: (read.append(path), real_read_entries(path))[1],
+        ),
+        patch("builtins.input", lambda *a: "y"),
+    ):
+        main_module._prime_coverage_decision(
+            env["hashes"], [f"-r {env['rules']}"], expanded, "Quick Crack"
+        )
+
+    assert read == [], "priming must not read any rule file"

--- a/tests/test_wordlist_listing.py
+++ b/tests/test_wordlist_listing.py
@@ -188,6 +188,7 @@ def _quick_crack_ctx(hc_module, wordlist_dir, tmp_path):
         list_rule_files=hc_module.list_rule_files,
         hcatQuickDictionary=lambda *a, **k: calls.append((a, k)),
         _prime_coverage_decision=lambda *a, **k: {},
+        _expand_wordlist_dirs=hc_module._expand_wordlist_dirs,
     ), calls
 
 
@@ -212,14 +213,24 @@ def test_quick_crack_marks_directories_in_the_grid(
     assert ".DS_Store" not in out
 
 
-def test_quick_crack_passes_a_selected_directory_through_as_a_directory(
+def test_quick_crack_expands_a_selected_directory_into_its_wordlists(
     hc_module, wordlist_dir, tmp_path, monkeypatch
 ):
-    """hashcat consumes every file in a directory, so selecting one must hand
-    the directory itself to hcatQuickDictionary, not a file inside it."""
+    """Selecting a directory must attack every wordlist in it -- never just one
+    file, and never fewer than hashcat itself would read.
+
+    This used to assert the directory was passed through *as* a directory.
+    hashcat does accept one there and reads exactly these files, so the
+    candidate set is identical either way; what the directory cannot do is
+    carry a content fingerprint, and attack coverage keyed on a fingerprint
+    that cannot be computed records nothing and filters nothing. So the
+    expansion happens here instead. See main._expand_wordlist_dirs and
+    tests/test_coverage_wordlist_scope.py.
+    """
     from hate_crack import attacks
 
     ctx, calls = _quick_crack_ctx(hc_module, wordlist_dir, tmp_path)
+    (wordlist_dir / "hibp" / "part2.txt").write_text("b\n")
     entries = hc_module.list_wordlist_entries(str(wordlist_dir))
     choice = str(1 + [e.name for e in entries].index("hibp"))
 
@@ -232,9 +243,10 @@ def test_quick_crack_passes_a_selected_directory_through_as_a_directory(
 
     assert calls, "hcatQuickDictionary was never called"
     passed = calls[0][0][3]
-    assert passed == str(wordlist_dir / "hibp"), (
-        f"expected the directory itself, got {passed!r}"
-    )
+    assert passed == [
+        str(wordlist_dir / "hibp" / "part1.txt"),
+        str(wordlist_dir / "hibp" / "part2.txt"),
+    ], f"expected every wordlist in the directory, got {passed!r}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Quick Crack bucketed every run under its attack name, so **a brand-new wordlist with previously-used rules was flagged as already covered.** Reported from an engagement.

Two defects compounded, both reachable from the default answer at Quick Crack's wordlist prompt.

**`_prime_coverage_decision` ignored the wordlists it was handed.** It asked the store only whether anything named `Quick Crack` had ever run against this hash file. Since a rule counts as covered only for the wordlist it ran against, selecting a fresh corpus produced *"Quick Crack has run against this hash file before"* with nothing recorded that could possibly be skipped. The question is now scoped to the wordlists, answered by a new `CoverageStore.has_prior_run()` against a new `run_wordlists` table — still without reading a single rule file, which is the property that prompt exists to preserve (see #dc3c536 / #2a1bb96), and at no extra cost because `plan_run` computes the same memoized fingerprints moments later for the first chain.

**The reason it never went away is that Quick Crack's default *is* a directory,** and a directory has no content fingerprint. Every plan went inert — nothing recorded, nothing ever filterable — while the run was still logged and kept feeding the prompt. A selected directory now expands to the wordlists inside it, one level deep, the same fix `hcatHybrid` got in `dbda2fa` for the same reason. hashcat reads exactly those files when handed the directory itself, so the candidate set is unchanged; it just becomes something coverage can key on.

## A regression the review caught

The first cut of the expansion could return an empty list — an empty wordlists directory, or one holding only subdirectories or only archives — and `hcatQuickDictionary` would then launch with **no dictionary operand at all**. That is not an error in hashcat: `-a 0` with no wordlist is the documented `generator | hashcat` stdin path. `_run_hcat_cmd_uncovered` passes `stdin=None`, so the run would inherit the menu's terminal and sit consuming the operator's keystrokes — then report Exhausted on ctrl-D, which is exit 1, which is what records coverage. A run that enumerated nothing would have claimed every rule line. Verified against hashcat 7.1.2 and now guarded, as `hcatHybrid` already was.

## Safety

`has_prior_run` can only decide **whether a question is asked**. Filtering and skipping stay driven entirely by the per-entry diff in `plan_run`, so no path here can wrongly skip untried candidates — the module's stated invariant. A SQLite built without JSON1 answers "no prior run", costing an absent prompt rather than a wrong skip.

An existing engagement's store needs no migration and loses nothing: `CREATE TABLE IF NOT EXISTS` runs on every connect, the table arrives empty, and an empty answer suppresses the spurious prompt. `coverage forget` clears it too.

## Verification

- 3159 tests pass (22 new in `tests/test_coverage_wordlist_scope.py`), plus ruff check/format, ty, bandit and pip-audit.
- Directory-vs-subdirectory behaviour confirmed empirically against hashcat 7.1.2 rather than assumed, as was the stdin-mode finding.
- Mutation-tested: reverting the wordlist scoping, the expansion, the `run_wordlists` linking, the empty-expansion guard, or the `wordlists`-vs-`selection` guard each turns the suite red.
- End-to-end: a fresh corpus no longer prompts, a genuine repeat still prompts and still skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)