### PR TITLE
release: integrate nightly-dev batch of 2026-09-10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,17 @@ hashcat_debug*.log
 # matches either pattern.
 wordlists/
 optimized_wordlists/
+# Downloaded rule and mask files, same relative-default reasoning: the shipped
+# rules_directory is "./hashcat/rules", so on a checkout that kept the default
+# the Hashview/Hashmob rule and mask downloads land in the repo. No tracked
+# file lives under a directory named hashcat -- the bundled utilities are
+# hashcat-utils, which this does not match.
+hashcat/
+# macOS Finder metadata. One visit to the folder creates it, and it is ignored
+# on a developer machine only via a personal global excludesfile, which does
+# not clone -- so it showed up untracked on an operator install and nowhere
+# else.
+.DS_Store
 hate_crack/__init__.pyc
 hate_crack/_version.py
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
+## [Unreleased]
+
+### Fixed
+- **`--update`/`--nightly` no longer refuses to run because of untracked files the operator never created.** The pre-upgrade dirty check ran `git status --porcelain --ignore-submodules=dirty`, which reports untracked files as well as tracked edits, and aborted on any output. That guard exists to protect the `git checkout -B` below it, and the checkout only aborts on *tracked* modifications — untracked files survive it untouched — so gating on them protected nothing while blocking auto-upgrade permanently. Running hate_crack from a checkout reliably creates them: `.DS_Store` appears after a single Finder visit on macOS, and `hashcat/rules/` is the shipped `rules_directory` default that the rule and mask downloads write into. Neither was covered by `.gitignore`; `.DS_Store` is ignored on a developer machine only through a personal global excludesfile, which does not clone, which is why this reproduced on operator installs and nowhere else. The check now passes `--untracked-files=no`. The one untracked file that can genuinely lose data — one sitting at a path an incoming commit adds — is still caught, by `checkout -B` itself, whose error names the file and is already surfaced.
+- **The auto-upgrade refusal now lists the changed files instead of only saying there are some.** "Commit or stash them, then re-run" was unactionable when "them" was never named, which mattered most on exactly the machines hitting the bug above. The listing is capped at 20 entries so a large diff cannot bury the instructions under it.
+- `.DS_Store` and `hashcat/` added to `.gitignore`, so neither can be staged by a `git add -A` in a checkout.
+
 ## [2.36.1] - 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are omitted for releases predating this file; see the git tags for exact timing.
 
-## [Unreleased]
+## [2.36.2] - 2026-09-10
 
 ### Fixed
 - **`--update`/`--nightly` no longer refuses to run because of untracked files the operator never created.** The pre-upgrade dirty check ran `git status --porcelain --ignore-submodules=dirty`, which reports untracked files as well as tracked edits, and aborted on any output. That guard exists to protect the `git checkout -B` below it, and the checkout only aborts on *tracked* modifications — untracked files survive it untouched — so gating on them protected nothing while blocking auto-upgrade permanently. Running hate_crack from a checkout reliably creates them: `.DS_Store` appears after a single Finder visit on macOS, and `hashcat/rules/` is the shipped `rules_directory` default that the rule and mask downloads write into. Neither was covered by `.gitignore`; `.DS_Store` is ignored on a developer machine only through a personal global excludesfile, which does not clone, which is why this reproduced on operator installs and nowhere else. The check now passes `--untracked-files=no`. The one untracked file that can genuinely lose data — one sitting at a path an incoming commit adds — is still caught, by `checkout -B` itself, whose error names the file and is already surfaced.

--- a/hate_crack/main.py
+++ b/hate_crack/main.py
@@ -2290,15 +2290,41 @@ def _run_upgrade(branch="main"):
     # after the very install this tool tells people to run. `dirty` still
     # reports a submodule pinned to a different commit than recorded, which
     # `checkout -B` on the superproject cannot fix anyway.
+    #
+    # --untracked-files=no: the guard protects tracked edits, which the
+    # checkout below aborts on rather than discarding. Untracked files are not
+    # at risk -- the checkout leaves them exactly where they are -- so blocking
+    # on them guards nothing while bricking the upgrade permanently, because
+    # running hate_crack from a checkout reliably creates them. `.DS_Store`
+    # appears after one Finder visit on macOS, and `hashcat/rules/` is the
+    # shipped `rules_directory` default that the rule and mask downloads write
+    # into. The one untracked file that can lose data is one sitting at a path
+    # an incoming commit adds; `checkout -B` refuses in that case and names the
+    # file, and the failure handler below surfaces that.
     status = subprocess.run(
-        ["git", "status", "--porcelain", "--ignore-submodules=dirty"],
+        [
+            "git",
+            "status",
+            "--porcelain",
+            "--untracked-files=no",
+            "--ignore-submodules=dirty",
+        ],
         cwd=repo_root,
         capture_output=True,
         text=True,
     )
     if status.stdout.strip():
+        # Name them: the operator may be looking at a machine they never
+        # deliberately edited, and "commit or stash them" is unactionable
+        # without knowing what "them" is. Capped so a large diff cannot bury
+        # the instruction that follows it.
+        changed = status.stdout.strip().splitlines()
+        listing = "\n".join(f"    {line}" for line in changed[:20])
+        if len(changed) > 20:
+            listing += f"\n    ... and {len(changed) - 20} more"
         print(
             f"\n  Cannot auto-upgrade: uncommitted changes on '{current_branch or 'HEAD'}'."
+            f"\n{listing}"
             "\n  Commit or stash them, then re-run."
             f"\n  Or upgrade manually: git checkout -B {branch} origin/{branch} && make install\n"
         )

--- a/tests/test_upgrade_real_git.py
+++ b/tests/test_upgrade_real_git.py
@@ -328,3 +328,118 @@ def test_inherited_git_repo_vars_do_not_leak_into_throwaway_repos(tmp_path):
     _git("add", "f.txt", cwd=repo)
     _git("commit", "-qm", "initial", cwd=repo)
     assert _git("rev-parse", "--short", "HEAD", cwd=repo).stdout.strip()
+
+
+def test_run_upgrade_ignores_untracked_operator_artifacts(
+    hc_module_real_git, rewritten_remote_and_clone, capsys
+):
+    """Untracked files in the checkout must not block auto-upgrade.
+
+    The dirty guard exists to protect tracked edits from `checkout -B`, which
+    aborts rather than discarding them. Untracked files are not at risk: the
+    checkout leaves them in place. Gating on them anyway is what bricked
+    `--update` in the field, because running hate_crack from a checkout
+    reliably creates them -- `.DS_Store` from one Finder visit on macOS, and
+    `hashcat/rules/` from the shipped `rules_directory` default of
+    `./hashcat/rules` that the rule and mask downloads write into. Neither is
+    an edit the operator made, and the error named no file, so there was
+    nothing to act on.
+    """
+    _remote, clone = rewritten_remote_and_clone
+    (clone / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1")
+    (clone / "hashcat" / "rules").mkdir(parents=True)
+    (clone / "hashcat" / "rules" / "best64.rule").write_text(":\n")
+
+    real_run = subprocess.run
+    shell_calls = []
+
+    def passthrough(cmd, *args, **kwargs):
+        if kwargs.get("shell"):
+            shell_calls.append(cmd)
+
+            class Ok:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return Ok()
+        return real_run(cmd, *args, **kwargs)
+
+    with (
+        patch.object(hc_module_real_git, "_repo_root", str(clone)),
+        patch("subprocess.run", side_effect=passthrough),
+        pytest.raises(SystemExit) as exc,
+    ):
+        hc_module_real_git._run_upgrade()
+
+    out = capsys.readouterr().out
+    assert exc.value.code == 0, out
+    assert "uncommitted changes" not in out
+    # The upgrade actually happened.
+    assert (clone / "app.py").read_text() == "print('v2')\n"
+    assert shell_calls and "make install" in shell_calls[0]
+    # And the operator's untracked files are still there, untouched.
+    assert (clone / ".DS_Store").exists()
+    assert (clone / "hashcat" / "rules" / "best64.rule").read_text() == ":\n"
+
+
+def test_run_upgrade_reports_an_untracked_file_the_checkout_would_overwrite(
+    hc_module_real_git, tmp_path, capsys
+):
+    """The one untracked case that does block, handled by the checkout itself.
+
+    `checkout -B` refuses when an incoming commit adds a file at a path an
+    untracked file already occupies -- the only way an untracked file can lose
+    data. Relaxing the dirty guard hands that case to the checkout's own error
+    path, so it must still exit non-zero and tell the operator which file.
+    """
+    remote = _init(tmp_path / "remote")
+    (remote / "app.py").write_text("print('v1')\n")
+    _git("add", "-A", cwd=remote)
+    _git("commit", "-qm", "release 1.0", cwd=remote)
+    _git("tag", "v1.0", cwd=remote)
+
+    clone = tmp_path / "clone"
+    _git("clone", "-q", str(remote), str(clone), cwd=tmp_path)
+
+    # Upstream adds a new tracked file...
+    (remote / "collides.txt").write_text("from upstream\n")
+    _git("add", "-A", cwd=remote)
+    _git("commit", "-qm", "release 1.1", cwd=remote)
+    _git("tag", "v1.1", cwd=remote)
+
+    # ...at a path the operator's checkout already has as an untracked file.
+    (clone / "collides.txt").write_text("operator's own\n")
+
+    with (
+        patch.object(hc_module_real_git, "_repo_root", str(clone)),
+        pytest.raises(SystemExit) as exc,
+    ):
+        hc_module_real_git._run_upgrade()
+
+    out = capsys.readouterr().out
+    assert exc.value.code == 1, out
+    assert "collides.txt" in out
+    # Nothing was clobbered.
+    assert (clone / "collides.txt").read_text() == "operator's own\n"
+
+
+def test_run_upgrade_names_the_uncommitted_files_it_refuses_over(
+    hc_module_real_git, rewritten_remote_and_clone, capsys
+):
+    """The message must name the files, not just say "commit or stash them".
+
+    The operator sees this on a machine they may not have edited deliberately,
+    so the message has to say which file to look at.
+    """
+    _remote, clone = rewritten_remote_and_clone
+    (clone / "app.py").write_text("print('my local edit')\n")
+
+    with (
+        patch.object(hc_module_real_git, "_repo_root", str(clone)),
+        pytest.raises(SystemExit) as exc,
+    ):
+        hc_module_real_git._run_upgrade()
+
+    assert exc.value.code == 1
+    assert "app.py" in capsys.readouterr().out


### PR DESCRIPTION
Cuts **v2.36.2**. One fix in the batch, so `tools/next_version.py --channel stable` lands on a patch.

## What is in it

**`--update`/`--nightly` no longer refuses to run because of untracked files the operator never created.** The pre-upgrade dirty check ran `git status --porcelain --ignore-submodules=dirty` and aborted on any output, which includes untracked files. That guard exists to protect the `git checkout -B` below it, and the checkout only aborts on *tracked* modifications. Untracked files survive it untouched, so gating on them protected nothing while blocking auto-upgrade permanently.

Running hate_crack from a checkout reliably creates them. `.DS_Store` appears after a single Finder visit on macOS, and `hashcat/rules/` is the shipped `rules_directory` default that the rule and mask downloads write into. Neither was covered by `.gitignore`, and `.DS_Store` is ignored on a developer machine only through a personal global excludesfile, which does not clone. That is why this reproduced on operator installs and nowhere else.

The check now passes `--untracked-files=no`. The one untracked file that can genuinely lose data, one sitting at a path an incoming commit adds, is still caught by `checkout -B` itself, whose error names the file and is already surfaced.

Two smaller changes ride along. The refusal now lists the changed files, capped at 20, because "commit or stash them" was unactionable when nothing said what "them" was. And `.DS_Store` and `hashcat/` were added to `.gitignore`.

## Verification

Three new tests in `tests/test_upgrade_real_git.py`, each watched failing first, running real git commands against real repositories rather than mocks. They cover untracked artifacts no longer blocking and surviving the upgrade, the colliding-path case still exiting non-zero and naming the file, and the refusal naming the tracked file it refuses over.

Gates run locally on the merge candidate, all green:

| Gate | Result |
|---|---|
| pytest | 3342 passed, 44 skipped |
| ruff check | 0 |
| ruff format --check | 0 |
| ty | 0 |
| bandit | 0 |
| pip-audit | 0 |

No issue references in the `[Unreleased]` section, so this PR carries no closing keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)